### PR TITLE
Added searchFieldAlignment option

### DIFF
--- a/src/m-table-toolbar.js
+++ b/src/m-table-toolbar.js
@@ -19,7 +19,7 @@ class MTableToolbar extends React.Component {
   defaultExportCsv = () => {
     const columns = this.props.columns
       .filter(columnDef => {
-        return !columnDef.hidden && columnDef.field && columnDef.export !== false; 
+        return !columnDef.hidden && columnDef.field && columnDef.export !== false;
       });
 
     const data = this.props.renderData.map(rowData =>
@@ -49,7 +49,7 @@ class MTableToolbar extends React.Component {
     if (this.props.search) {
       return (
         <TextField
-          className={this.props.classes.searchField}
+          className={this.props.searchFieldAlignment === 'left' && this.props.showTitle === false ? null : this.props.classes.searchField}
           value={this.props.searchText}
           onChange={event => this.props.onSearchChanged(event.target.value)}
           color="inherit"
@@ -85,7 +85,6 @@ class MTableToolbar extends React.Component {
     const localization = { ...MTableToolbar.defaultProps.localization, ...this.props.localization };
     return (
       <div>
-        {this.renderSearch()}
         {this.props.columnsButton &&
           <span>
             <Tooltip title={localization.showColumnsTitle}>
@@ -182,7 +181,9 @@ class MTableToolbar extends React.Component {
         {title && <div className={classes.title}>
           <Typography variant="h6">{title}</Typography>
         </div>}
+        {this.props.searchFieldAlignment === 'left' && this.renderSearch()}
         {this.props.toolbarButtonAlignment === 'right' && <div className={classes.spacer} />}
+        {this.props.searchFieldAlignment === 'right' && this.renderSearch()}
         <div className={classes.actions}>
           {this.renderActions()}
         </div>
@@ -208,6 +209,7 @@ MTableToolbar.defaultProps = {
   search: true,
   showTitle: true,
   toolbarButtonAlignment: 'right',
+  searchFieldAlignment: 'right',
   searchText: '',
   selectedRows: [],
   title: 'No Title!'
@@ -228,6 +230,7 @@ MTableToolbar.propTypes = {
   title: PropTypes.string.isRequired,
   showTitle: PropTypes.bool.isRequired,
   toolbarButtonAlignment: PropTypes.string.isRequired,
+  searchFieldAlignment: PropTypes.string.isRequired,
   renderData: PropTypes.array,
   data: PropTypes.array,
   exportButton: PropTypes.bool,

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -322,6 +322,7 @@ class MaterialTable extends React.Component {
               search={props.options.search}
               showTitle={props.options.showTitle}
               toolbarButtonAlignment={props.options.toolbarButtonAlignment}
+              searchFieldAlignment={props.options.searchFieldAlignment}
               searchText={this.state.searchText}
               searchFieldStyle={props.options.searchFieldStyle}
               title={props.title}
@@ -630,6 +631,7 @@ MaterialTable.defaultProps = {
     search: true,
     showTitle: true,
     toolbarButtonAlignment: 'right',
+    searchFieldAlignment: 'right',
     searchFieldStyle: {},
     selection: false,
     sorting: true,
@@ -778,6 +780,7 @@ MaterialTable.propTypes = {
     search: PropTypes.bool,
     showTitle: PropTypes.bool,
     toolbarButtonAlignment: PropTypes.string,
+    searchFieldAlignment: PropTypes.string,
     searchFieldStyle: PropTypes.object,
     selection: PropTypes.bool,
     sorting: PropTypes.bool,


### PR DESCRIPTION
## Related Issue
No current issue.

## Description
Hey there. I needed to display the search field to the left, and could not use the component function to recreate the whole thing. Just added the params. Not sure if this is up to your standard I am not that experienced.

I would assume this is a small change/improvement. I also made sure the left padding is removed if no title is showed.


## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
other_pr_production | [link]()
other_pr_master | [link]()

## Impacted Areas in Application
List general components of the application that this PR will affect:

*

## Additional Notes
This is optional, feel free to follow your hearth and write here :)