### PR TITLE
Removing select all checkbox from table

### DIFF
--- a/src/m-table-header.js
+++ b/src/m-table-header.js
@@ -81,6 +81,7 @@ class MTableHeader extends React.Component {
         style={{ ...this.props.headerStyle, ...this.stickyStyle }}
       >
         <Checkbox
+          style={this.props.displaySelectAll ? {}:{display:'none'}}
           indeterminate={this.props.selectedCount > 0 && this.props.selectedCount < this.props.dataCount}
           checked={this.props.selectedCount === this.props.dataCount}
           onChange={(event, checked) => this.props.onAllSelected && this.props.onAllSelected(checked)}
@@ -146,6 +147,7 @@ MTableHeader.defaultProps = {
   dataCount: 0,
   hasSelection: false,
   headerStyle: {},
+  displaySelectAll: true,
   selectedCount: 0,
   sorting: true,
   localization: {


### PR DESCRIPTION
## Related Issue
#347 

## Description
Removing Select All checkbox from table

-----------------------------------------------
We can make a custom header component and send "displaySelectAll={false}" to it, it will not display the select all checkbox.