### PR TITLE
Correctly pass detailPanel to EditRow.

### DIFF
--- a/src/m-table-body.js
+++ b/src/m-table-body.js
@@ -45,6 +45,7 @@ class MTableBody extends React.Component {
             key={index}
             mode={data.tableData.editing}
             options={this.props.options}
+            detailPanel={this.props.detailPanel}
             onEditingCanceled={this.props.onEditingCanceled}
             onEditingApproved={this.props.onEditingApproved}
           />
@@ -148,6 +149,7 @@ class MTableBody extends React.Component {
             mode="add"
             localization={{ ...MTableBody.defaultProps.localization.editRow, ...this.props.localization.editRow }}
             options={this.props.options}
+            detailPanel={this.props.detailPanel}
             onEditingCanceled={this.props.onEditingCanceled}
             onEditingApproved={this.props.onEditingApproved}
           />


### PR DESCRIPTION
Without this modification, EditRow incorrectly offsets columns, takes on incorrect data types per field, and clips content inappropriately.

## Impacted Areas in Application
* `MTableEditRow`(seen as `props.components.EditRow` from `MTableBody`)