### PR TITLE
Check if value is undefined instead of 'false'

### DIFF
--- a/src/material-table.js
+++ b/src/material-table.js
@@ -216,7 +216,7 @@ class MaterialTable extends React.Component {
   }
 
   getFieldValue = (rowData, columnDef) => {
-    let value = rowData[columnDef.field] || this.byString(rowData, columnDef.field);
+    let value = (typeof rowData[columnDef.field] !== 'undefined' ? rowData[columnDef.field] : this.byString(rowData, columnDef.field));
     if (columnDef.lookup) {
       value = columnDef.lookup[value];
     }


### PR DESCRIPTION
When getFieldValue() is used, check if the data is defined, then fallback to "getbystring" instead of checking if value is "false".
For exemple, if you had an array like this: 
[{"toto.tata": ''}]
it would return null instead of an empty string.

## Related Issue
Relate the Github issue with this PR using `#`

## Description
Simple words to describe the overall goals of the pull request's commits.

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
other_pr_production | [link]()
other_pr_master | [link]()

## Impacted Areas in Application
List general components of the application that this PR will affect:

*

## Additional Notes
This is optional, feel free to follow your hearth and write here :)