### PR TITLE
Fix TypeError in findDataByPath function when childRows are null

### DIFF
--- a/src/utils/data-manager.js
+++ b/src/utils/data-manager.js
@@ -295,7 +295,12 @@ export default class DataManager {
   findDataByPath = (renderData, path) => {
     if (this.isDataType("tree")) {
       const node = path.reduce((result, current) => {
-        return result.tableData.childRows[current];
+        return (
+          result &&
+          result.tableData &&
+          result.tableData.childRows &&
+          result.tableData.childRows[current]
+        );
       }, { tableData: { childRows: renderData } });
 
       return node;


### PR DESCRIPTION
## Related Issue
#494

## Description
This PR fixes the small bug I have mentioned in the above issue as far as I have tested. Tree view renders correctly after these checks. Please let me know if I have missed anything.

## Related PRs

None

## Impacted Areas in Application

* Tree Data view when table receives `parentChildData` prop

## Additional Notes
Thank you for your hard work and your contributions to open source world, keep it up please!