### PR TITLE
Add option for exporting all data instead of just the visible rows

### DIFF
--- a/docz/props.mdx
+++ b/docz/props.mdx
@@ -192,6 +192,7 @@ Options property could be given to component as `options` property. You can chan
 | detailPanelType            | `single` or `multiple` | `multiple`    | Detail panel visibility type.                                                     |
 | doubleHorizontalScroll     | boolean                | false         | Flag for double scroll bar for long tables                                        |
 | emptyRowsWhenPaging        | boolean                | true          | Flag for rendering rows to complete page size                                     |
+| exportAllData              | boolean                | false         | Should CSV export include all data (true) or only visible rows (false, default)   |
 | exportButton               | boolean                | false         | Flag for export button that render export buttons                                 |
 | exportDelimiter            | string                 | ,             | Delimiter to use in exported CSV file                                             |
 | exportFileName             | string                 | Title         | Exported file name                                                                |

--- a/src/m-table-toolbar.js
+++ b/src/m-table-toolbar.js
@@ -22,7 +22,9 @@ export class MTableToolbar extends React.Component {
         return !columnDef.hidden && columnDef.field && columnDef.export !== false;
       });
 
-    const data = this.props.renderData.map(rowData =>
+    const dataToExport = this.props.exportAllData ? this.props.data : this.props.renderData;
+
+    const data = dataToExport.map(rowData =>
       columns.map(columnDef => {
         return this.props.getFieldValue(rowData, columnDef);
       })
@@ -237,6 +239,7 @@ MTableToolbar.propTypes = {
   searchFieldAlignment: PropTypes.string.isRequired,
   renderData: PropTypes.array,
   data: PropTypes.array,
+  exportAllData: PropTypes.bool,
   exportButton: PropTypes.bool,
   exportDelimiter: PropTypes.string,
   exportFileName: PropTypes.string,

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -317,6 +317,7 @@ class MaterialTable extends React.Component {
               columns={this.state.columns}
               columnsButton={props.options.columnsButton}
               icons={props.icons}
+              exportAllData={props.options.exportAllData}
               exportButton={props.options.exportButton}
               exportDelimiter={props.options.exportDelimiter}
               exportFileName={props.options.exportFileName}
@@ -628,6 +629,7 @@ MaterialTable.defaultProps = {
     debounceInterval: 200,
     doubleHorizontalScroll: false,
     emptyRowsWhenPaging: true,
+    exportAllData: false,
     exportButton: false,
     exportDelimiter: ',',
     filtering: false,
@@ -777,6 +779,7 @@ MaterialTable.propTypes = {
     detailPanelType: PropTypes.oneOf(['single', 'multiple']),
     doubleHorizontalScroll: PropTypes.bool,
     emptyRowsWhenPaging: PropTypes.bool,
+    exportAllData: PropTypes.bool,
     exportButton: PropTypes.bool,
     exportDelimiter: PropTypes.string,
     exportFileName: PropTypes.string,


### PR DESCRIPTION
## Related Issue
None

## Description
At the moment, material-table's CSV export only exports the data that is currently visible. This change makes it possible to instead export all data by passing `exportAllData: true` in the options.

## Related PRs
None

## Impacted Areas in Application
* CSV exporting

## Additional Notes
material-table is the best batteries-included table package for material UI that we've encountered so far. Thanks for all your hard work!