### PR TITLE
Fix this undefined for groupBy

### DIFF
--- a/src/material-table.js
+++ b/src/material-table.js
@@ -267,10 +267,10 @@ class MaterialTable extends React.Component {
   }
 
   groupBy(data, groups) {
-    const subData = data.reduce(function(result, current) {
+    const subData = data.reduce((result, current) => {
 
       let object = result;
-      object = groups.reduce(function(o, colDef) {
+      object = groups.reduce((o, colDef) => {
         const value = current[colDef.field] || this.byString(current, colDef.field);
         let group = o.groups.find(g => g.value === value);
         if (!group) {


### PR DESCRIPTION
Fix this undefined for groupBy

## Related Issue
#201 

## Description
Fixes the groupBy function to use arrow function, since this will be undefined in the reduce function. Arrow functions do not change this, so now it will not crash, if a value is undefined.

## Impacted Areas in Application
* material-table.js
