### PR TITLE
Adding filter to header row

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -52,7 +52,7 @@ class App extends Component {
       { title: 'Evli', field: 'isMarried', type: 'boolean' },
       { title: 'Cinsiyet', field: 'sex', disableClick: true, editable: 'onAdd' },
       { title: 'Tipi', field: 'type', removable: false, editable: 'never' },
-      { title: 'Doğum Yılı', field: 'birthDate', type: 'date' },
+      { title: 'Doğum Yılı', field: 'birthDate', type: 'date', filtering: false },
       { title: 'Doğum Yeri', field: 'birthCity', lookup: { 34: 'İstanbul', 0: 'Şanlıurfa' } },
       { title: 'Kayıt Tarihi', field: 'insertDateTime', type: 'datetime' },
       { title: 'Zaman', field: 'time', type: 'time' }
@@ -81,8 +81,11 @@ class App extends Component {
                   data={this.state.data}
                   title="Demo Title"
                   options={{
-                    maxBodyHeight: '200px',
-                    grouping: true
+                    selection: true,
+                    grouping: true,
+                    filtering: true,
+                    filterType: 'header',
+                    maxBodyHeight: '400px',
                   }}
                 />
               </Grid>

--- a/demo/webpack.config.js
+++ b/demo/webpack.config.js
@@ -26,5 +26,6 @@ module.exports = {
     contentBase: './demo',
     hot: true,
     disableHostCheck: true
-  }
+  },
+  devtool: 'source-map'
 };

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -12,6 +12,7 @@ import MTableHeader from './m-table-header';
 import MTablePagination from './m-table-pagination';
 import MTableSteppedPagination from './m-table-stepped-pagination';
 import MTableToolbar from './m-table-toolbar';
+import MTableFilterButton from './m-table-filter-button';
 
 export {
   MTableAction,
@@ -28,4 +29,5 @@ export {
   MTablePagination,
   MTableSteppedPagination,
   MTableToolbar,
+  MTableFilterButton,
 };

--- a/src/components/m-table-body.js
+++ b/src/components/m-table-body.js
@@ -126,7 +126,7 @@ class MTableBody extends React.Component {
     }
     return (
       <TableBody>
-        {this.props.options.filtering &&
+        {this.props.options.filtering && this.props.options.filterType == 'row' &&
           <this.props.components.FilterRow
             columns={this.props.columns.filter(columnDef => { return !columnDef.hidden })}
             icons={this.props.icons}

--- a/src/components/m-table-filter-button.js
+++ b/src/components/m-table-filter-button.js
@@ -1,0 +1,223 @@
+/* eslint-disable no-unused-vars */
+import * as React from 'react';
+import {
+    TextField, FormControl, Checkbox,
+    ListItemText, InputAdornment, withStyles,
+    Popover, List, ListItem,
+} from '@material-ui/core';
+import { MuiPickersUtilsProvider, TimePicker, DatePicker, DateTimePicker } from 'material-ui-pickers';
+import DateFnsUtils from '@date-io/date-fns';
+import PropTypes from 'prop-types';
+/* eslint-enable no-unused-vars */
+
+class MTableFilterButton extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            anchorEl: null
+        };
+    }
+    handleOpenPopoverButtonClick = (e) => {
+        this.setState({
+            anchorEl: e.currentTarget
+        });
+    }
+    handlePopoverClose = () => {
+        this.setState({
+            anchorEl: null
+        });
+    }
+    handleLookupCheckboxToggle = (columnDef, key) => {
+        let filterValue = (columnDef.tableData.filterValue || []).slice();
+        const elementIndex = filterValue.indexOf(key);
+        if (elementIndex == -1) {
+            filterValue.push(key);
+        } else {
+            filterValue.splice(elementIndex, 1);
+        }
+        if (filterValue.length == 0) filterValue = undefined;
+        this.props.onFilterChanged(columnDef.tableData.id, filterValue);
+    }
+    handleCheckboxToggle = (columnDef) => {
+        let val;
+        if (columnDef.tableData.filterValue === undefined) {
+            val = 'checked';
+        } else if (columnDef.tableData.filterValue === 'checked') {
+            val = 'unchecked';
+        }
+        this.props.onFilterChanged(columnDef.tableData.id, val);
+    }
+    renderFilterBody(columnDef) {
+        if (columnDef.field || columnDef.customFilterAndSearch) {
+            if (columnDef.lookup) {
+                return this.renderLookupFilter(columnDef);
+            } else if (columnDef.type === 'boolean') {
+                return this.renderBooleanFilter(columnDef);
+            } else if (['date', 'datetime', 'time'].includes(columnDef.type)) {
+                return this.renderDateTypeFilter(columnDef);
+            } else {
+                return this.renderDefaultFilter(columnDef);
+            }
+        }
+        return null;
+    }
+    renderLookupFilter = (columnDef) => {
+        const { classes } = this.props;
+        return (
+            <FormControl style={{ width: '100%' }}>
+                <List className={classes.filterList}>
+                    {Object.keys(columnDef.lookup).map(key => (
+                        <ListItem
+                            className={classes.filterListItem}
+                            key={key} role={undefined} dense button
+                            onClick={() => this.handleLookupCheckboxToggle(columnDef, key)}
+                        >
+                            <Checkbox
+                                className={classes.filterCheckbox}
+                                checked={columnDef.tableData.filterValue ? columnDef.tableData.filterValue.indexOf(key.toString()) > -1 : false}
+                                tabIndex={-1}
+                                disableRipple
+                            />
+                            <ListItemText primary={columnDef.lookup[key]} className={classes.filterText} />
+                        </ListItem>
+                    ))}
+                </List>
+            </FormControl>
+        );
+    }
+    renderBooleanFilter = (columnDef) => {
+        const { classes } = this.props;
+        return (
+            <Checkbox
+                className={classes.filterCheckbox}
+                indeterminate={columnDef.tableData.filterValue === undefined}
+                checked={columnDef.tableData.filterValue === 'checked'}
+                onChange={() => this.handleCheckboxToggle(columnDef)}
+            />
+        );
+    }
+    renderDefaultFilter = (columnDef) => {
+        return (
+            <TextField
+                style={columnDef.type === 'numeric' ? { float: 'right' } : {}}
+                type={columnDef.type === 'numeric' ? 'number' : 'text'}
+                value={columnDef.tableData.filterValue || ''}
+                onChange={(event) => {
+                    this.props.onFilterChanged(columnDef.tableData.id, event.target.value);
+                }}
+                InputProps={{
+                    startAdornment: (
+                        <InputAdornment position="start">
+                            <></>
+                        </InputAdornment>
+                    )
+                }}
+            />
+        );
+    }
+    renderDateTypeFilter = (columnDef) => {
+        let dateInputElement = null;
+        const onDateInputChange = date => this.props.onFilterChanged(columnDef.tableData.id, date);
+
+        if (columnDef.type === 'date') {
+            dateInputElement = (
+                <DatePicker
+                    value={columnDef.tableData.filterValue || null}
+                    onChange={onDateInputChange}
+                    clearable
+                />
+            );
+        } else if (columnDef.type === 'datetime') {
+            dateInputElement = (
+                <DateTimePicker
+                    value={columnDef.tableData.filterValue || null}
+                    onChange={onDateInputChange}
+                    clearable
+                />
+            );
+        } else if (columnDef.type === 'time') {
+            dateInputElement = (
+                <TimePicker
+                    value={columnDef.tableData.filterValue || null}
+                    onChange={onDateInputChange}
+                    clearable
+                />
+            );
+        }
+
+        return (
+            <MuiPickersUtilsProvider utils={DateFnsUtils}>
+                {dateInputElement}
+            </MuiPickersUtilsProvider>
+        );
+    }
+    render() {
+        const columnDef = this.props.columnDef;
+        if (columnDef.filtering === false) return null;
+        const { classes } = this.props;
+        const popoverOpened = this.state.anchorEl != null;
+        const iconColor = `rgba(0, 0, 0, ${columnDef.tableData.filterValue ? '1' : '0.2'})`;
+        return (
+            <>
+                <this.props.icons.Filter
+                    style={{ color: iconColor }}
+                    className={classes.filterIcon}
+                    aria-owns={popoverOpened ? 'filter-popover' : undefined}
+                    aria-haspopup="true"
+                    variant="contained"
+                    onClick={e => this.handleOpenPopoverButtonClick(e)}
+                />
+                <Popover
+                    id='filter-popover'
+                    open={popoverOpened}
+                    anchorEl={this.state.anchorEl}
+                    onClose={this.handlePopoverClose}
+                    anchorOrigin={{
+                        vertical: 'bottom',
+                        horizontal: 'center',
+                    }}
+                    transformOrigin={{
+                        vertical: 'top',
+                        horizontal: 'center',
+                    }}
+                >
+                    <div className={classes.filterBody}>
+                        {this.renderFilterBody(columnDef)}
+                    </div>
+                </Popover>
+            </>);
+    }
+}
+
+export const styles = theme => ({
+    filterIcon: {
+        verticalAlign: 'middle',
+        cursor: 'pointer'
+    },
+    filterBody: {
+        padding: '8px'
+    },
+    filterCheckbox: {
+        padding: '12px'
+    },
+    filterList: {
+        padding: '0'
+    },
+    filterListItem: {
+        padding: '0 12px'
+    },
+    filterText: {
+        fontSize: '1rem',
+        fontWeight: '400',
+        lineHeight: '1.5em'
+    },
+});
+
+MTableFilterButton.propTypes = {
+    icons: PropTypes.object.isRequired,
+    columnDef: PropTypes.object.isRequired,
+    onFilterChanged: PropTypes.func.isRequired,
+    classes: PropTypes.object,
+};
+
+export default withStyles(styles)(MTableFilterButton);

--- a/src/components/m-table-header.js
+++ b/src/components/m-table-header.js
@@ -7,8 +7,8 @@ import {
 } from '@material-ui/core';
 import { Droppable, Draggable } from 'react-beautiful-dnd';
 /* eslint-enable no-unused-vars */
-
 export class MTableHeader extends React.Component {
+
   renderHeader() {
     const mapArr = this.props.columns.filter(columnDef => !columnDef.hidden && !(columnDef.tableData.groupOrder > -1))
       .sort((a, b) => a.tableData.columnOrder - b.tableData.columnOrder)
@@ -50,12 +50,26 @@ export class MTableHeader extends React.Component {
           );
         }
 
+        if (this.props.filtering && this.props.filterType == 'header') {
+          content = (
+            <>
+              {content}
+              <this.props.components.FilterButton
+                icons={this.props.icons}
+                columnDef={columnDef}
+                onFilterChanged={this.props.onFilterChanged}
+              >
+              </this.props.components.FilterButton>
+            </>
+          );
+        }
+
         return (
           <TableCell
             key={columnDef.tableData.id}
             align={['numeric'].indexOf(columnDef.type) !== -1 ? "right" : "left"}
             className={this.props.classes.header}
-            style={{ ...this.props.headerStyle, ...columnDef.headerStyle }}
+            style={{ ...this.props.headerStyle, ...columnDef.headerStyle, whiteSpace: 'nowrap' }}
           >
             {content}
           </TableCell>

--- a/src/default-props.js
+++ b/src/default-props.js
@@ -34,7 +34,8 @@ export const defaultProps = {
     OverlayLoading: OverlayLoading,
     Pagination: TablePagination,
     Row: MComponents.MTableBodyRow,
-    Toolbar: MComponents.MTableToolbar
+    Toolbar: MComponents.MTableToolbar,
+    FilterButton: MComponents.MTableFilterButton
   },
   data: [],
   icons: {
@@ -72,6 +73,7 @@ export const defaultProps = {
     exportButton: false,
     exportDelimiter: ',',
     filtering: false,
+    filterType: 'row',
     header: true,
     loadingType: 'overlay',
     paging: true,

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -493,7 +493,7 @@ export default class MaterialTable extends React.Component {
                   <div style={{ maxHeight: props.options.maxBodyHeight, overflowY: 'auto' }}>
                     <Table>
                       {props.options.header &&
-                        <props.components.Header
+                        <props.components.Header                        
                           localization={{ ...MaterialTable.defaultProps.localization.header, ...this.props.localization.header }}
                           columns={this.state.columns}
                           hasSelection={props.options.selection}
@@ -511,7 +511,12 @@ export default class MaterialTable extends React.Component {
                           actionsHeaderIndex={props.options.actionsColumnIndex}
                           sorting={props.options.sorting}
                           grouping={props.options.grouping}
+                          filtering={props.options.filtering}
+                          filterType={props.options.filterType}
                           isTreeData={this.props.parentChildData !== undefined}
+                          icons={this.props.icons}
+                          onFilterChanged={this.onFilterChange}
+                          components={props.components}
                         />
                       }
                       <props.components.Body

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -111,6 +111,7 @@ export const propTypes = {
     exportFileName: PropTypes.string,
     exportCsv: PropTypes.func,
     filtering: PropTypes.bool,
+    filterType: PropTypes.oneOf(['row', 'header']),
     filterCellStyle: PropTypes.object,
     header: PropTypes.bool,
     headerStyle: PropTypes.object,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -147,6 +147,7 @@ export const MTableGroupRow: () => React.ReactElement<any>;
 export const MTableHeader: () => React.ReactElement<any>;
 export const MTablePagination: () => React.ReactElement<any>;
 export const MTableToolbar: () => React.ReactElement<any>;
+export const MTableFilterButton: () => React.ReactElement<any>;
 
 
 export interface Icons {
@@ -185,6 +186,7 @@ export interface Options {
   exportFileName?: string;
   exportCsv?: (columns: any[], renderData: any[]) => void;
   filtering?: boolean;
+  filterType?: ('row' | 'header');
   filterCellStyle?: React.CSSProperties;
   header?: boolean;
   headerStyle?: React.CSSProperties;


### PR DESCRIPTION
## Related Issue
 #192

## Description
New Feature: showing filter either in header or in separate row.
The color of the filter icon is changing to dark when filters are applied.

`filterType: PropTypes.oneOf(['row', 'header']),`

![image](https://user-images.githubusercontent.com/15865485/58240462-71259200-7d64-11e9-862c-517cfe32893e.png)


