### PR TITLE
Fixed error regarding actions/icon #127

### DIFF
--- a/src/material-table.js
+++ b/src/material-table.js
@@ -247,7 +247,7 @@ class MaterialTable extends React.Component {
                     this.onChangeRowsPerPage(event.target.value);
                   });
                 }}
-                ActionsComponent={(subProps) => <MTablePagination {...subProps} icons={props.icons} localization={localization}/>}
+                ActionsComponent={(subProps) => <MTablePagination {...subProps} icons={props.icons} localization={localization} />}
                 labelDisplayedRows={(row) => localization.labelDisplayedRows.replace('{from}', row.from).replace('{to}', row.to).replace('{count}', row.count)}
                 labelRowsPerPage={localization.labelRowsPerPage}
               />
@@ -417,7 +417,7 @@ MaterialTable.defaultProps = {
 
 MaterialTable.propTypes = {
   actions: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.shape({
-    icon: PropTypes.string.isRequired,
+    icon: PropTypes.oneOfType([PropTypes.element, PropTypes.func, PropTypes.string]).isRequired,
     isFreeAction: PropTypes.bool,
     tooltip: PropTypes.string,
     onClick: PropTypes.func.isRequired,


### PR DESCRIPTION
## Related Issue
Relate the Github issue with this PR using `#127`

## Description
By using anything else than a string for the icons in the actions prop the console gave a warning, this is now fixed. 

## Impacted Areas in Application
List general components of the application that this PR will affect:

* Element types allowed for icons in the action prop