### PR TITLE
Fix bug Warning: A component is changing an uncontrolled

### DIFF
--- a/src/m-table-edit-row.js
+++ b/src/m-table-edit-row.js
@@ -14,13 +14,13 @@ export default class MTableEditRow extends React.Component {
 
     this.state = {
       data: props.data ? JSON.parse(JSON.stringify(props.data)) : {}
-    };    
+    };
   }
 
   renderColumns() {
     const mapArr = this.props.columns.filter(columnDef => !columnDef.hidden && !(columnDef.tableData.groupOrder > -1))
       .map((columnDef, index) => {
-        const value = this.state.data[columnDef.field];
+        const value = this.state.data[columnDef.field] || '';
         const style = {};
         if (index === 0) {
           style.paddingLeft = 24 + this.props.level * 20;
@@ -59,7 +59,7 @@ export default class MTableEditRow extends React.Component {
     return mapArr;
   }
 
-  renderActions() {    
+  renderActions() {
     const localization = { ...MTableEditRow.defaultProps.localization, ...this.props.localization };
     const actions = [
       {
@@ -144,16 +144,16 @@ export default class MTableEditRow extends React.Component {
         columns.splice(0, 0, <TableCell padding="none" key={"key-group-cell" + columnDef.tableData.id} />);
       });
 
-    const { 
-      detailPanel, 
-      isTreeData, 
-      onRowClick, 
-      onRowSelected, 
-      onTreeExpandChanged, 
-      onToggleDetailPanel, 
+    const {
+      detailPanel,
+      isTreeData,
+      onRowClick,
+      onRowSelected,
+      onTreeExpandChanged,
+      onToggleDetailPanel,
       onEditingApproved,
       onEditingCanceled,
-      ...rowProps 
+      ...rowProps
     } = this.props;
 
     return (
@@ -193,6 +193,6 @@ MTableEditRow.propTypes = {
   columns: PropTypes.array,
   onRowClick: PropTypes.func,
   onEditingApproved: PropTypes.func,
-  onEditingCanceled: PropTypes.func,  
+  onEditingCanceled: PropTypes.func,
   localization: PropTypes.object
 };


### PR DESCRIPTION
## Related Issue
Relate the Github issue #363 

## Description
Fix Warning: A component is changing an uncontrolled input of type text to be controlled. Input elements should not switch from uncontrolled to controlled (or vice versa). Decide between using a controlled or uncontrolled input element for the lifetime of the component.

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
other_pr_production | [link]()
other_pr_master | [link]()

## Impacted Areas in Application
List general components of the application that this PR will affect:

*

## Additional Notes
This is optional, feel free to follow your hearth and write here :)