### PR TITLE
Edit padding fix

### DIFF
--- a/src/m-table-edit-row.js
+++ b/src/m-table-edit-row.js
@@ -88,8 +88,6 @@ export default class MTableEditRow extends React.Component {
       columns = this.renderColumns();
     }
     else {
-      // eslint-disable-next-line no-console
-      console.log(this.props.options);
       const colSpan = this.props.columns.filter(columnDef => !columnDef.hidden && !(columnDef.tableData.groupOrder > -1)).length;
       columns = [
         <TableCell

--- a/src/m-table-edit-row.js
+++ b/src/m-table-edit-row.js
@@ -88,9 +88,14 @@ export default class MTableEditRow extends React.Component {
       columns = this.renderColumns();
     }
     else {
+      // eslint-disable-next-line no-console
+      console.log(this.props.options);
       const colSpan = this.props.columns.filter(columnDef => !columnDef.hidden && !(columnDef.tableData.groupOrder > -1)).length;
       columns = [
-        <TableCell padding="none" key="key-selection-cell" colSpan={colSpan}>
+        <TableCell
+          padding={this.props.options.actionsColumnIndex === 0 ? "none" : undefined}
+          key="key-selection-cell"
+          colSpan={colSpan}>
           <Typography variant="h6">
             Are you sure delete this row?
           </Typography>


### PR DESCRIPTION
## Description
This fixes a padding error for the editable row, when the actionsColumIndex is -1:
![image](https://user-images.githubusercontent.com/17567991/54531978-ebadec00-4986-11e9-8992-9b34eff29283.png)

## Impacted Areas in Application
- m-table-edit-row