### PR TITLE
Fixes not using default OverlayLoading component.

### DIFF
--- a/src/material-table.js
+++ b/src/material-table.js
@@ -560,7 +560,7 @@ export default class MaterialTable extends React.Component {
 
           {(this.state.isLoading || props.isLoading) && props.options.loadingType === 'overlay' &&
             <div style={{ position: 'absolute', top: 0, left: 0, height: '100%', width: '100%', zIndex: 11 }}>
-              <this.props.components.OverlayLoading theme={props.theme} />
+              <props.components.OverlayLoading theme={props.theme} />
             </div>
           }
         </props.components.Container>


### PR DESCRIPTION
## Related Issue
#568 

## Description
Fixes component crashing for accessing user provided props instead of default ones.

## Impacted Areas in Application
List general components of the application that this PR will affect:

* Main table component