### PR TITLE
Update m-table-header.js

### DIFF
--- a/src/m-table-header.js
+++ b/src/m-table-header.js
@@ -81,7 +81,7 @@ class MTableHeader extends React.Component {
   }
   render() {
     const headers = this.renderHeader();
-    if (this.props.hasSelection) {
+    if (this.props.hasSelection && this.props.dataCount) {
       headers.splice(0, 0, this.renderSelectionHeader());
     }
 


### PR DESCRIPTION
Hide selection-box if data is empty

# Description
When data is empty and the selection prop is true then will be shown a red selection box in the header.
This pr hides it.

![image](https://user-images.githubusercontent.com/15114434/52905421-670e6780-323a-11e9-9601-b123308c5799.png)

## Impacted Areas in Application
List general components of the application that this PR will affect:

* m-table-header
