### PR TITLE
Migrate to MUI v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,12 +72,12 @@
   },
   "dependencies": {
     "@date-io/date-fns": "^1.1.0",
-    "@material-ui/core": "^3.9.3",
+    "@material-ui/core": "^4.0.1",
+    "@material-ui/pickers": "^3.0.0",
     "classnames": "^2.2.6",
     "date-fns": "^2.0.0-alpha.27",
     "debounce": "^1.2.0",
     "filefy": "0.1.9",
-    "material-ui-pickers": "2.2.4",
     "prop-types": "^15.6.2",
     "react-beautiful-dnd": "11.0.3",
     "react-double-scrollbar": "0.0.15"

--- a/src/components/m-table-edit-field.js
+++ b/src/components/m-table-edit-field.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { TextField, Checkbox, Select, MenuItem } from '@material-ui/core';
 import DateFnsUtils from '@date-io/date-fns';
-import { MuiPickersUtilsProvider, TimePicker, DatePicker, DateTimePicker } from 'material-ui-pickers';
+import { MuiPickersUtilsProvider, TimePicker, DatePicker, DateTimePicker } from '@material-ui/pickers';
 import PropTypes from 'prop-types';
 
 class MTableEditField extends React.Component {

--- a/src/components/m-table-filter-row.js
+++ b/src/components/m-table-filter-row.js
@@ -8,7 +8,7 @@ import {
   InputAdornment, Icon, Tooltip,
 } from '@material-ui/core';
 import DateFnsUtils from '@date-io/date-fns';
-import { MuiPickersUtilsProvider, TimePicker, DatePicker, DateTimePicker } from 'material-ui-pickers';
+import { MuiPickersUtilsProvider, TimePicker, DatePicker, DateTimePicker } from '@material-ui/pickers';
 
 const ITEM_HEIGHT = 48;
 const ITEM_PADDING_TOP = 8;

--- a/src/components/m-table-stepped-pagination.js
+++ b/src/components/m-table-stepped-pagination.js
@@ -38,7 +38,7 @@ class MTablePaginationInner extends React.Component {
           size="small"
           style={{
             boxShadow: 'none',
-            maxWidth: '30px', maxHeight: '30px', minWidth: '30px', minHeight: '30px'            
+            maxWidth: '30px', maxHeight: '30px', minWidth: '30px', minHeight: '30px'
           }}
           disabled={p === this.props.page}
           variant={buttonVariant}
@@ -97,7 +97,7 @@ const actionsStyles = theme => ({
   root: {
     flexShrink: 0,
     color: theme.palette.text.secondary,
-    marginLeft: theme.spacing.unit * 2.5
+    marginLeft: theme.spacing(2.5)
   }
 });
 

--- a/src/components/m-table-toolbar.js
+++ b/src/components/m-table-toolbar.js
@@ -253,7 +253,7 @@ MTableToolbar.propTypes = {
 
 export const styles = theme => ({
   root: {
-    paddingRight: theme.spacing.unit
+    paddingRight: theme.spacing(1)
   },
   highlight:
     theme.palette.type === 'light'
@@ -275,7 +275,7 @@ export const styles = theme => ({
     flex: '0 0 auto'
   },
   searchField: {
-    paddingLeft: theme.spacing.unit * 2
+    paddingLeft: theme.spacing(2)
   }
 });
 

--- a/src/default-props.js
+++ b/src/default-props.js
@@ -15,7 +15,7 @@ OverlayLoading.propTypes = {
   theme: PropTypes.any
 };
 
-const Container = (props) => <Paper {...props}/>;
+const Container = (props) => <Paper elevation={2} {...props}/>;
 
 export const defaultProps = {
   actions: [],
@@ -41,23 +41,23 @@ export const defaultProps = {
   data: [],
   icons: {
     /* eslint-disable react/display-name */
-    Add: (props) => <Icon {...props}>add_box</Icon>,
-    Check: (props) => <Icon {...props}>check</Icon>,
-    Clear: (props) => <Icon {...props}>clear</Icon>,
-    Delete: (props) => <Icon {...props}>delete_outline</Icon>,
-    DetailPanel: (props) => <Icon {...props}>chevron_right</Icon>,
-    Edit: (props) => <Icon {...props}>edit</Icon>,
-    Export: (props) => <Icon {...props}>save_alt</Icon>,
-    Filter: (props) => <Icon {...props}>filter_list</Icon>,
-    FirstPage: (props) => <Icon {...props}>first_page</Icon>,
-    LastPage: (props) => <Icon {...props}>last_page</Icon>,
-    NextPage: (props) => <Icon {...props}>chevron_right</Icon>,
-    PreviousPage: (props) => <Icon {...props}>chevron_left</Icon>,
-    ResetSearch: (props) => <Icon {...props}>clear</Icon>,
-    Search: (props) => <Icon {...props}>search</Icon>,
-    SortArrow: (props) => <Icon {...props}>arrow_upward</Icon>,
-    ThirdStateCheck: (props) => <Icon {...props}>remove</Icon>,
-    ViewColumn: (props) => <Icon {...props}>view_column</Icon>
+    Add: React.forwardRef((props, ref) => <Icon {...props} ref={ref}>add_box</Icon>),
+    Check: React.forwardRef((props, ref) => <Icon {...props} ref={ref}>check</Icon>),
+    Clear: React.forwardRef((props, ref) => <Icon {...props} ref={ref}>clear</Icon>),
+    Delete: React.forwardRef((props, ref) => <Icon {...props} ref={ref}>delete_outline</Icon>),
+    DetailPanel: React.forwardRef((props, ref) => <Icon {...props} ref={ref}>chevron_right</Icon>),
+    Edit: React.forwardRef((props, ref) => <Icon {...props} ref={ref}>edit</Icon>),
+    Export: React.forwardRef((props, ref) => <Icon {...props} ref={ref}>save_alt</Icon>),
+    Filter: React.forwardRef((props, ref) => <Icon {...props} ref={ref}>filter_list</Icon>),
+    FirstPage: React.forwardRef((props, ref) => <Icon {...props} ref={ref}>first_page</Icon>),
+    LastPage: React.forwardRef((props, ref) => <Icon {...props} ref={ref}>last_page</Icon>),
+    NextPage: React.forwardRef((props, ref) => <Icon {...props} ref={ref}>chevron_right</Icon>),
+    PreviousPage: React.forwardRef((props, ref) => <Icon {...props} ref={ref}>chevron_left</Icon>),
+    ResetSearch: React.forwardRef((props, ref) => <Icon {...props} ref={ref}>clear</Icon>),
+    Search: React.forwardRef((props, ref) => <Icon {...props} ref={ref}>search</Icon>),
+    SortArrow: React.forwardRef((props, ref) => <Icon {...props} ref={ref}>arrow_upward</Icon>),
+    ThirdStateCheck: React.forwardRef((props, ref) => <Icon {...props} ref={ref}>remove</Icon>),
+    ViewColumn: React.forwardRef((props, ref) => <Icon {...props} ref={ref}>view_column</Icon>)
     /* eslint-enable react/display-name */
   },
   isLoading: false,

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -1,5 +1,11 @@
 import PropTypes from 'prop-types';
 
+const RefComponent = PropTypes.shape({ current: PropTypes.element });
+const StyledComponent = PropTypes.shape({
+  classes: PropTypes.object,
+  innerRef: RefComponent
+});
+
 export const propTypes = {
   actions: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.shape({
     icon: PropTypes.oneOfType([PropTypes.element, PropTypes.func, PropTypes.string]).isRequired,
@@ -39,21 +45,21 @@ export const propTypes = {
     type: PropTypes.oneOf(['string', 'boolean', 'numeric', 'date', 'datetime', 'time', 'currency'])
   })).isRequired,
   components: PropTypes.shape({
-    Action: PropTypes.oneOfType([PropTypes.element, PropTypes.func]),
-    Actions: PropTypes.oneOfType([PropTypes.element, PropTypes.func]),
-    Body: PropTypes.oneOfType([PropTypes.element, PropTypes.func]),
-    Cell: PropTypes.oneOfType([PropTypes.element, PropTypes.func]),
-    Container: PropTypes.oneOfType([PropTypes.element, PropTypes.func]),
-    EditField: PropTypes.oneOfType([PropTypes.element, PropTypes.func]),
-    EditRow: PropTypes.oneOfType([PropTypes.element, PropTypes.func]),
-    FilterRow: PropTypes.oneOfType([PropTypes.element, PropTypes.func]),
-    Groupbar: PropTypes.oneOfType([PropTypes.element, PropTypes.func]),
-    GroupRow: PropTypes.oneOfType([PropTypes.element, PropTypes.func]),
-    Header: PropTypes.oneOfType([PropTypes.element, PropTypes.func]),
-    OverlayLoading: PropTypes.oneOfType([PropTypes.element, PropTypes.func]),
-    Pagination: PropTypes.oneOfType([PropTypes.element, PropTypes.func]),
-    Row: PropTypes.oneOfType([PropTypes.element, PropTypes.func]),
-    Toolbar: PropTypes.oneOfType([PropTypes.element, PropTypes.func])
+    Action: PropTypes.oneOfType([PropTypes.element, PropTypes.func, StyledComponent]),
+    Actions: PropTypes.oneOfType([PropTypes.element, PropTypes.func, StyledComponent]),
+    Body: PropTypes.oneOfType([PropTypes.element, PropTypes.func, StyledComponent]),
+    Cell: PropTypes.oneOfType([PropTypes.element, PropTypes.func, StyledComponent]),
+    Container: PropTypes.oneOfType([PropTypes.element, PropTypes.func, StyledComponent]),
+    EditField: PropTypes.oneOfType([PropTypes.element, PropTypes.func, StyledComponent]),
+    EditRow: PropTypes.oneOfType([PropTypes.element, PropTypes.func, StyledComponent]),
+    FilterRow: PropTypes.oneOfType([PropTypes.element, PropTypes.func, StyledComponent]),
+    Groupbar: PropTypes.oneOfType([PropTypes.element, PropTypes.func, StyledComponent]),
+    GroupRow: PropTypes.oneOfType([PropTypes.element, PropTypes.func, StyledComponent]),
+    Header: PropTypes.oneOfType([PropTypes.element, PropTypes.func, StyledComponent]),
+    OverlayLoading: PropTypes.oneOfType([PropTypes.element, PropTypes.func, StyledComponent]),
+    Pagination: PropTypes.oneOfType([PropTypes.element, PropTypes.func, StyledComponent]),
+    Row: PropTypes.oneOfType([PropTypes.element, PropTypes.func, StyledComponent]),
+    Toolbar: PropTypes.oneOfType([PropTypes.element, PropTypes.func, StyledComponent])
   }),
   data: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.object), PropTypes.func]).isRequired,
   editable: PropTypes.shape({
@@ -75,23 +81,23 @@ export const propTypes = {
     ]))
   ]),
   icons: PropTypes.shape({
-    Add: PropTypes.oneOfType([PropTypes.element, PropTypes.func]),
-    Check: PropTypes.oneOfType([PropTypes.element, PropTypes.func]),
-    Clear: PropTypes.oneOfType([PropTypes.element, PropTypes.func]),
-    Delete: PropTypes.oneOfType([PropTypes.element, PropTypes.func]),
-    DetailPanel: PropTypes.oneOfType([PropTypes.element, PropTypes.func]),
-    Edit: PropTypes.oneOfType([PropTypes.element, PropTypes.func]),
-    Export: PropTypes.oneOfType([PropTypes.element, PropTypes.func]),
-    Filter: PropTypes.oneOfType([PropTypes.element, PropTypes.func]),
-    FirstPage: PropTypes.oneOfType([PropTypes.element, PropTypes.func]),
-    LastPage: PropTypes.oneOfType([PropTypes.element, PropTypes.func]),
-    NextPage: PropTypes.oneOfType([PropTypes.element, PropTypes.func]),
-    PreviousPage: PropTypes.oneOfType([PropTypes.element, PropTypes.func]),
-    ResetSearch: PropTypes.oneOfType([PropTypes.element, PropTypes.func]),
-    Search: PropTypes.oneOfType([PropTypes.element, PropTypes.func]),
-    SortArrow: PropTypes.oneOfType([PropTypes.element, PropTypes.func]),
-    ThirdStateCheck: PropTypes.oneOfType([PropTypes.element, PropTypes.func]),
-    ViewColumn: PropTypes.oneOfType([PropTypes.element, PropTypes.func]),
+    Add: PropTypes.oneOfType([PropTypes.element, PropTypes.func, RefComponent]),
+    Check: PropTypes.oneOfType([PropTypes.element, PropTypes.func, RefComponent]),
+    Clear: PropTypes.oneOfType([PropTypes.element, PropTypes.func, RefComponent]),
+    Delete: PropTypes.oneOfType([PropTypes.element, PropTypes.func, RefComponent]),
+    DetailPanel: PropTypes.oneOfType([PropTypes.element, PropTypes.func, RefComponent]),
+    Edit: PropTypes.oneOfType([PropTypes.element, PropTypes.func, RefComponent]),
+    Export: PropTypes.oneOfType([PropTypes.element, PropTypes.func, RefComponent]),
+    Filter: PropTypes.oneOfType([PropTypes.element, PropTypes.func, RefComponent]),
+    FirstPage: PropTypes.oneOfType([PropTypes.element, PropTypes.func, RefComponent]),
+    LastPage: PropTypes.oneOfType([PropTypes.element, PropTypes.func, RefComponent]),
+    NextPage: PropTypes.oneOfType([PropTypes.element, PropTypes.func, RefComponent]),
+    PreviousPage: PropTypes.oneOfType([PropTypes.element, PropTypes.func, RefComponent]),
+    ResetSearch: PropTypes.oneOfType([PropTypes.element, PropTypes.func, RefComponent]),
+    Search: PropTypes.oneOfType([PropTypes.element, PropTypes.func, RefComponent]),
+    SortArrow: PropTypes.oneOfType([PropTypes.element, PropTypes.func, RefComponent]),
+    ThirdStateCheck: PropTypes.oneOfType([PropTypes.element, PropTypes.func, RefComponent]),
+    ViewColumn: PropTypes.oneOfType([PropTypes.element, PropTypes.func, RefComponent]),
   }),
   isLoading: PropTypes.bool,
   title: PropTypes.oneOfType([PropTypes.element, PropTypes.string]),


### PR DESCRIPTION
## Related Issue
#619 

## Description
Migration to `@material-ui/core` v4  alongside with `material-ui-pickers` v3 (note: the package has been moved to `@material-ui/pickers`)

## Impacted Areas in Application
Changes:

* Add new PropTypes: RefComponent, StyledComponent
* Update theme.spacing.unit usages to a new [API](https://material-ui.com/guides/migration-v3/#theme)
* Wrap icons in React.forwardRef (see [caveat with refs](https://material-ui.com/guides/composition/#caveat-with-refs))