### PR TITLE
This closes #89, example-emptydatasource.mdx can be helpful about usi…

### DIFF
--- a/docz/examples/example-emptydatasource.mdx
+++ b/docz/examples/example-emptydatasource.mdx
@@ -1,0 +1,35 @@
+---
+name: Empty DataSource Message Example
+order: 7
+menu: Examples
+---
+
+import { Playground } from 'docz'
+import MaterialTable from '../../src/material-table'
+
+# Empty DataSource Message Example
+
+<Playground>
+  <MaterialTable
+    columns={[
+      {title: 'Name', field: 'name'},
+      {title: 'Surname', field: 'surname'},
+      {title: 'Birth Year', field: 'birthYear', type: 'numeric'},
+      {title: 'Birth Place', field: 'birthCity', lookup: {34: 'İstanbul', 63: 'Şanlıurfa'}},      
+    ]}
+    data={[ ]}
+    title="Empty DataSource Example"
+    options={{
+      toolbar: false,
+      paging: false,      
+      showEmptyDataSourceMessage:true
+    }}
+     localization={{
+       emptyDataSourceMessage:'No records to display'
+    }}
+  />
+</Playground>
+
+
+
+

--- a/docz/props.mdx
+++ b/docz/props.mdx
@@ -58,23 +58,25 @@ const data = [
 
 locations settings could be use to change default texts of datatable.
 
-| Field         | Type    | Default               | Description         |
-|:--------------|:--------|:----------------------|:--------------------|
-| actions       | string  | 'Actions'             |                     |
-| nRowsSelected | string  | '{0} row(s) selected' |                     |
+| Field                 | Type    | Default                | Description         |
+|:----------------------|:--------|:-----------------------|:--------------------|
+| actions               | string  | 'Actions'              |                     |
+| nRowsSelected         | string  | '{0} row(s) selected'  |                     |
+|emptyDataSourceMessage | string  | 'No records to display'|                     |
 
 ## options
 
 Options property could be given to component as `options` property. You can change behaviour of grid.
 
-| Field             | Type      | Default       | Description                                                                       |
-|:------------------|:----------|:--------------|:----------------------------------------------------------------------------------|
-| columnsButton     | boolean   | false         | Flag for columns button that controls which column could be rendered              |
-| exportButton      | boolean   | false         | Flag for export button that render export buttons                                 |
-| filtering         | boolean   | false         | Flag for filtering row                                                            |
-| paging            | boolean   | true          | Flag for paging feature                                                           |
-| pageSize          | numeric   | 5             | Number of rows that would be rendered on every page                               |
-| pageSizeOptions   | array     | [5, 10, 20]   | Page size options that could be selected by user                                  |
-| search            | boolean   | true          | Flag for search feature                                                           |
-| selection         | boolean   | false         | Flag for selection feature                                                        |
-| toolbar           | boolean   | true          | Flag for toolbar                                                                  |
+| Field                      | Type      | Default       | Description                                                                       |
+|:---------------------------|:----------|:--------------|:----------------------------------------------------------------------------------|
+| columnsButton              | boolean   | false         | Flag for columns button that controls which column could be rendered              |
+| exportButton               | boolean   | false         | Flag for export button that render export buttons                                 |
+| filtering                  | boolean   | false         | Flag for filtering row                                                            |
+| paging                     | boolean   | true          | Flag for paging feature                                                           |
+| pageSize                   | numeric   | 5             | Number of rows that would be rendered on every page                               |
+| pageSizeOptions            | array     | [5, 10, 20]   | Page size options that could be selected by user                                  |
+| search                     | boolean   | true          | Flag for search feature                                                           |
+| selection                  | boolean   | false         | Flag for selection feature                                                        |
+| toolbar                    | boolean   | true          | Flag for toolbar                                                                  |
+| showEmptyDataSourceMessage | boolean   | true          | Flag for showing message if there is no data in table                             |

--- a/index.d.ts
+++ b/index.d.ts
@@ -39,11 +39,13 @@ export interface Options {
   search?: boolean;
   selection?: boolean;
   toolbar?: boolean;
+  showEmptyDataSourceMessage?:boolean;
 }
 
 export interface Localization {
   actions?: string;
   nRowsSelected?: string;
+  emptyDataSourceMessage?:string;
 }
 
 declare const MaterialTable: React.ComponentType<MaterialTableProps>;

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "react-dom": "^16.5.2"
   },
   "dependencies": {
+    "@material-ui/core": "^3.6.0",
     "classnames": "^2.2.6",
     "date-fns": "2.0.0-alpha.16",
     "filefy": "^0.1.2",

--- a/src/m-table-body.js
+++ b/src/m-table-body.js
@@ -3,7 +3,7 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import MTableFilterRow from './m-table-filter-row';
 import MTableBodyRow from './m-table-body-row';
-import { TableBody, TableRow } from '@material-ui/core';
+import { TableBody, TableRow,TableCell } from '@material-ui/core';
 /* eslint-enable no-unused-vars */
 
 export default class MTableBody extends React.Component {
@@ -43,6 +43,12 @@ export default class MTableBody extends React.Component {
             );
           })
         }
+        {(this.props.options.showEmptyDataSourceMessage && renderData.length==0) &&
+           <TableRow style={{height: 49}} key={'empty-' + 0} >
+        <TableCell style={{paddingTop: 0, paddingBottom: 0}} colSpan={this.props.columns.length}  key="empty-"> 
+        {this.props.localization.emptyDataSourceMessage}
+           </TableCell>
+           </TableRow>}
         {[...Array(emptyRowCount)].map((r, index) => <TableRow style={{height: 49}} key={'empty-' + index} />)}
         {emptyRowCount > 0 && <TableRow style={{height: 1}} key={'empty-last1'} />}
       </TableBody>
@@ -55,7 +61,8 @@ MTableBody.defaultProps = {
   currentPage: 0,
   pageSize: 5,
   renderData: [],
-  selection: false
+  selection: false,
+  localization: {},
 };
 
 MTableBody.propTypes = {
@@ -68,5 +75,6 @@ MTableBody.propTypes = {
   pageSize: PropTypes.number,
   renderData: PropTypes.array,
   selection: PropTypes.bool.isRequired,
-  onFilterSelectionChanged: PropTypes.func.isRequired
+  onFilterSelectionChanged: PropTypes.func.isRequired,
+  localization: PropTypes.object
 };

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -312,6 +312,7 @@ class MaterialTable extends React.Component {
                 }), () => this.onSelectionChange());
                 this.setData();
               }}
+              localization={{...MaterialTable.defaultProps.localization, ...this.props.localization}}
             />
           </Table>
         </div>
@@ -336,11 +337,13 @@ MaterialTable.defaultProps = {
     pageSizeOptions: [5, 10, 20],
     search: true,
     selection: false,
-    toolbar: true
+    toolbar: true,
+    showEmptyDataSourceMessage:true
   },
   localization: {
     actions: 'Actions',
-    nRowsSelected: '{0} row(s) selected'
+    nRowsSelected: '{0} row(s) selected',
+    emptyDataSourceMessage:'No records to display',
   }
 };
 
@@ -377,7 +380,8 @@ MaterialTable.propTypes = {
   }),
   localization: PropTypes.shape({
     actions: PropTypes.string,
-    nRowsSelected: PropTypes.string
+    nRowsSelected: PropTypes.string,
+    emptyDataSourceMessage:PropTypes.string
   }),
   onSelectionChange: PropTypes.func
 };


### PR DESCRIPTION
This closes #89, example-emptydatasource.mdx can be helpful about using showEmptyDataSourceMessage and emptyDataSourceMessage props to show message when there is no data to display.
