### PR TITLE
added a few tooltips and made component completely translatable

### DIFF
--- a/docz/examples/09-example-localization.mdx
+++ b/docz/examples/09-example-localization.mdx
@@ -30,7 +30,36 @@ import MaterialTable from '../../src/material-table'
       }
     ]}
     localization={{
-      actions: 'Buttons'
+      pagination: {
+        labelDisplayedRows: '{from}-{to} von {count}',        // {from}-{to} of {count}
+        labelRowsPerPage: 'Zeilen pro Seite:',       // Rows per page:
+        firstAriaLabel: 'Erste Seite',       // First Page
+        firstTooltip: 'Erste Seite',       // First Page
+        previousAriaLabel: 'Vorherige Seite',       // Previous Page
+        previousTooltip: 'Vorherige Seite',       // Previous Page
+        nextAriaLabel: 'Nächste Seite',     // Next Page
+        nextTooltip: 'Nächste Seite',     // Next Page
+        lastAriaLabel: 'Letzte Seite',      // Last Page
+        lastTooltip: 'Letzte Seite'      // Last Page
+      },
+      toolbar: {
+        nRowsSelected: '{0} Zeile(n) ausgewählt',      // {0} row(s) selected
+        showColumnsTitle: 'Spalten anzeigen',        // Show Columns
+        showColumnsAriaLabel: 'Spalten anzeigen',        // Show Columns
+        exportTitle: 'Exportieren',     // Export
+        exportAriaLabel: 'Exportieren',      // Export
+        exportName: 'Als CSV exportieren',      // Export as CSV
+        searchTooltip: 'Suchen'        // Search
+      },
+      header: {
+        actions: 'Aktionen'        // Actions
+      },
+      body: {
+        emptyDataSourceMessage: 'Keine Einträge an zu zeigen',     // No records to display
+        filterRow: {
+          filterTooltip: 'Filtern'     // Filter
+        }
+      }
     }}
   />
 </Playground>

--- a/docz/props.mdx
+++ b/docz/props.mdx
@@ -97,13 +97,35 @@ const data = [
 
 ### localization
 
-locations settings could be use to change default texts of datatable.
+Localization settings could be used to change/translate default texts of datatable.
 
-| Field                   | Type    | Default                 | Description         |
-|:------------------------|:--------|:------------------------|:--------------------|
-| actions                 | string  | 'Actions'               |                     |
-| nRowsSelected           | string  | '{0} row(s) selected'   |                     |
-| emptyDataSourceMessage  | string  | 'No records to display' |                     |
+| Field                         | Type   | Default                   | Description                                      |
+|:------------------------------|:-------|:--------------------------|:-------------------------------------------------|
+| pagination                    | object | {}                        | Key value pair for localize pagination component |
+| pagination.labelDisplayedRows | string | {from}-{to} of {count}    |                                                  |
+| pagination.labelRowsPerPage   | string | Rows per page:            |                                                  |
+| pagination.firstAriaLabel     | string | First Page                |                                                  |
+| pagination.firstTooltip       | string | First Page                |                                                  |
+| pagination.previousAriaLabel  | string | Previous Page             |                                                  |
+| pagination.previousTooltip    | string | Previous Page             |                                                  |
+| pagination.nextAriaLabel      | string | Next Page                 |                                                  |
+| pagination.nextTooltip        | string | Next Page                 |                                                  |
+| pagination.lastAriaLabel      | string | Last Page                 |                                                  |
+| pagination.lastTooltip        | string | Last Page                 |                                                  |
+| toolbar                       | object | {}                        | Key value pair for localize toolbar component    |
+| toolbar.nRowsSelected         | string | {0} row(s) selected       |                                                  |
+| toolbar.showColumnsTitle      | string | Show Columns              |                                                  |
+| toolbar.showColumnsAriaLabel  | string | Show Columns              |                                                  |
+| toolbar.exportTitle           | string | Export                    |                                                  |
+| toolbar.exportAriaLabel       | string | Export                    |                                                  |
+| toolbar.exportName            | string | Export as CSV             |                                                  |
+| toolbar.searchTooltip         | string | Search                    |                                                  |
+| header                        | object | {}                        | Key value pair for localize header component     |
+| header.actions                | string | Actions                   |                                                  |
+| body                          | object | {}                        | Key value pair for localize body component       |
+| body.emptyDataSourceMessage   | string | No records to display     |                                                  |
+| body.filterRow                | object | {}                        | Key value pair for localize filter row component |
+| body.filterRow.filterTooltip  | string | Filter                    |                                                  |
 
 ### options
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -80,9 +80,10 @@ export interface Options {
 }
 
 export interface Localization {
-  actions?: string;
-  nRowsSelected?: string;
-  emptyDataSourceMessage?:string;
+  pagination?: object;
+  toolbar?: object;
+  header?: object;
+  body?: object;
 }
 
 declare const MaterialTable: React.ComponentType<MaterialTableProps>;

--- a/src/m-table-body.js
+++ b/src/m-table-body.js
@@ -4,8 +4,9 @@ import PropTypes from 'prop-types';
 import * as React from 'react';
 /* eslint-enable no-unused-vars */
 
-export default class MTableBody extends React.Component {
+class MTableBody extends React.Component {
   renderEmpty(emptyRowCount, renderData) {
+    const localization = { ...MTableBody.defaultProps.localization, ...this.props.localization };
     if (this.props.options.showEmptyDataSourceMessage && renderData.length === 0) {
       let addColumn = 0;
       if(this.props.options.selection || (this.props.actions && this.props.actions.filter(a => !a.isFreeAction && !this.props.options.selection).length > 0)) {
@@ -14,7 +15,7 @@ export default class MTableBody extends React.Component {
       return (
         <TableRow style={{ height: 49 * (this.props.options.paging && this.props.options.emptyRowsWhenPaging ? this.props.pageSize : 1) }} key={'empty-' + 0} >
           <TableCell style={{ paddingTop: 0, paddingBottom: 0, textAlign: 'center' }} colSpan={this.props.columns.length + addColumn} key="empty-">
-            {this.props.localization.emptyDataSourceMessage}
+            {localization.emptyDataSourceMessage}
           </TableCell>
         </TableRow>
       );
@@ -49,6 +50,7 @@ export default class MTableBody extends React.Component {
             onFilterChanged={this.props.onFilterChanged}
             selection={this.props.options.selection}
             onFilterSelectionChanged={this.props.onFilterSelectionChanged}
+            localization={{ ...MTableBody.defaultProps.localization.filterRow, ...this.props.localization.filterRow }}
           />
         }
         {
@@ -81,7 +83,10 @@ MTableBody.defaultProps = {
   pageSize: 5,
   renderData: [],
   selection: false,
-  localization: {}
+  localization: {
+    emptyDataSourceMessage: 'No records to display',
+    filterRow: {}
+  }
 };
 
 MTableBody.propTypes = {
@@ -100,3 +105,5 @@ MTableBody.propTypes = {
   localization: PropTypes.object,
   onFilterChanged: PropTypes.func
 };
+
+export default MTableBody;

--- a/src/m-table-filter-row.js
+++ b/src/m-table-filter-row.js
@@ -5,7 +5,7 @@ import {
   TableCell, TableRow, TextField,
   FormControl, Select, Input,
   MenuItem, Checkbox, ListItemText,
-  InputAdornment, Icon
+  InputAdornment, Icon, Tooltip,
 } from '@material-ui/core';
 import DateFnsUtils from 'material-ui-pickers/utils/date-fns-utils';
 import MuiPickersUtilsProvider from 'material-ui-pickers/MuiPickersUtilsProvider';
@@ -66,21 +66,28 @@ class MTableFilterRow extends React.Component {
     />
   )
 
-  renderDefaultFilter = (columnDef) => (
-    <TextField
-      style={columnDef.type === 'numeric' ? { float: 'right' } : {}}
-      type={columnDef.type === 'numeric' ? 'number' : 'text'}
-      value={columnDef.tableData.filterValue}
-      onChange={(event) => { this.props.onFilterChanged(columnDef.tableData.id, event.target.value) }}
-      InputProps={{
-        startAdornment: (
-          <InputAdornment position="start">
-            <this.props.icons.Filter/>
-          </InputAdornment>
-        )
-      }}
-    />
-  )
+  renderDefaultFilter = (columnDef) => {
+    const localization = {...MTableFilterRow.defaultProps.localization, ...this.props.localization};
+    return (
+      <TextField
+        style={columnDef.type === 'numeric' ? {float: 'right'} : {}}
+        type={columnDef.type === 'numeric' ? 'number' : 'text'}
+        value={columnDef.tableData.filterValue}
+        onChange={(event) => {
+          this.props.onFilterChanged(columnDef.tableData.id, event.target.value);
+        }}
+        InputProps={{
+          startAdornment: (
+            <InputAdornment position="start">
+              <Tooltip title={localization.filterTooltip}>
+                <this.props.icons.Filter/>
+              </Tooltip>
+            </InputAdornment>
+          )
+        }}
+      />
+    );
+  }
 
   renderDateTypeFilter = (columnDef) => {
     let dateInputElement = null;
@@ -176,6 +183,9 @@ MTableFilterRow.defaultProps = {
   columns: [],
   selection: false,
   hasActions: false,
+  localization: {
+    filterTooltip: 'Filter'
+  }
 };
 
 MTableFilterRow.propTypes = {
@@ -186,6 +196,7 @@ MTableFilterRow.propTypes = {
   onFilterSelectionChanged: PropTypes.func.isRequired,
   actionsColumnIndex: PropTypes.number,
   hasActions: PropTypes.bool,
+  localization: PropTypes.object
 };
 
 export default MTableFilterRow;

--- a/src/m-table-header.js
+++ b/src/m-table-header.js
@@ -34,9 +34,10 @@ class MTableHeader extends React.Component {
   }
 
   renderActionsHeader() {
+    const localization = { ...MTableHeader.defaultProps.localization, ...this.props.localization };
     return (
       <TableCell key="key-actions-column">
-        <TableSortLabel>{this.props.localization.actions}</TableSortLabel>
+        <TableSortLabel>{localization.actions}</TableSortLabel>
       </TableCell>
     );
   }
@@ -84,7 +85,9 @@ MTableHeader.defaultProps = {
   hasSelection: false,
   selectedCount: 0,
   sorting: true,
-  localization: {},
+  localization: {
+    actions: 'Actions'
+  },
   orderBy: undefined,
   orderDirection: 'asc',
   actionsHeaderIndex: 0

--- a/src/m-table-pagination.js
+++ b/src/m-table-pagination.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-unused-vars */
-import { Icon, IconButton, withStyles } from '@material-ui/core';
+import { Icon, IconButton, withStyles, Tooltip } from '@material-ui/core';
 import PropTypes from 'prop-types';
 import * as React from 'react';
 /* eslint-enable no-unused-vars */
@@ -26,37 +26,55 @@ class MTablePaginationInner extends React.Component {
 
   render() {
     const { classes, count, page, rowsPerPage } = this.props;
-
+    
+    const localization = { ...MTablePaginationInner.defaultProps.localization, ...this.props.localization };
+    
     return (
       <div className={classes.root}>
-        <IconButton
-          onClick={this.handleFirstPageButtonClick}
-          disabled={page === 0}
-          aria-label="First Page"
-        >          
-          <this.props.icons.FirstPage/>
-        </IconButton>
-        <IconButton
-          onClick={this.handleBackButtonClick}
-          disabled={page === 0}
-          aria-label="Previous Page"
-        >
-          <this.props.icons.PreviousPage/>
-        </IconButton>
-        <IconButton
-          onClick={this.handleNextButtonClick}
-          disabled={page >= Math.ceil(count / rowsPerPage) - 1}
-          aria-label="Next Page"
-        >
-          <this.props.icons.NextPage/>
-        </IconButton>
-        <IconButton
-          onClick={this.handleLastPageButtonClick}
-          disabled={page >= Math.ceil(count / rowsPerPage) - 1}
-          aria-label="Last Page"
-        >
-          <this.props.icons.LastPage/>
-        </IconButton>
+        <Tooltip title={localization.firstTooltip}>
+          <span>
+            <IconButton
+              onClick={this.handleFirstPageButtonClick}
+              disabled={page === 0}
+              aria-label={localization.firstAriaLabel}
+            >
+              <this.props.icons.FirstPage/>
+            </IconButton>
+          </span>
+        </Tooltip>
+        <Tooltip title={localization.previousTooltip}>
+          <span>
+            <IconButton
+              onClick={this.handleBackButtonClick}
+              disabled={page === 0}
+              aria-label={localization.previousAriaLabel}
+            >
+              <this.props.icons.PreviousPage/>
+            </IconButton>
+          </span>
+        </Tooltip>
+        <Tooltip title={localization.nextTooltip}>
+          <span>
+            <IconButton
+              onClick={this.handleNextButtonClick}
+              disabled={page >= Math.ceil(count / rowsPerPage) - 1}
+              aria-label={localization.nextAriaLabel}
+            >
+              <this.props.icons.NextPage/>
+            </IconButton>
+          </span>
+        </Tooltip>
+        <Tooltip title={localization.lastTooltip}>
+          <span>
+            <IconButton
+              onClick={this.handleLastPageButtonClick}
+              disabled={page >= Math.ceil(count / rowsPerPage) - 1}
+              aria-label={localization.lastAriaLabel}
+            >
+              <this.props.icons.LastPage/>
+            </IconButton>
+          </span>
+        </Tooltip>
       </div>
     );
   }
@@ -75,7 +93,21 @@ MTablePaginationInner.propTypes = {
   page: PropTypes.number,
   count: PropTypes.number,
   rowsPerPage: PropTypes.number,
-  classes: PropTypes.object
+  classes: PropTypes.object,
+  localization: PropTypes.object
+};
+
+MTablePaginationInner.defaultProps = {
+  localization: {
+    firstAriaLabel: 'First Page',
+    previousAriaLabel: 'Previous Page',
+    nextAriaLabel: 'Next Page',
+    lastAriaLabel: 'Last Page',
+    firstTooltip: 'First Page',
+    previousTooltip: 'Previous Page',
+    nextTooltip: 'Next Page',
+    lastTooltip: 'Last Page'
+  }
 };
 
 const MTablePagination = withStyles(actionsStyles, { withTheme: true })(MTablePaginationInner);

--- a/src/m-table-toolbar.js
+++ b/src/m-table-toolbar.js
@@ -36,6 +36,7 @@ class MTableToolbar extends React.Component {
   }
 
   renderSearch() {
+    const localization = { ...MTableToolbar.defaultProps.localization, ...this.props.localization };
     if (this.props.search) {
       return (        
         <TextField
@@ -44,8 +45,10 @@ class MTableToolbar extends React.Component {
           color="inherit"          
           InputProps={{            
             startAdornment: (
-              <InputAdornment position="start">                
-                <this.props.icons.Search color="inherit"/>
+              <InputAdornment position="start">
+                <Tooltip title={localization.searchTooltip}>
+                  <this.props.icons.Search color="inherit"/>
+                </Tooltip>
               </InputAdornment>
             )
           }}
@@ -58,16 +61,17 @@ class MTableToolbar extends React.Component {
   }
 
   renderDefaultActions() {
+    const localization = { ...MTableToolbar.defaultProps.localization, ...this.props.localization };
     return (
       <div>        
         {this.renderSearch()}        
         {this.props.columnsButton &&
           <span>    
-            <Tooltip title="Show Columns">            
+            <Tooltip title={localization.showColumnsTitle}>
               <IconButton
                 color="inherit"
                 onClick={event => this.setState({ columnsButtonAnchorEl: event.currentTarget })}
-                aria-label="Show Columns">                
+                aria-label={localization.showColumnsAriaLabel}>
                 
                 <this.props.icons.ViewColumn/>
               </IconButton>
@@ -102,11 +106,11 @@ class MTableToolbar extends React.Component {
         }
         {this.props.exportButton &&
           <span>
-            <Tooltip title="Export">
+            <Tooltip title={localization.exportTitle}>
               <IconButton
                 color="inherit"
                 onClick={event => this.setState({ exportButtonAnchorEl: event.currentTarget })}
-                aria-label="Show Columns">
+                aria-label={localization.exportAriaLabel}>
                 <this.props.icons.Export/>
               </IconButton>
             </Tooltip>
@@ -116,7 +120,7 @@ class MTableToolbar extends React.Component {
               onClose={() => this.setState({ exportButtonAnchorEl: null })}
             >
               <MenuItem key="export-csv" onClick={this.exportCsv}>
-                Export as CSV
+                {localization.exportName}
               </MenuItem>
             </Menu>
           </span>
@@ -149,7 +153,8 @@ class MTableToolbar extends React.Component {
 
   render() {
     const { classes } = this.props;
-    const title = this.props.selectedRows && this.props.selectedRows.length > 0 ? this.props.localization.nRowsSelected.replace('{0}', this.props.selectedRows.length) : this.props.title;
+    const localization = { ...MTableToolbar.defaultProps.localization, ...this.props.localization };
+    const title = this.props.selectedRows && this.props.selectedRows.length > 0 ? localization.nRowsSelected.replace('{0}', this.props.selectedRows.length) : this.props.title;
     return (
       <Toolbar className={classNames(classes.root, { [classes.highlight]: this.props.selectedRows && this.props.selectedRows.length > 0 })}>
         <div className={classes.title}>
@@ -168,7 +173,15 @@ MTableToolbar.defaultProps = {
   actions: [],
   columns: [],
   columnsButton: false,
-  localization: {},
+  localization: {
+    nRowsSelected: '{0} row(s) selected',
+    showColumnsTitle: 'Show Columns',
+    showColumnsAriaLabel: 'Show Columns',
+    exportTitle: 'Export',
+    exportAriaLabel: 'Export',
+    exportName: 'Export as CSV',
+    searchTooltip: 'Search'
+  },
   search: true,
   searchText: '',
   selectedRows: [],

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -219,6 +219,7 @@ class MaterialTable extends React.Component {
   renderFooter() {
     const props = this.getProps();
     if (props.options.paging) {
+      const localization = { ...MaterialTable.defaultProps.localization.pagination, ...this.props.localization.pagination };
       return (
         <Table>
           <TableFooter style={{ display: 'grid' }}>
@@ -246,7 +247,9 @@ class MaterialTable extends React.Component {
                     this.onChangeRowsPerPage(event.target.value);
                   });
                 }}
-                ActionsComponent={(subProps) => <MTablePagination {...subProps} icons={props.icons}/>}
+                ActionsComponent={(subProps) => <MTablePagination {...subProps} icons={props.icons} localization={localization}/>}
+                labelDisplayedRows={(row) => localization.labelDisplayedRows.replace('{from}', row.from).replace('{to}', row.to).replace('{count}', row.count)}
+                labelRowsPerPage={localization.labelRowsPerPage}
               />
             </TableRow>
           </TableFooter>
@@ -279,13 +282,13 @@ class MaterialTable extends React.Component {
             title={props.title}
             onSearchChanged={searchText => this.setState({ searchText }, () => this.setData())}
             onColumnsChanged={columns => this.setState({ columns })}
-            localization={{ ...MaterialTable.defaultProps.localization, ...this.props.localization }}
+            localization={{ ...MaterialTable.defaultProps.localization.toolbar, ...this.props.localization.toolbar }}
           />
         }
         <div style={{ overflowX: 'auto' }}>
           <Table>
             <props.components.Header
-              localization={{ ...MaterialTable.defaultProps.localization, ...this.props.localization }}
+              localization={{ ...MaterialTable.defaultProps.localization.header, ...this.props.localization.header }}
               columns={this.state.columns}
               hasSelection={props.options.selection}
               selectedCount={this.state.selectedCount}
@@ -343,7 +346,7 @@ class MaterialTable extends React.Component {
                 }), () => this.onSelectionChange());
                 this.setData();
               }}
-              localization={{ ...MaterialTable.defaultProps.localization, ...this.props.localization }}
+              localization={{ ...MaterialTable.defaultProps.localization.body, ...this.props.localization.body }}
             />
           </Table>
         </div>
@@ -399,9 +402,15 @@ MaterialTable.defaultProps = {
     toolbar: true
   },
   localization: {
-    actions: 'Actions',
-    nRowsSelected: '{0} row(s) selected',
-    emptyDataSourceMessage: 'No records to display'
+    pagination: {
+      labelDisplayedRows: '{from}-{to} of {count}',
+      labelRowsPerPage: 'Rows per page:'
+    },
+    toolbar: {},
+    header: {},
+    body: {
+      filterRow: {}
+    }
   }
 };
 
@@ -472,9 +481,10 @@ MaterialTable.propTypes = {
     toolbar: PropTypes.bool
   }),
   localization: PropTypes.shape({
-    actions: PropTypes.string,
-    nRowsSelected: PropTypes.string,
-    emptyDataSourceMessage: PropTypes.string
+    pagination: PropTypes.object,
+    toolbar: PropTypes.object,
+    header: PropTypes.object,
+    body: PropTypes.object
   }),
   onSelectionChange: PropTypes.func,
   onChangeRowsPerPage: PropTypes.func,


### PR DESCRIPTION
## Related Issue
Relate the Github issue with this PR using `#113`

## Description
added tooltips in toolbar (first, previous, next and last button) and filter row
changed all "direct" texts to values from localization props
added default (english) translation as default props in each component
adjusted docs, examples etc. with the new translation

## Impacted Areas in Application
List general components of the application that this PR will affect:
MaterialTable
MTableToolbar
MTablePagination
MTableHeader
MTableBody
MTableFilterRow

*

## Additional Notes
I usually develop projects not libraries, so I'm not sure if i.e. the `index.d.ts` file is correct or if the coding style fits (as far as I can see there are more than one), but I run the lint command with no errors or warnings...
Not knowing docz I didn't run any commands regarding docz and in the contribution file you didn't mention it...
My example translation is German :-) to see the difference, but in the code, I commented the values with their defaults...