### PR TITLE
Changed custom action icon object handling

### DIFF
--- a/src/m-table-action.js
+++ b/src/m-table-action.js
@@ -1,37 +1,45 @@
 /* eslint-disable no-unused-vars */
-import * as React from 'react';
-import PropTypes from 'prop-types';
-import { Icon, IconButton, Tooltip } from '@material-ui/core';
+import * as React from "react";
+import PropTypes from "prop-types";
+import { Icon, IconButton, Tooltip } from "@material-ui/core";
 /* eslint-enable no-unused-vars */
 
 class MTableAction extends React.Component {
   render() {
     let action = this.props.action;
-    if (typeof action === 'function') {
+    if (typeof action === "function") {
       action = action(this.props.data);
       if (!action) {
         return null;
       }
     }
 
+    const handleOnClick = event => {
+      if (action.onClick) {
+        action.onClick(event, this.props.data);
+        event.stopPropagation();
+      }
+    };
+
     const button = (
       <span>
-        <IconButton
-          color="inherit"
-          disabled={action.disabled}
-          onClick={(event) => {
-            if (action.onClick) {
-              action.onClick(event, this.props.data);
-              event.stopPropagation();
-            }
-          }}
-        >
-          {typeof action.icon === "string" ?
-            <Icon {...action.iconProps} fontSize="small">{action.icon}</Icon>
-            :
-            <action.icon {...action.iconProps} />
-          }
-        </IconButton>
+        {typeof action.icon === "string" ? (
+          <IconButton
+            color="inherit"
+            disabled={action.disabled}
+            onClick={event => handleOnClick(event)}
+          >
+            <Icon {...action.iconProps} fontSize="small">
+              {action.icon}
+            </Icon>
+          </IconButton>
+        ) : (
+          <action.icon
+            {...action.iconProps}
+            disabled={action.disabled}
+            onClick={event => handleOnClick(event)}
+          />
+        )}
       </span>
     );
 
@@ -50,7 +58,10 @@ MTableAction.defaultProps = {
 
 MTableAction.propTypes = {
   action: PropTypes.oneOfType([PropTypes.func, PropTypes.object]).isRequired,
-  data: PropTypes.oneOfType([PropTypes.object, PropTypes.arrayOf(PropTypes.object)]),
+  data: PropTypes.oneOfType([
+    PropTypes.object,
+    PropTypes.arrayOf(PropTypes.object)
+  ])
 };
 
 export default MTableAction;

--- a/src/m-table-action.js
+++ b/src/m-table-action.js
@@ -1,13 +1,13 @@
 /* eslint-disable no-unused-vars */
-import * as React from "react";
-import PropTypes from "prop-types";
-import { Icon, IconButton, Tooltip } from "@material-ui/core";
+import * as React from 'react';
+import PropTypes from 'prop-types';
+import { Icon, IconButton, Tooltip } from '@material-ui/core';
 /* eslint-enable no-unused-vars */
 
 class MTableAction extends React.Component {
   render() {
     let action = this.props.action;
-    if (typeof action === "function") {
+    if (typeof action === 'function') {
       action = action(this.props.data);
       if (!action) {
         return null;
@@ -23,23 +23,24 @@ class MTableAction extends React.Component {
 
     const button = (
       <span>
-        {typeof action.icon === "string" ? (
-          <IconButton
-            color="inherit"
-            disabled={action.disabled}
-            onClick={event => handleOnClick(event)}
-          >
-            <Icon {...action.iconProps} fontSize="small">
-              {action.icon}
-            </Icon>
-          </IconButton>
-        ) : (
-          <action.icon
-            {...action.iconProps}
-            disabled={action.disabled}
-            onClick={event => handleOnClick(event)}
-          />
-        )}
+
+          {typeof action.icon === "string" ? (
+            <IconButton
+              color="inherit"
+              disabled={action.disabled}
+              onClick={(event) => handleOnClick(event)}
+            >
+              <Icon {...action.iconProps} fontSize="small">{action.icon}</Icon>
+            </IconButton>
+          ) : (
+            <action.icon
+              {...action.iconProps}
+              disabled={action.disabled}
+              onClick={(event) => handleOnClick(event)}
+            />
+           )
+          }
+
       </span>
     );
 
@@ -58,10 +59,7 @@ MTableAction.defaultProps = {
 
 MTableAction.propTypes = {
   action: PropTypes.oneOfType([PropTypes.func, PropTypes.object]).isRequired,
-  data: PropTypes.oneOfType([
-    PropTypes.object,
-    PropTypes.arrayOf(PropTypes.object)
-  ])
+  data: PropTypes.oneOfType([PropTypes.object, PropTypes.arrayOf(PropTypes.object)]),
 };
 
 export default MTableAction;


### PR DESCRIPTION
## Related Issue
No related issue

## Description
Moved the Icon Button element in the action button so that a custom button can be assigned to the icon option correctly (was returning a nesting error in React since it was nesting the custom button inside the IconButton element).

This is how I am passing it.

```
  const AddButton = props => <Button {...props}>Add New Template</Button>;

  const actions = [
    {
      icon: props => AddButton(props),
      onClick: (event, rowData) => {
        handleOpen("addDialog");
      },
      iconProps: {
        color: "primary"
      },
      isFreeAction: true
    }
  ];
```

PS sorry for the dual commit, I left prettifier on before editing and I messed up the rollback so I had to re-commit:S

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
other_pr_production | [link]()
other_pr_master | [link]()

## Impacted Areas in Application
List general components of the application that this PR will affect:

*

## Additional Notes
This is optional, feel free to follow your hearth and write here :)