### PR TITLE
Allow grouping by fields with render functions

### DIFF
--- a/src/m-table-group-row.js
+++ b/src/m-table-group-row.js
@@ -79,10 +79,7 @@ export default class MTableGroupRow extends React.Component {
     }
 
     let value = this.props.groupData.value;
-    if(column.render) {
-      value = column.render(value, 'group');
-    }
-    else if (column.lookup) {
+    if (column.lookup) {
       value = column.lookup[value];
     }
     if((value === undefined || value === null) && column.emptyValue) {

--- a/src/utils/data-manager.js
+++ b/src/utils/data-manager.js
@@ -566,7 +566,7 @@ export default class DataManager {
 
       let object = result;
       object = groups.reduce((o, colDef) => {
-        const value = current[colDef.field] || byString(current, colDef.field);
+        const value = colDef.render ? colDef.render(current) : (current[colDef.field] || byString(current, colDef.field));
         let group = o.groups.find(g => g.value === value);
         if (!group) {
           const path = [...(o.path || []), value];

--- a/src/utils/data-manager.js
+++ b/src/utils/data-manager.js
@@ -566,7 +566,10 @@ export default class DataManager {
 
       let object = result;
       object = groups.reduce((o, colDef) => {
-        const value = colDef.render ? colDef.render(current) : (current[colDef.field] || byString(current, colDef.field));
+        const value = 
+          current[colDef.field] 
+            ? ( colDef.render ? colDef.render(current[colDef.field], 'group') : current[colDef.field] )
+            : byString(current, colDef.field);
         let group = o.groups.find(g => g.value === value);
         if (!group) {
           const path = [...(o.path || []), value];


### PR DESCRIPTION
## Description
I have cells which contain objects, e.g. { latitude: 0.5, longitude: 0.5 }. 
Everything displays as expected when using a render function on the column e.g. {render:  (data) => data.coords.latitude }

However, when grouping the render function is ignored and the groupData() function tries to group the [Object Object].

The column render function is currently used further down the  render chain in the table-group-row.

In this PR, I propose moving the render() call higher up the chain to the groupData() function so that grouping works correctly while still displaying correctly in the component render.


## Impacted Areas in Application
List general components of the application that this PR will affect:

* Grouping
