### PR TITLE
adds missing dependencies required by other dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "webpack-dev-server": "^3.1.10"
   },
   "dependencies": {
+    "@date-io/core": "^1.3.6",
     "@date-io/date-fns": "^1.1.0",
     "@material-ui/core": "^4.0.1",
     "@material-ui/pickers": "^3.0.0",
@@ -79,7 +80,9 @@
     "debounce": "^1.2.0",
     "filefy": "0.1.9",
     "prop-types": "^15.6.2",
+    "react": "^16.8.5",
     "react-beautiful-dnd": "11.0.3",
+    "react-dom": "^16.8.4",
     "react-double-scrollbar": "0.0.15"
   }
 }


### PR DESCRIPTION
the following dependencies are required to be listed as they are peerDependencies of the listed packages.
this raises a warning when running with yarn2(berry) and will break PNP when using material-table as a dependency.

material-table@npm:1.39.0 doesn't provide react@^16.8.0 requested by @material-ui/core@workspace:packages/material-ui
material-table@npm:1.39.0 doesn't provide react-dom@^16.8.0 requested by @material-ui/core@workspace:packages/material-ui
material-table@npm:1.39.0 doesn't provide @date-io/core@^1.3.6 requested by @material-ui/pickers@npm:3.0.0
material-table@npm:1.39.0 doesn't provide react@^16.8.4 requested by @material-ui/pickers@npm:3.0.0
material-table@npm:1.39.0 doesn't provide react-dom@^16.8.4 requested by @material-ui/pickers@npm:3.0.0
material-table@npm:1.39.0 doesn't provide react@^16.8.5 requested by react-beautiful-dnd@npm:11.0.3
material-table@npm:1.39.0 doesn't provide react@>= 0.14.7 requested by react-double-scrollbar@npm:0.0.15

tagging @arcanis as requested in https://yarnpkg.com/en/docs/pnp/troubleshooting