### PR TITLE
Change page if it is out of range

### DIFF
--- a/src/material-table.js
+++ b/src/material-table.js
@@ -85,12 +85,12 @@ export default class MaterialTable extends React.Component {
   }
 
   componentDidUpdate() {
-    const count = this.isRemoteData() ? this.state.query.totalCount : this.state.data.length
-    const currentPage = this.isRemoteData() ? this.state.query.page : this.state.currentPage
-    const pageSize = this.isRemoteData() ? this.state.query.pageSize : this.state.pageSize
+    const count = this.isRemoteData() ? this.state.query.totalCount : this.state.data.length;
+    const currentPage = this.isRemoteData() ? this.state.query.page : this.state.currentPage;
+    const pageSize = this.isRemoteData() ? this.state.query.pageSize : this.state.pageSize;
 
     if (count <= pageSize * currentPage && currentPage !== 0) {
-      this.onChangePage(null, Math.max(0, Math.ceil(count / pageSize) - 1))
+      this.onChangePage(null, Math.max(0, Math.ceil(count / pageSize) - 1));
     }
   }
 

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -84,6 +84,16 @@ export default class MaterialTable extends React.Component {
     this.setState(this.dataManager.getRenderState());
   }
 
+  componentDidUpdate() {
+    const count = this.isRemoteData() ? this.state.query.totalCount : this.state.data.length
+    const currentPage = this.isRemoteData() ? this.state.query.page : this.state.currentPage
+    const pageSize = this.isRemoteData() ? this.state.query.pageSize : this.state.pageSize
+
+    if (count <= pageSize * currentPage && currentPage !== 0) {
+      this.onChangePage(null, Math.max(0, Math.ceil(count / pageSize) - 1))
+    }
+  }
+
   getProps(props) {
     const calculatedProps = { ...(props || this.props) };
 


### PR DESCRIPTION
## Related Issue
Fixes #708 

## Description
Change the page if it is out of range from either deleting rows or filtering

## Related PRs
N/A

## Impacted Areas in Application
List general components of the application that this PR will affect:
MaterialTable

## Additional Notes
The error still appears in the console as we don't catch it before the update.

The ideal solution would be to use getDerivedStateFromProps and also use it to replace `UNSAFE_componentWillReceiveProps`. This seemed like quite a major refactor though, so I decided against it