### PR TITLE
Add support for read-only columns

### DIFF
--- a/docz/examples/15-example-editable.mdx
+++ b/docz/examples/15-example-editable.mdx
@@ -9,11 +9,59 @@ import MaterialTable from '../../src/material-table'
 
 # Editable Examples
 
+## Editable Example
+
 <Playground>
   <MaterialTable
     columns={[
       {title: 'Name', field: 'name'},
       {title: 'Surname', field: 'surname'},
+      {title: 'Birth Year', field: 'birthYear', type: 'numeric'},
+      {title: 'Birth Place', field: 'birthCity', lookup: {34: 'İstanbul', 63: 'Şanlıurfa'}},      
+    ]}
+    data={[
+      {name: 'Mehmet', surname: 'Baran', birthYear: 1987, birthCity: 63},
+      {name: 'Zerya Betül', surname: 'Baran', birthYear: 2017, birthCity: 34},
+    ]}
+    editable={{
+      onRowAdd: (newData) => new Promise((resolve, reject) => {
+        setTimeout(() => {
+          {/* const data = this.state.data;
+          data.push(newData);
+          this.setState({ data }, () => resolve()); */}
+
+          resolve();
+        }, 1000);
+      }),
+      onRowUpdate: (newData, oldData) => new Promise((resolve, reject) => {
+        setTimeout(() => {
+          {/* const data = this.state.data;
+          const index = data.indexOf(oldData);
+          data[index] = newData;                
+          this.setState({ data }, () => resolve()); */}
+          resolve();
+        }, 1000);
+      }),
+      onRowDelete: (oldData) => new Promise((resolve, reject) => {
+        setTimeout(() => {
+          {/* let data = this.state.data;
+          const index = data.indexOf(oldData);
+          data.splice(index, 1);
+          this.setState({ data }, () => resolve()); */}
+          resolve();
+        }, 1000);
+      }),
+    }}
+  />
+</Playground>
+
+## Readonly Columns Example
+
+<Playground>
+  <MaterialTable
+    columns={[
+      {title: 'Name', field: 'name'},
+      {title: 'Surname', field: 'surname', readonly: true},
       {title: 'Birth Year', field: 'birthYear', type: 'numeric'},
       {title: 'Birth Place', field: 'birthCity', lookup: {34: 'İstanbul', 63: 'Şanlıurfa'}},      
     ]}

--- a/docz/props.mdx
+++ b/docz/props.mdx
@@ -61,6 +61,7 @@ import MaterialTable from '../src/material-table'
 | headerStyle             | object          |           | Header cell style                                                                                             |
 | hidden                  | boolean         | false     | Flag for hide column                                                                                          |
 | lookup                  | object          |           | Key value pair for lookup render data from                                                                    |
+| readonly                | boolean         | false     | Flag to make column readonly when editing, the column will still be editable when adding a row                |
 | removable               | boolean         | true      | Flag for column that could be removed with columnsButton or not                                               |
 | render                  | func            |           | Render a custom node for cell. Parameter is `rowData` and return value must be ReactElement                   |
 | searchable              | boolean         | undefined | If true, includes the column when performing a search                                                         |

--- a/index.d.ts
+++ b/index.d.ts
@@ -77,6 +77,7 @@ export interface Column {
   headerStyle?: React.CSSProperties;
   hidden?: boolean;
   lookup?: object;
+  readonly?: boolean;
   removable?: boolean;
   render?: (data: any, type: ('row' | 'group')) => any;
   searchable?: boolean;

--- a/src/m-table-edit-row.js
+++ b/src/m-table-edit-row.js
@@ -3,6 +3,7 @@ import { Checkbox, TableCell, TableRow, IconButton, Icon, Tooltip, Typography } 
 import PropTypes from 'prop-types';
 import * as React from 'react';
 import FormField from './form/form-field';
+import MTableCell from './m-table-cell';
 /* eslint-enable no-unused-vars */
 
 
@@ -24,22 +25,36 @@ export default class MTableEditRow extends React.Component {
         if (index === 0) {
           style.paddingLeft = 24 + this.props.level * 20;
         }
-        return (
-          <TableCell
-            key={columnDef.tableData.id}
-            align={['numeric'].indexOf(columnDef.type) !== -1 ? "right" : "left"}
-          >
-            <FormField
-              key={columnDef.tableData.id}
+
+        if (this.props.mode !== 'add' && columnDef.readonly) {
+          return (
+            <this.props.components.Cell
+              icons={this.props.icons}
               columnDef={columnDef}
               value={value}
-              onChange={value => {
-                const data = { ...this.state.data };
-                data[columnDef.field] = value;
-                this.setState({ data });
-              }} />
-          </TableCell>
-        );
+              key={columnDef.tableData.id}
+              rowData={this.props.data}
+            />
+          );
+        }
+        else {
+          return (
+            <TableCell
+              key={columnDef.tableData.id}
+              align={['numeric'].indexOf(columnDef.type) !== -1 ? "right" : "left"}
+            >
+              <FormField
+                key={columnDef.tableData.id}
+                columnDef={columnDef}
+                value={value}
+                onChange={value => {
+                  const data = { ...this.state.data };
+                  data[columnDef.field] = value;
+                  this.setState({ data });
+                }} />
+            </TableCell>
+          );
+        }
       });
     return mapArr;
   }

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -689,6 +689,7 @@ MaterialTable.propTypes = {
     headerStyle: PropTypes.object,
     hidden: PropTypes.bool,
     lookup: PropTypes.object,
+    readonly: PropTypes.bool,
     removable: PropTypes.bool,
     render: PropTypes.func,
     searchable: PropTypes.bool,


### PR DESCRIPTION
## Related issues

#350

## Description
Allow columns to be flagged as read-only when editing a row. The read-only column remains editable when adding a new row.

## Impacted Areas in Application

* readonly flag added to column definition
* MTableEditRow updated to render column with this.props.components.Cell if readonly and not adding a new row, otherwise behaviour is as before.
* additional example added to "Editable Examples" demonstrating the feature