### PR TITLE
feat(checkbox): add init checked rows

### DIFF
--- a/src/material-table.js
+++ b/src/material-table.js
@@ -35,28 +35,38 @@ class MaterialTable extends React.Component {
       orderBy: defaultSortColumnIndex,
       orderDirection: defaultSortDirection,
       filterSelectionChecked: false,
-      ...this.getDataAndColumns(calculatedProps)
+      ...this.getData(calculatedProps),
+      ...this.getColumns(calculatedProps)
     };
   }
 
   UNSAFE_componentWillReceiveProps(nextProps) {
-    const dataAndColumns = this.getDataAndColumns(this.getProps(nextProps));
-    this.setState(dataAndColumns);
+    if (nextProps.data !== this.props.data) {
+      const data = this.getData(this.getProps(nextProps));
+      const columns = this.getColumns(this.getProps(nextProps));
+      this.setState(() => ({ ...columns, ...data }));
+    }
   }
 
-  getDataAndColumns(props) {
+  getData(props) {
     const data = props.data.map((row, index) => {
-      row.tableData = { id: index };
+      const checked = row.checked || false;
+      row.tableData = { id: index, checked };
       return row;
     });
 
+    const renderData = this.getRenderData(data, props);
+
+    return { data, renderData };
+  }
+
+  getColumns(props) {
     const columns = props.columns.map((columnDef, index) => {
       columnDef.tableData = { id: index };
       return columnDef;
     });
 
-    const renderData = this.getRenderData(data, props);
-    return { data, columns, renderData };
+    return { columns };
   }
 
   getProps(props) {


### PR DESCRIPTION
fix the issue #82 in the same time

## Related Issue
#96 
#82 

## Description
#96 :
* init table with already checked rows

#82 : 
* material-table component will update only if it gets new data (not only new props). That way, if a rows is checked, it won't go through `UNSAFE_componentWillReceiveProps` logic

## Impacted Areas in Application

* material-table.js
