### PR TITLE
Data age

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,6 +7,7 @@ export interface MaterialTableProps {
   columns: Column[];
   components?: Components;
   data: any[] | ((query: Query) => Promise<QueryResult>);
+  dataAge?: number;
   detailPanel?: ((rowData: any) => React.ReactNode) | (DetailPanel | ((rowData: any) => DetailPanel))[];
   editable?: {
     onRowAdd?: (newData: any) => Promise<void>;

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -51,7 +51,7 @@ class MaterialTable extends React.Component {
     };
   }
 
-  componentDidMount() {
+  componentDidMount() {    
     this.setState(this.dataManager.getRenderState(), () => {
       if (this.isRemoteData()) {
         this.onQueryChange(this.state.query);
@@ -151,8 +151,7 @@ class MaterialTable extends React.Component {
     return calculatedProps;
   }
 
-  onSelectionChange = () => {
-    this.invalidated++;
+  onSelectionChange = () => {    
     if (this.props.onSelectionChange) {
       const selectedRows = [];
 
@@ -171,25 +170,21 @@ class MaterialTable extends React.Component {
     }
   }
 
-  onChangePage = (...args) => {
-    this.invalidated++;
+  onChangePage = (...args) => {    
     this.props.onChangePage && this.props.onChangePage(...args);
   }
 
-  onChangeRowsPerPage = (...args) => {
-    this.invalidated++;
+  onChangeRowsPerPage = (...args) => {    
     this.props.onChangeRowsPerPage && this.props.onChangeRowsPerPage(...args);
   }
 
-  onOrderChange = (...args) => {
-    this.invalidated++;
+  onOrderChange = (...args) => {    
     this.props.onOrderChange && this.props.onOrderChange(...args);
   }
 
   isRemoteData = () => !Array.isArray(this.props.data)
 
-  onQueryChange = (query, callback) => {
-    this.invalidated++;    
+  onQueryChange = (query, callback) => {    
     query = { ...this.state.query, ...query };
 
     this.setState({ isLoading: true }, () => {
@@ -208,8 +203,7 @@ class MaterialTable extends React.Component {
     });
   }
 
-  onSearchChange = debounce(() => {
-    this.invalidated++;    
+  onSearchChange = debounce(() => {     
     this.dataManager.changeSearchText(this.state.searchText);
 
     if (this.isRemoteData()) {
@@ -224,8 +218,7 @@ class MaterialTable extends React.Component {
     }
   }, this.props.options.debounceInterval)
 
-  onFilterChange = debounce(() => {
-    this.invalidated++;    
+  onFilterChange = debounce(() => {    
     if (this.isRemoteData()) {
       const query = { ...this.state.query };
       query.filters = this.state.columns
@@ -269,6 +262,7 @@ class MaterialTable extends React.Component {
                 }}
                 page={this.isRemoteData() ? this.state.query.page : this.state.currentPage}
                 onChangePage={(event, page) => {
+                  this.invalidated++;
                   if (this.isRemoteData()) {
                     const query = { ...this.state.query };
                     query.page = page;
@@ -282,6 +276,7 @@ class MaterialTable extends React.Component {
                   }
                 }}
                 onChangeRowsPerPage={(event) => {
+                  this.invalidated++;
                   this.dataManager.changePageSize(event.target.value);
 
                   if (this.isRemoteData()) {
@@ -358,8 +353,9 @@ class MaterialTable extends React.Component {
               searchText={this.state.searchText}
               searchFieldStyle={props.options.searchFieldStyle}
               title={props.title}
-              onSearchChanged={searchText => this.setState({ searchText }, this.onSearchChange)}
+              onSearchChanged={searchText => { this.invalidated++; this.setState({ searchText }, this.onSearchChange) }}
               onColumnsChanged={(columnId, hidden) => {
+                this.invalidated++;
                 this.dataManager.changeColumnHidden(columnId, hidden);
                 this.setState(this.dataManager.getRenderState());
               }}
@@ -375,10 +371,12 @@ class MaterialTable extends React.Component {
                 .sort((col1, col2) => col1.tableData.groupOrder - col2.tableData.groupOrder)
               }
               onSortChanged={(groupedColumn) => {
+                this.invalidated++;
                 this.dataManager.changeGroupOrder(groupedColumn.tableData.id);
                 this.setState(this.dataManager.getRenderState());
               }}
               onGroupRemoved={(groupedColumn, index) => {
+                this.invalidated++;
                 const result = {
                   combine: null,
                   destination: { droppableId: "headers", index: 0 },
@@ -416,10 +414,12 @@ class MaterialTable extends React.Component {
                           orderBy={this.state.orderBy}
                           orderDirection={this.state.orderDirection}
                           onAllSelected={(checked) => {
+                            this.invalidated++;
                             this.dataManager.changeAllSelected(checked);
                             this.setState(this.dataManager.getRenderState(), () => this.onSelectionChange());
                           }}
                           onOrderChange={(orderBy, orderDirection) => {
+                            this.invalidated++;    
                             this.dataManager.changeOrder(orderBy, orderDirection);
 
                             if (this.isRemoteData()) {
@@ -457,32 +457,39 @@ class MaterialTable extends React.Component {
                         getFieldValue={this.dataManager.getFieldValue}
                         isTreeData={this.props.parentChildData !== undefined}
                         onFilterChanged={(columnId, value) => {
+                          this.invalidated++;
                           this.dataManager.changeFilterValue(columnId, value);
                           this.setState({}, () => this.onFilterChange());
                         }}
                         onFilterSelectionChanged={(event) => {
+                          this.invalidated++;
                           this.dataManager.changeFilterSelectionChecked(event.target.checked);
                           this.setState(this.dataManager.getRenderState());
                         }}
                         onRowSelected={(event, path) => {
+                          this.invalidated++;
                           this.dataManager.changeRowSelected(event.target.checked, path);
                           this.setState(this.dataManager.getRenderState(), () => this.onSelectionChange());
                         }}
                         onToggleDetailPanel={(path, render) => {
+                          this.invalidated++;
                           this.dataManager.changeDetailPanelVisibility(path, render);
                           this.setState(this.dataManager.getRenderState());
                         }}
                         onGroupExpandChanged={(path) => {
+                          this.invalidated++;
                           this.dataManager.changeGroupExpand(path);
                           this.setState(this.dataManager.getRenderState());
                         }}
                         onTreeExpandChanged={(path, data) => {
+                          this.invalidated++;
                           this.dataManager.changeTreeExpand(path);
                           this.setState(this.dataManager.getRenderState(), () => {
                             this.props.onTreeExpandChange && this.props.onTreeExpandChange(data, data.tableData.isTreeExpanded);
                           });
                         }}
                         onEditingCanceled={(mode, rowData) => {
+                          this.invalidated++;
                           if (mode === "add") {
                             this.setState({ showAddRow: false });
                           }
@@ -492,6 +499,7 @@ class MaterialTable extends React.Component {
                           }
                         }}
                         onEditingApproved={(mode, newData, oldData) => {
+                          this.invalidated++;    
                           if (mode === "add") {
                             this.setState({ isLoading: true }, () => {
                               this.props.editable.onRowAdd(newData)

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -79,6 +79,7 @@ class MaterialTable extends React.Component {
       this.dataManager.changeApplyFilters(true);
       this.dataManager.setData(props.data);
     }
+    this.dataManager.setDataAge(props.dataAge);
 
     isInit && this.dataManager.changeOrder(defaultSortColumnIndex, defaultSortDirection);
     isInit && this.dataManager.changeCurrentPage(props.options.initialPage ? props.options.initialPage : 0);
@@ -89,10 +90,9 @@ class MaterialTable extends React.Component {
   }
 
   UNSAFE_componentWillReceiveProps(nextProps) {
-    const props = this.getProps(nextProps);
-    this.dataAge = nextProps.dataAge;
+    const props = this.getProps(nextProps);            
     this.setDataManagerFields(props);
-    this.setState(this.dataManager.getRenderState());
+    this.setState(this.dataManager.getRenderState());    
   }
 
   getProps(props) {
@@ -310,16 +310,17 @@ class MaterialTable extends React.Component {
     }
   }
 
-  shouldComponentUpdate(nextProps, nextState, nextContext) {
-    if (this.invalidated) {      
-      this.invalidated = false;
-      return true;
-    }
-    
+  shouldComponentUpdate(nextProps, nextState, nextContext) {            
+    // backward compatibility
+    if (this.state.dataAge === -1) { return true }    
+
     if (this.renderedDataAge < this.props.dataAge) {
-      this.renderedDataAge = this.props.dataAge;      
+      this.renderedDataAge = this.props.dataAge;
+      this.invalidated = false;
       return true;      
     }
+
+    if (this.invalidated) { this.invalidated = false; return true }        
 
     return false;
   }

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -318,11 +318,11 @@ class MaterialTable extends React.Component {
 
     if (this.renderedDataAge < this.props.dataAge) {
       this.renderedDataAge = this.props.dataAge;
-      this.invalidated--;
+      this.invalidated = 0;
       return true;      
     }
 
-    if (this.invalidated > 0) { this.invalidated--; return true }        
+    if (this.invalidated > 0) { this.invalidated = 0; return true }        
 
     return false;
   }

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -26,7 +26,7 @@ import { debounce } from 'debounce';
 class MaterialTable extends React.Component {
   dataManager = new DataManager();
   renderedDataAge = -1;  
-  invalidated = true;
+  invalidated = 1;
 
   constructor(props) {
     super(props);
@@ -152,7 +152,7 @@ class MaterialTable extends React.Component {
   }
 
   onSelectionChange = () => {
-    this.invalidated = true;    
+    this.invalidated++;
     if (this.props.onSelectionChange) {
       const selectedRows = [];
 
@@ -172,24 +172,24 @@ class MaterialTable extends React.Component {
   }
 
   onChangePage = (...args) => {
-    this.invalidated = true;    
+    this.invalidated++;
     this.props.onChangePage && this.props.onChangePage(...args);
   }
 
   onChangeRowsPerPage = (...args) => {
-    this.invalidated = true;    
+    this.invalidated++;
     this.props.onChangeRowsPerPage && this.props.onChangeRowsPerPage(...args);
   }
 
   onOrderChange = (...args) => {
-    this.invalidated = true;    
+    this.invalidated++;
     this.props.onOrderChange && this.props.onOrderChange(...args);
   }
 
   isRemoteData = () => !Array.isArray(this.props.data)
 
   onQueryChange = (query, callback) => {
-    this.invalidated = true;    
+    this.invalidated++;    
     query = { ...this.state.query, ...query };
 
     this.setState({ isLoading: true }, () => {
@@ -209,7 +209,7 @@ class MaterialTable extends React.Component {
   }
 
   onSearchChange = debounce(() => {
-    this.invalidated = true;    
+    this.invalidated++;    
     this.dataManager.changeSearchText(this.state.searchText);
 
     if (this.isRemoteData()) {
@@ -225,7 +225,7 @@ class MaterialTable extends React.Component {
   }, this.props.options.debounceInterval)
 
   onFilterChange = debounce(() => {
-    this.invalidated = true;    
+    this.invalidated++;    
     if (this.isRemoteData()) {
       const query = { ...this.state.query };
       query.filters = this.state.columns
@@ -314,13 +314,15 @@ class MaterialTable extends React.Component {
     // backward compatibility
     if (this.state.dataAge === -1) { return true }    
 
+    if (this.state.searchText !== nextState.searchText) { this.invalidated++ }    
+
     if (this.renderedDataAge < this.props.dataAge) {
       this.renderedDataAge = this.props.dataAge;
-      this.invalidated = false;
+      this.invalidated--;
       return true;      
     }
 
-    if (this.invalidated) { this.invalidated = false; return true }        
+    if (this.invalidated > 0) { this.invalidated--; return true }        
 
     return false;
   }

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -307,9 +307,7 @@ class MaterialTable extends React.Component {
 
   shouldComponentUpdate(nextProps, nextState, nextContext) {            
     // backward compatibility
-    if (this.state.dataAge === -1) { return true }    
-
-    if (this.state.searchText !== nextState.searchText) { this.invalidated++ }    
+    if (this.state.dataAge === -1) { return true }        
 
     if (this.renderedDataAge < this.props.dataAge) {
       this.renderedDataAge = this.props.dataAge;

--- a/src/utils/data-manager.js
+++ b/src/utils/data-manager.js
@@ -21,6 +21,7 @@ export default class DataManager {
   defaultExpanded = false;
 
   data = [];
+  dataAge = -1;
   columns = [];
 
   filteredData = [];
@@ -53,6 +54,10 @@ export default class DataManager {
     });
 
     this.filtered = false;
+  }
+
+  setDataAge(age) {    
+    this.dataAge = age;
   }
 
   setColumns(columns) {
@@ -418,6 +423,7 @@ export default class DataManager {
       columns: this.columns,
       currentPage: this.currentPage,
       data: this.sortedData,
+      dataAge: this.dataAge,
       lastEditingRow: this.lastEditingRow,
       orderBy: this.orderBy,
       orderDirection: this.orderDirection,


### PR DESCRIPTION
## Related Issue
Relate the Github issue with this PR using #500 

## Description
dataAge table prop if omitted works in a backward compatible way
if specified a value more than -1 it can be used to communicate the table that datasource changed causing render to be accepted

## Impacted Areas in Application
List general components of the application that this PR will affect:

- render performance

## Additional Notes
follow [sandbox](https://codesandbox.io/s/github/devel0/repros/tree/b0668933257b011f03bfbe34115476b9e78a3ac5/material-table/test01) shows how this works in a backward mode and then using dataAge to fire render on datasource changes

![Peek 2019-04-24 19-08x](https://user-images.githubusercontent.com/13405008/56679304-0598c800-66c5-11e9-9fd9-2e9b5cb1b96b.gif)
