### PR TITLE
Add support for default `exportCsv` function.

### DIFF
--- a/docz/props.mdx
+++ b/docz/props.mdx
@@ -188,6 +188,7 @@ Options property could be given to component as `options` property. You can chan
 | exportButton               | boolean                | false         | Flag for export button that render export buttons                                 |
 | exportDelimiter            | string                 | ,             | Delimiter to use in exported CSV file                                             |
 | exportFileName             | string                 | Title         | Exported file name                                                                |
+| exportCsv                  | func                   |               | Function to create a custom CSV file                                              |
 | filtering                  | boolean                | false         | Flag for filtering row                                                            |
 | header                     | boolean                | true          | Flag for header visibility                                                        |
 | headerStyle                | object                 |               | Header cell style for all headers                                                 |

--- a/index.d.ts
+++ b/index.d.ts
@@ -145,6 +145,7 @@ export interface Options {
   exportButton?: boolean;
   exportDelimiter?: string;
   exportFileName?: string;
+  exportCsv?: (toolbar: MTableToolbar, columns: any[], renderData: any[]) => void;
   filtering?: boolean;
   header?: boolean;
   headerStyle?: React.CSSProperties;

--- a/src/m-table-toolbar.js
+++ b/src/m-table-toolbar.js
@@ -16,7 +16,7 @@ class MTableToolbar extends React.Component {
     };
   }
 
-  exportCsv = () => {
+  defaultExportCsv = () => {
     const columns = this.props.columns
       .filter(columnDef => {
         return !columnDef.hidden && columnDef.field && columnDef.export !== false; 
@@ -34,6 +34,15 @@ class MTableToolbar extends React.Component {
       .exportFile();
 
     this.setState({ exportButtonAnchorEl: null });
+  }
+
+  exportCsv = () => {
+    const _this = this;
+    if(this.props.exportCsv) {
+      this.props.exportCsv(_this, this.props.columns, this.props.data);
+    } else {
+      this.defaultExportCsv();
+    }
   }
 
   renderSearch() {
@@ -221,9 +230,11 @@ MTableToolbar.propTypes = {
   showTitle: PropTypes.bool.isRequired,
   toolbarButtonAlignment: PropTypes.string.isRequired,
   renderData: PropTypes.array,
+  data: PropTypes.array,
   exportButton: PropTypes.bool,
   exportDelimiter: PropTypes.string,
   exportFileName: PropTypes.string,
+  exportCsv: PropTypes.func,
   classes: PropTypes.object
 };
 

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -741,6 +741,7 @@ MaterialTable.propTypes = {
     exportButton: PropTypes.bool,
     exportDelimiter: PropTypes.string,
     exportFileName: PropTypes.string,
+    exportCsv: PropTypes.func,
     filtering: PropTypes.bool,
     header: PropTypes.bool,
     headerStyle: PropTypes.object,

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -296,6 +296,8 @@ class MaterialTable extends React.Component {
               exportButton={props.options.exportButton}
               exportDelimiter={props.options.exportDelimiter}
               exportFileName={props.options.exportFileName}
+              exportCsv={props.options.exportCsv}
+              data={this.state.data}
               renderData={this.state.renderData}
               search={props.options.search}
               showTitle={props.options.showTitle}


### PR DESCRIPTION
## Related Issue
This PR Closes #288

## Description
This PR add the `exportCsv` prop to material table, so the user is able to build it's own csv file.

## Impacted Areas in Application
List general components of the application that this PR will affect:

* `MaterialTable`
* `MTableToolbar `

## Additional Notes
The solution is pretty much the same as proposed in the issue, I just needed to pass the `m-table-toolbar` so can call the `this.setState` and close the tooltip.

My suggestion would be "hook" the `defaultCsv` and close the tooltip inside the toolbar, so least exposure would be needed, but I'm keeping this PR simple, focused on the solution so we can discuss it better.

Thank youuu!! :D

## Example of Usage

I tested in my application and worked with the following code:

```jsx
import { CsvBuilder } from 'filefy';

function Index({model}) {
  const handleExportCsv = (toolbar, columns, renderData) => {
    const csvColumns = columns
      .filter(columnDef => {
        return !columnDef.hidden && columnDef.field && columnDef.export !== false; 
      });

    const data = renderData.map(rowData =>
      csvColumns.map(columnDef => rowData[columnDef.field])
    );

    const builder = new CsvBuilder(('foo') + '.csv')
      .setDelimeter(',')
      .setColumns(csvColumns.map(columnDef => columnDef.title))
      .addRows(data)
      .exportFile();

    toolbar.setState({ exportButtonAnchorEl: null }); // this is the reason to pass the m-table-toolbar object
  }

  return (
    <MaterialTable
      columns={[
        { title: 'ID', field: 'id' },
        { title: 'Name', field: 'name' },
      ]}
      data={model}
      title="Title"
      options={{
        columnsButton: true,
        exportButton: true,
        actionsColumnIndex: -1,
        exportCsv: handleExportCsv,
        exportFileName: 'untitled.csv' // using custom this is not used anymore
      }}
    />
  );
}
```