### PR TITLE
fix types for editComponent

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -60,6 +60,23 @@ export interface Action {
   iconProps?: IconProps;
 }
 
+export interface EditComponentProps {
+  value: any,
+  onChange: (newValue: any) => void,
+  columnDef: EditCellColumnDef,
+}
+
+export interface EditCellColumnDef {
+  field: string,
+  title: string,
+  tableData: {
+    filterValue: any,
+    groupOrder: any,
+    groupSort: string,
+    id: number,
+  }
+}
+
 export interface Column {
   cellStyle?: React.CSSProperties | ((data: any) => React.CSSProperties);
   currencySetting?: { locale?: string, currencyCode?: string, minimumFractionDigits?: number, maximumFractionDigits?: number };
@@ -70,7 +87,7 @@ export interface Column {
   defaultGroupSort?: ('asc' | 'desc');
   defaultSort?: ('asc' | 'desc');
   disableClick?: boolean;
-  editComponent?: React.ComponentType<any>;
+  editComponent?: ((props: EditComponentProps) => React.ReactElement<any>);
   emptyValue?: string | React.ReactElement<any> | ((data: any) => React.ReactElement<any> | string);
   export?: boolean;
   field?: string;

--- a/src/m-table-edit-row.js
+++ b/src/m-table-edit-row.js
@@ -38,8 +38,8 @@ export default class MTableEditRow extends React.Component {
           );
         }
         else {
-          const EditComponent = columnDef.editComponent || this.props.components.EditField;
-
+          const { editComponent, ...cellProps } = columnDef;
+          const EditComponent = editComponent || this.props.components.EditField;
           return (
             <TableCell
               key={columnDef.tableData.id}
@@ -47,7 +47,7 @@ export default class MTableEditRow extends React.Component {
             >
               <EditComponent
                 key={columnDef.tableData.id}
-                columnDef={columnDef}
+                columnDef={cellProps}
                 value={value}
                 onChange={value => {
                   const data = { ...this.state.data };


### PR DESCRIPTION
## Related Issue
Relate the Github issue with this PR using `#`

## Description
Custom components should have better TypeScript intellisense, I've done this for editComponent. Will open up a PR for others I find. Need feedback if they should live in this branch or open up seperate small PRs for each component that I come across.
![image](https://user-images.githubusercontent.com/27971797/56072540-bfa34200-5d5d-11e9-844d-8b4450493985.png)

**NOTE**: small fix here, `editComponent` should not receive the function that it's calling, why would the child need to call the function to render more of itself? Fix uses spread operator to pull `editComponent` out, use it and then pass remaining props into cell component.

## Related PRs
`N/A`

## Impacted Areas in Application
List general components of the application that this PR will affect:
* index.d.ts - added two interfaces
* m-table-edit-row-js - fixed issue with `editComponent()` being sent in improperly

## Additional Notes
Loving finding things to help on ;)