### PR TITLE
adds logic around draggable headers based on grouping option

### DIFF
--- a/src/m-table-header.js
+++ b/src/m-table-header.js
@@ -27,8 +27,8 @@ class MTableHeader extends React.Component {
                 this.props.onOrderChange(columnDef.tableData.id, orderDirection);
               }}
             >
-
-              <Draggable
+            {(this.props.grouping)
+              ? <Draggable
                 key={columnDef.tableData.id}
                 draggableId={columnDef.tableData.id.toString()}
                 index={index}>
@@ -43,6 +43,8 @@ class MTableHeader extends React.Component {
                   </div>
                 )}
               </Draggable>
+              : columnDef.title
+            }
             </TableSortLabel>
             : columnDef.title
           }

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -566,6 +566,7 @@ class MaterialTable extends React.Component {
                         }}
                         actionsHeaderIndex={props.options.actionsColumnIndex}
                         sorting={props.options.sorting}
+                        grouping={props.options.grouping}
                       />
                     }
                     <props.components.Body


### PR DESCRIPTION
## Related Issue
#216 

## Description
Adds logic around draggable headers so that they are only draggable if the grouping option is set to true.

## Impacted Areas in Application
MTableHeader

## Additional Notes
This is my first pull request.