### PR TITLE
table toolbar custom title

### DIFF
--- a/docz/props.mdx
+++ b/docz/props.mdx
@@ -26,7 +26,7 @@ import MaterialTable from '../src/material-table'
 | options             | object                          |                   | All options of table                                              |
 | parentChildData     | func                            |                   | Func that makes table parent-child table                          |
 | tableRef            | any                             |                   | Could be use to pass ref over withStyles                          |
-| title               | string                          | 'Table Title'     | Table Title (only render if toolbar option is true                |
+| title               | string or ReactElement          | 'Table Title'     | Table Title (only render if toolbar option is true                |
 
 
 ### actions

--- a/index.d.ts
+++ b/index.d.ts
@@ -16,6 +16,7 @@ export interface MaterialTableProps {
   icons?: Icons;
   isLoading?: boolean;
   title: string;
+  customTitle?: JSX.Element;
   options?: Options;
   parentChildData?: (row: any, rows: any[]) => any;
   localization?: Localization;

--- a/index.d.ts
+++ b/index.d.ts
@@ -15,8 +15,7 @@ export interface MaterialTableProps {
   }
   icons?: Icons;
   isLoading?: boolean;
-  title: string;
-  customTitle?: JSX.Element;
+  title?: string | React.ReactElement;
   options?: Options;
   parentChildData?: (row: any, rows: any[]) => any;
   localization?: Localization;

--- a/src/m-table-toolbar.js
+++ b/src/m-table-toolbar.js
@@ -183,11 +183,12 @@ export class MTableToolbar extends React.Component {
     const { classes } = this.props;
     const localization = { ...MTableToolbar.defaultProps.localization, ...this.props.localization };
     const title = this.props.showTitle ? (this.props.selectedRows && this.props.selectedRows.length > 0 ? localization.nRowsSelected.replace('{0}', this.props.selectedRows.length) : this.props.title) : null;
+    const customTitle = this.props.customTitle;
     return (
-      <Toolbar className={classNames(classes.root, { [classes.highlight]: this.props.selectedRows && this.props.selectedRows.length > 0 })}>
-        {title && <div className={classes.title}>
+      <Toolbar className={classNames(classes.root, { [classes.highlight]: this.props.selectedRows && this.props.selectedRows.length > 0 })}>        
+        {(customTitle && <>{customTitle}</>) || (title && <div className={classes.title}>
           <Typography variant="h6">{title}</Typography>
-        </div>}
+        </div>)}
         {this.props.searchFieldAlignment === 'left' && this.renderSearch()}
         {this.props.toolbarButtonAlignment === 'left' && this.renderActions()}
         <div className={classes.spacer} />
@@ -218,7 +219,8 @@ MTableToolbar.defaultProps = {
   searchFieldAlignment: 'right',
   searchText: '',
   selectedRows: [],
-  title: 'No Title!'
+  title: 'No Title!',
+  customTitle: null,
 };
 
 MTableToolbar.propTypes = {
@@ -234,6 +236,7 @@ MTableToolbar.propTypes = {
   searchText: PropTypes.string.isRequired,
   selectedRows: PropTypes.array,
   title: PropTypes.string.isRequired,
+  customTitle: PropTypes.object,
   showTitle: PropTypes.bool.isRequired,
   toolbarButtonAlignment: PropTypes.string.isRequired,
   searchFieldAlignment: PropTypes.string.isRequired,

--- a/src/m-table-toolbar.js
+++ b/src/m-table-toolbar.js
@@ -3,7 +3,7 @@ import { Checkbox, FormControlLabel, Icon, IconButton, InputAdornment, Menu, Men
 import { lighten } from '@material-ui/core/styles/colorManipulator';
 import classNames from 'classnames';
 import { CsvBuilder } from 'filefy';
-import PropTypes from 'prop-types';
+import PropTypes, { oneOf } from 'prop-types';
 import * as React from 'react';
 /* eslint-enable no-unused-vars */
 
@@ -183,12 +183,11 @@ export class MTableToolbar extends React.Component {
     const { classes } = this.props;
     const localization = { ...MTableToolbar.defaultProps.localization, ...this.props.localization };
     const title = this.props.showTitle ? (this.props.selectedRows && this.props.selectedRows.length > 0 ? localization.nRowsSelected.replace('{0}', this.props.selectedRows.length) : this.props.title) : null;
-    const customTitle = this.props.customTitle;
     return (
-      <Toolbar className={classNames(classes.root, { [classes.highlight]: this.props.selectedRows && this.props.selectedRows.length > 0 })}>        
-        {(customTitle && <>{customTitle}</>) || (title && <div className={classes.title}>
+      <Toolbar className={classNames(classes.root, { [classes.highlight]: this.props.selectedRows && this.props.selectedRows.length > 0 })}>
+        {title && <div className={classes.title}>
           <Typography variant="h6">{title}</Typography>
-        </div>)}
+        </div>}
         {this.props.searchFieldAlignment === 'left' && this.renderSearch()}
         {this.props.toolbarButtonAlignment === 'left' && this.renderActions()}
         <div className={classes.spacer} />
@@ -219,8 +218,7 @@ MTableToolbar.defaultProps = {
   searchFieldAlignment: 'right',
   searchText: '',
   selectedRows: [],
-  title: 'No Title!',
-  customTitle: null,
+  title: 'No Title!'
 };
 
 MTableToolbar.propTypes = {
@@ -235,8 +233,7 @@ MTableToolbar.propTypes = {
   searchFieldStyle: PropTypes.object,
   searchText: PropTypes.string.isRequired,
   selectedRows: PropTypes.array,
-  title: PropTypes.string.isRequired,
-  customTitle: PropTypes.object,
+  title: PropTypes.oneOfType([PropTypes.element, PropTypes.string]),
   showTitle: PropTypes.bool.isRequired,
   toolbarButtonAlignment: PropTypes.string.isRequired,
   searchFieldAlignment: PropTypes.string.isRequired,

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -326,6 +326,7 @@ class MaterialTable extends React.Component {
               searchText={this.state.searchText}
               searchFieldStyle={props.options.searchFieldStyle}
               title={props.title}
+              customTitle={props.customTitle}
               onSearchChanged={searchText => this.setState({ searchText }, this.onSearchChange)}
               onColumnsChanged={(columnId, hidden) => {
                 this.dataManager.changeColumnHidden(columnId, hidden);

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -326,7 +326,6 @@ class MaterialTable extends React.Component {
               searchText={this.state.searchText}
               searchFieldStyle={props.options.searchFieldStyle}
               title={props.title}
-              customTitle={props.customTitle}
               onSearchChanged={searchText => this.setState({ searchText }, this.onSearchChange)}
               onColumnsChanged={(columnId, hidden) => {
                 this.dataManager.changeColumnHidden(columnId, hidden);
@@ -754,7 +753,7 @@ MaterialTable.propTypes = {
     ViewColumn: PropTypes.oneOfType([PropTypes.element, PropTypes.func]),
   }),
   isLoading: PropTypes.bool,
-  title: PropTypes.string,
+  title: PropTypes.oneOfType([PropTypes.element, PropTypes.string]),
   options: PropTypes.shape({
     actionsColumnIndex: PropTypes.number,
     columnsButton: PropTypes.bool,


### PR DESCRIPTION
## Description
Allow to customize toolbar title.

## Impacted Areas in Application
Toolbar.

## Additional Notes

It was useful for my application to reuse toolbar space and integrate a "New" record button command to go into a separate detail page.

with follow code

```ts
<MaterialTable
    title={""}
    customTitle={
        <Grid
            container={true}
            direction="row"
            justify="space-around"
            alignItems="center"
        >
            <Grid item={true}>
                <Typography variant="h6">
                    Jobs
            </Typography>
            </Grid>
            <Grid item={true}>
                <Button color="primary">New</Button>
            </Grid>
        </Grid>
    }
```

to generate

![image](https://user-images.githubusercontent.com/13405008/55537595-dcd07480-56bc-11e9-8c21-81cc0cb25e3b.png)
