### PR TITLE
Make sure 'stickyStyle' does not overwrite any user defined styles

### DIFF
--- a/src/m-table-header.js
+++ b/src/m-table-header.js
@@ -23,7 +23,7 @@ class MTableHeader extends React.Component {
           key={columnDef.tableData.id}
           align={['numeric'].indexOf(columnDef.type) !== -1 ? "right" : "left"}
 
-          style={{ ...this.props.headerStyle, ...columnDef.headerStyle, ...this.stickyStyle }}
+          style={{ ...this.stickyStyle, ...this.props.headerStyle, ...columnDef.headerStyle }}
         >
           {(columnDef.sort !== false && columnDef.sorting !== false && this.props.sorting)
             ? <TableSortLabel


### PR DESCRIPTION
The properties at the end of the spread notation overwrite any existing properties set by the user through the headerStyle from options or the column itself.

See the "Sort overriding with customSort" example.
https://mbrn.github.io/material-table/#/docz-examples-04-example-sorting

The custom headerStyle backgroundColor for the name column is being overwritten by the white backgroundColor from stickyStyle.