### PR TITLE
Use env babel preset, fixes issues with nextjs and jest

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,5 @@
 {
-  "presets": ["@babel/react"], 
+  "presets": ["@babel/preset-env", "@babel/react"], 
   "plugins": [
     "@babel/plugin-transform-runtime",
     "@babel/plugin-proposal-class-properties",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@babel/plugin-proposal-class-properties": "7.1.0",
     "@babel/plugin-proposal-object-rest-spread": "7.0.0",
     "@babel/plugin-transform-runtime": "7.1.0",
+    "@babel/preset-env": "^7.2.0",
     "@babel/preset-react": "7.0.0",
     "babel-eslint": "10.0.1",
     "babel-loader": "^8.0.4",


### PR DESCRIPTION
## Related Issue
Fixes #105 

## Description
Use the standard babel presets to support environments without esmodules support. 