### PR TITLE
Fixes issue with search when parent field is null

### DIFF
--- a/src/material-table.js
+++ b/src/material-table.js
@@ -311,7 +311,7 @@ class MaterialTable extends React.Component {
     var a = s.split('.');
     for (var i = 0, n = a.length; i < n; ++i) {
       var x = a[i];
-      if (x in o) {
+      if (o && x in o) {
         o = o[x];
       } else {
         return;


### PR DESCRIPTION

## Related Issue
Issue not opened

## Description
Fixes an issue where the field of the object is null (instead of only undefined). This changewill make it not crash, but rather return an undefined value.
