### PR TITLE
Update README.md to fix @material-ui/icons typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Icons can be imported to be used in material-table offering more flexibility for
 
 To install @material-ui/icons with `npm`:
 
-    npm install material-table --save
+    npm install @material-ui/icons --save
 
 To install @material-ui/icons with `yarn`:
 


### PR DESCRIPTION
## Description
Fixed typo in README.md where `material-table` is listed in the icons install through NPM rather than `@material-ui/icons`.