### PR TITLE
add before & after event hooks which fixes material-table/issues/64

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -20,6 +20,14 @@ export interface MaterialTableProps {
   onChangeRowsPerPage?: (pageSize: number) => void;
   onChangePage?: (page: number) => void;
   onOrderChange?: (orderBy: number, orderDirection: "asc" | "desc") => void;
+  onBeforeSelectionChange?: (data: any[]) => void;
+  onBeforeChangeRowsPerPage?: (pageSize: number) => void;
+  onBeforeChangePage?: (page: number) => void;
+  onBeforeOrderChange?: (orderBy: number, orderDirection: "asc" | "desc") => void;
+  onAfterSelectionChange?: (data: any[]) => void;
+  onAfterChangeRowsPerPage?: (pageSize: number) => void;
+  onAfterChangePage?: (page: number) => void;
+  onAfterOrderChange?: (orderBy: number, orderDirection: "asc" | "desc") => void;
 }
 
 export interface Action {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "material-table",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "description": "Datatable for React based on https://material-ui.com/api/table/ with additional features",
   "main": "dist/material-table.js",
   "types": "index.d.ts",

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -210,23 +210,50 @@ class MaterialTable extends React.Component {
     }
   }
 
-  onSelectionChange = () => {
-    if (this.props.onSelectionChange) {
+  // new before events
+  onBeforeSelectionChange = () => {
+    if (this.props.onBeforeSelectionChange) {
+      const selectedRows = this.state.data.filter(row => row.tableData.checked);
+      this.props.onBeforeSelectionChange(selectedRows);
+    }
+  }
+  
+  onBeforeChangePage = (...args) => {
+    this.props.onBeforeChangePage && this.props.onBeforeChangePage(...args);
+  }
+
+  onBeforeChangeRowsPerPage = (...args) => {
+    this.props.onBeforeChangeRowsPerPage && this.props.onBeforeChangeRowsPerPage(...args);
+  }
+
+  onBeforeOrderChange = (...args) => {
+    this.props.onBeforeOrderChange && this.props.onBeforeOrderChange(...args);
+  }
+
+  // new after events
+  onAfterSelectionChange = () => {
+    if (this.props.onAfterSelectionChange) {
+      const selectedRows = this.state.data.filter(row => row.tableData.checked);
+      this.props.onAfterSelectionChange(selectedRows);
+    } else if (this.props.onSelectionChange) { // backward compat.
       const selectedRows = this.state.data.filter(row => row.tableData.checked);
       this.props.onSelectionChange(selectedRows);
     }
   }
 
-  onChangePage = (...args) => {
-    this.props.onChangePage && this.props.onChangePage(...args);
+  onAfterChangePage = (...args) => {
+    this.props.onAfterChangePage && this.props.onAfterChangePage(...args) ||
+    this.props.onChangePage && this.props.onChangePage(...args); // backward compat.
   }
 
-  onChangeRowsPerPage = (...args) => {
-    this.props.onChangeRowsPerPage && this.props.onChangeRowsPerPage(...args);
+  onAfterChangeRowsPerPage = (...args) => {
+    this.props.onAfterChangeRowsPerPage && this.props.onAfterChangeRowsPerPage(...args) ||
+    this.props.onChangeRowsPerPage && this.props.onChangeRowsPerPage(...args); // backward compat.
   }
 
-  onOrderChange = (...args) => {
-    this.props.onOrderChange && this.props.onOrderChange(...args);
+  onAfterOrderChange = (...args) => {
+    this.props.onAfterOrderChange && this.props.onAfterOrderChange(...args) ||
+    this.props.onOrderChange && this.props.onOrderChange(...args); // backward compat.
   }
 
   renderFooter() {
@@ -245,19 +272,21 @@ class MaterialTable extends React.Component {
                 rowsPerPageOptions={props.options.pageSizeOptions}
                 page={this.state.currentPage}
                 onChangePage={(event, page) => {
+                  this.onBeforeChangePage(page);
                   this.setState({ currentPage: page }, () => {
                     this.setData();
-                    this.onChangePage(page);
+                    this.onAfterChangePage(page);
                   });
                 }}
                 onChangeRowsPerPage={(event) => {
+                  this.onBeforeChangeRowsPerPage(event.target.value);
                   this.setState(state => {
                     state.pageSize = event.target.value;
                     state.currentPage = 0;
                     return state;
                   }, () => {
                     this.setData();
-                    this.onChangeRowsPerPage(event.target.value);
+                    this.onAfterChangeRowsPerPage(event.target.value);
                   });
                 }}
                 ActionsComponent={(subProps) => <MTablePagination {...subProps} icons={props.icons} localization={localization} />}
@@ -317,12 +346,14 @@ class MaterialTable extends React.Component {
                   return row;
                 });
                 const selectedCount = checked ? data.length : 0;
-                this.setState({ renderData: data, selectedCount }, () => this.onSelectionChange());
+                this.onBeforeSelectionChange();
+                this.setState({ renderData: data, selectedCount }, () => this.onAfterSelectionChange());
               }}
               onOrderChange={(orderBy, orderDirection) => {
+                this.onBeforeOrderChange(orderBy, orderDirection);
                 this.setState({ orderBy, orderDirection, currentPage: 0 }, () => {
                   this.setData();
-                  this.onOrderChange(orderBy, orderDirection);
+                  this.onAfterOrderChange(orderBy, orderDirection);
                 });
               }}
               actionsHeaderIndex={props.options.actionsColumnIndex}
@@ -356,10 +387,11 @@ class MaterialTable extends React.Component {
               onRowSelected={(event, checked) => {
                 const data = this.state.data;
                 data[event.target.value].tableData.checked = checked;
+                this.onBeforeSelectionChange();
                 this.setState(state => ({
                   data: data,
                   selectedCount: state.selectedCount + (checked ? 1 : -1)
-                }), () => this.onSelectionChange());
+                }), () => this.onAfterSelectionChange());
                 this.setData();
               }}
               onToggleDetailPanel={(rowData, render) => {
@@ -530,6 +562,15 @@ MaterialTable.propTypes = {
     header: PropTypes.object,
     body: PropTypes.object
   }),
+  onBeforeSelectionChange: PropTypes.func,
+  onBeforeChangeRowsPerPage: PropTypes.func,
+  onBeforeChangePage: PropTypes.func,
+  onBeforeOrderChange: PropTypes.func,
+  onAfterChangeRowsPerPage: PropTypes.func,
+  onAfterSelectionChange: PropTypes.func,
+  onAfterChangePage: PropTypes.func,
+  onAfterOrderChange: PropTypes.func,
+  // backward compat
   onSelectionChange: PropTypes.func,
   onChangeRowsPerPage: PropTypes.func,
   onChangePage: PropTypes.func,


### PR DESCRIPTION
## Related Issue
#64 

## Description
As it stands, the onXyz events are triggered after data has already been loaded. By adding "before" events (and retaining the "after" events), we can easily enable remotely loading data before subsequently acting on it. I've bumped the version number to 1.12 and retained the original event handler names (eg: onChangePage) for backward compatibility (can just easily remove them). I can also add docs. I have a working example with react-redux and saga that remotely loads data from a REST API. Submitting this PR now a bit more bare bones to give you time to take a look and LMK what you think.