### PR TITLE
Feature/on row click

### DIFF
--- a/docz/props.mdx
+++ b/docz/props.mdx
@@ -19,6 +19,7 @@ import MaterialTable from '../src/material-table'
 | onChangePage        | func                            |                   | To handle page changes (page)                                     |
 | onChangeRowsPerPage | func                            |                   | To handle rows per page changes (pageSize)                        |
 | onOrderChange       | func                            |                   | To handle order changes (orderedColumnId, orderDirection)         |
+| onRowClick          | func                            |                   | To handle row click (event, rowData)                              |
 | onSelectionChange   | func                            |                   | To handle selection changes                                       |
 | options             | object                          |                   | All options of table                                              |
 | title               | string                          | 'Table Title'     | Table Title (only render if toolbar option is true                |
@@ -45,6 +46,7 @@ import MaterialTable from '../src/material-table'
 | customSort              | func            |           | This field can be used for overriding sort algorithm                                                          |
 | defaultFilter           | any             |           | Default Filter value for filtering column                                                                     |
 | defaultSort             | string          |           | Sorting direction: 'asc', 'desc'                                                                              |
+| disableClick            | boolean         | false     | Disable the 'onRowClick' event for this cell                                                                  |
 | emptyValue              | React.Element   |           | When data is empty or undefined, string value, React.Element or function result can be set as default value   |
 | field                   | string          |           | Field name of data row                                                                                        |
 | filtering               | boolean         | true      | Flag to activate or disable filtering feature of column                                                       |

--- a/src/m-table-body-row.js
+++ b/src/m-table-body-row.js
@@ -16,7 +16,8 @@ export default class MTableBodyRow extends React.Component {
             columnDef={columnDef}
             value={value}
             key={columnDef.tableData.id}
-            rowData={this.props.data} />
+            rowData={this.props.data} 
+            onClick={this.props.onRowClick} />
         );
       });
     return mapArr;
@@ -159,7 +160,8 @@ MTableBodyRow.defaultProps = {
   actions: [],
   index: 0,
   data: {},
-  options: {}
+  options: {},
+  onRowClick: () => {},
 };
 
 MTableBodyRow.propTypes = {
@@ -172,5 +174,6 @@ MTableBodyRow.propTypes = {
   onRowSelected: PropTypes.func,
   getFieldValue: PropTypes.func.isRequired,
   columns: PropTypes.array,
-  onToggleDetailPanel: PropTypes.func.isRequired
+  onToggleDetailPanel: PropTypes.func.isRequired,
+  onRowClick: PropTypes.func,
 };

--- a/src/m-table-body.js
+++ b/src/m-table-body.js
@@ -70,6 +70,7 @@ class MTableBody extends React.Component {
                 getFieldValue={this.props.getFieldValue}
                 detailPanel={this.props.detailPanel}
                 onToggleDetailPanel={this.props.onToggleDetailPanel}
+                onRowClick={this.props.onRowClick}
               />
             );
           })
@@ -89,7 +90,8 @@ MTableBody.defaultProps = {
   localization: {
     emptyDataSourceMessage: 'No records to display',
     filterRow: {}
-  }
+  },
+  onRowClick: () => {},
 };
 
 MTableBody.propTypes = {
@@ -108,7 +110,8 @@ MTableBody.propTypes = {
   onFilterSelectionChanged: PropTypes.func.isRequired,
   localization: PropTypes.object,
   onFilterChanged: PropTypes.func,
-  onToggleDetailPanel: PropTypes.func.isRequired
+  onToggleDetailPanel: PropTypes.func.isRequired,
+  onRowClick: PropTypes.func,
 };
 
 export default MTableBody;

--- a/src/m-table-cell.js
+++ b/src/m-table-cell.js
@@ -65,6 +65,12 @@ export default class MTableCell extends React.Component {
     }
   }
 
+  handleClickCell = e => {
+    const { columnDef, rowData, onClick } = this.props;
+    if( columnDef.disableClick || typeof onClick !== 'function') return;
+    onClick(e, rowData);
+  }
+
   render() {
     let cellStyle = {};
     if (typeof this.props.columnDef.cellStyle === 'function') {
@@ -76,6 +82,7 @@ export default class MTableCell extends React.Component {
     return (
       <TableCell style={cellStyle}
         align={['numeric'].indexOf(this.props.columnDef.type) !== -1 ? "right" : "left"}
+        onClick={this.handleClickCell}
       >
         {this.getRenderValue()}
       </TableCell>
@@ -85,11 +92,13 @@ export default class MTableCell extends React.Component {
 
 MTableCell.defaultProps = {
   columnDef: {},
-  value: undefined
+  value: undefined,
+  onClick: () => {},
 };
 
 MTableCell.propTypes = {
   columnDef: PropTypes.object.isRequired,
   value: PropTypes.any,
-  rowData: PropTypes.object
+  rowData: PropTypes.object,
+  onClick: PropTypes.func,
 };

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -394,6 +394,7 @@ class MaterialTable extends React.Component {
                 this.setData(data);
               }}
               localization={{ ...MaterialTable.defaultProps.localization.body, ...this.props.localization.body }}
+              onRowClick={this.props.onRowClick}
             />
           </Table>
         </ScrollBar>
@@ -480,7 +481,8 @@ MaterialTable.defaultProps = {
     body: {
       filterRow: {}
     }
-  }
+  },
+  onRowClick: () => {},
 };
 
 MaterialTable.propTypes = {
@@ -580,6 +582,7 @@ MaterialTable.propTypes = {
   onChangeRowsPerPage: PropTypes.func,
   onChangePage: PropTypes.func,
   onOrderChange: PropTypes.func,
+  onRowClick: PropTypes.func,
 };
 
 export default MaterialTable;


### PR DESCRIPTION
## Related Issue
#150 

## Description
This pull request adds the `onRowClick` property on the `MaterialTable` component.
This prop is a function that would be executed with two arguments :  
- event
- rowData

This prop is transfered to the `TableCell` component and is not added to the `TableRow` component for two reasons :  
- prevent the click to happen on the actions and selection columns
- allow to disbale the click on any specific cell using `columnDef.disableClick`

## Example
```javascript
const cellStyle = {cursor: 'pointer'}
 <MaterialTable
    columns={[
      {title: 'Name', field: 'name', cellStyle},
      {title: 'Birth Date', field: 'birthDate', type: 'date', cellStyle},
      {title: 'Birth Time', field: 'birthTime', type: 'time', disableClick: true}
    ]}
    data={[
      {name: 'Baldi', birthDate: '08/13/1996', birthTime: '02:00'},
      {name: 'Luiz', birthDate: '10/20/2018', birthTime: '17:00'}
    ]}
    title="Click Example"
    onRowClick={(e, d) => console.log(e.target, d)}
  />
```