### PR TITLE
Fixes crash, if no tableData provided

### DIFF
--- a/src/m-table-body-row.js
+++ b/src/m-table-body-row.js
@@ -174,7 +174,7 @@ export default class MTableBodyRow extends React.Component {
         >
           {columns}
         </TableRow>
-        {this.props.data.tableData.showDetailPanel &&
+        {this.props.data.tableData && this.props.data.tableData.showDetailPanel &&
           <TableRow selected={this.props.index % 2 === 0}>
             <TableCell colSpan={columns.length} padding="none">
               {this.props.data.tableData.showDetailPanel(this.props.data)}


### PR DESCRIPTION
If tableData is undefined, this line caused a crash, because tableData.showDetailPanel was called.
This fixes this, because it checks, if table data is present.
