### PR TITLE
Fix react warning about numeric being deprecated

### DIFF
--- a/src/m-table-cell.js
+++ b/src/m-table-cell.js
@@ -64,7 +64,7 @@ export default class MTableCell extends React.Component {
 
     return (
       <TableCell style={cellStyle}
-        numeric={['numeric'].indexOf(this.props.columnDef.type) !== -1}
+        align={['numeric'].indexOf(this.props.columnDef.type) !== -1 ? "right": "left"}
       >
         {this.getRenderValue()}
       </TableCell>

--- a/src/m-table-header.js
+++ b/src/m-table-header.js
@@ -13,7 +13,7 @@ class MTableHeader extends React.Component {
       .map((columnDef) => (
         <TableCell
           key={columnDef.tableData.id}
-          numeric={['numeric'].indexOf(columnDef.type) !== -1}
+          align={['numeric'].indexOf(columnDef.type) !== -1 ? "right" : "left"}
         >
           {(columnDef.sort !== false && columnDef.sorting !== false && this.props.sorting)
             ? <TableSortLabel


### PR DESCRIPTION
See https://material-ui.com/api/table-cell/

## Related Issue
#124 

## Description
Remove warning about numerin being deprecated for TableCell :

Warning: Failed prop type: The prop `numeric` of `TableCell` is deprecated. Instead, use the `align` property.
    in TableCell (created by WithStyles(TableCell))
    in WithStyles(TableCell) (created by MTableHeader)
    in tr (created by Context.Consumer)
    in TableRow (created by WithStyles(TableRow))
    in WithStyles(TableRow) (created by MTableHeader)
    in thead (created by TableHead)
    in TableHead (created by WithStyles(TableHead))
    in WithStyles(TableHead) (created by MTableHeader)
    in MTableHeader (created by MaterialTable)
    in table (created by Table)
    in Table (created by WithStyles(Table))
    in WithStyles(Table) (created by MaterialTable)
    in div (created by MaterialTable)
    in div (created by Paper)
    in Paper (created by WithStyles(Paper))
    in WithStyles(Paper) (created by MaterialTable)
    in MaterialTable (created by MaterialTableAsset)
    in div (created by MaterialTableAsset)

## Impacted Areas in Application
TableCell
