### PR TITLE
fixed tree sort behavior

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -42,7 +42,7 @@ class App extends Component {
       { id: 1, name: 'A1', surname: 'B', isMarried: true, birthDate: new Date(1987, 1, 1), birthCity: 0, sex: 'Male', type: 'adult', insertDateTime: new Date(2018, 1, 1, 12, 23, 44), time: new Date(1900, 1, 1, 14, 23, 35) },
       { id: 2, name: 'A2', surname: 'B', isMarried: false, birthDate: new Date(1987, 1, 1), birthCity: 34, sex: 'Female', type: 'adult', insertDateTime: new Date(2018, 1, 1, 12, 23, 44), time: new Date(1900, 1, 1, 14, 23, 35), parentId: 1 },
       { id: 3, name: 'A3', surname: 'B', isMarried: true, birthDate: new Date(1987, 1, 1), birthCity: 34, sex: 'Female', type: 'child', insertDateTime: new Date(2018, 1, 1, 12, 23, 44), time: new Date(1900, 1, 1, 14, 23, 35), parentId: 1 },
-      { id: 4, name: 'A4', surname: 'C', isMarried: true, birthDate: new Date(1987, 1, 1), birthCity: 34, sex: 'Female', type: 'child', insertDateTime: new Date(2018, 1, 1, 12, 23, 44), time: new Date(1900, 1, 1, 14, 23, 35), parentId: 3 },
+      { id: 4, name: 'A4', surname: 'Dede', isMarried: true, birthDate: new Date(1987, 1, 1), birthCity: 34, sex: 'Female', type: 'child', insertDateTime: new Date(2018, 1, 1, 12, 23, 44), time: new Date(1900, 1, 1, 14, 23, 35), parentId: 3 },
       { id: 5, name: 'A5', surname: 'C', isMarried: false, birthDate: new Date(1987, 1, 1), birthCity: 34, sex: 'Female', type: 'child', insertDateTime: new Date(2018, 1, 1, 12, 23, 44), time: new Date(1900, 1, 1, 14, 23, 35) },
       { id: 6, name: 'A6', surname: 'C', isMarried: true, birthDate: new Date(1989, 1, 1), birthCity: 34, sex: 'Female', type: 'child', insertDateTime: new Date(2018, 1, 1, 12, 23, 44), time: new Date(1900, 1, 1, 14, 23, 35), parentId: 5 },
     ],
@@ -127,7 +127,7 @@ class App extends Component {
                     />
                   ),
                 },
-                { title: 'Id', field: 'id', filterPlaceholder:'placeholder' },
+                { title: 'Id', field: 'id', filterPlaceholder: 'placeholder' },
                 { title: 'First Name', field: 'first_name' },
                 { title: 'Last Name', field: 'last_name' },
               ]}

--- a/src/utils/data-manager.js
+++ b/src/utils/data-manager.js
@@ -558,10 +558,10 @@ export default class DataManager {
     if (this.searchText && this.applySearch) {
       this.searchedData.forEach(row => {
         row.tableData.isTreeExpanded = false;
-      })
+      });
       this.searchedData = this.searchedData.filter(row => {
         return this.columns
-          .filter(columnDef => { return columnDef.searchable === undefined ? !columnDef.hidden : columnDef.searchable; })
+          .filter(columnDef => { return columnDef.searchable === undefined ? !columnDef.hidden : columnDef.searchable })
           .some(columnDef => {
             if (columnDef.customFilterAndSearch) {
               return !!columnDef.customFilterAndSearch(this.searchText, row, columnDef);
@@ -672,19 +672,19 @@ export default class DataManager {
         if (pointer.tableData && pointer.tableData.childRows) {
           pointer = pointer.tableData.childRows;
         }
-        pointer = pointer[pathPart]
-      })
+        pointer = pointer[pathPart];
+      });
       pointer.tableData.markedForTreeRemove = true;
-    }
+    };
 
     const traverseChildrenAndUnmark = (rowData) => {
       if (rowData.tableData.childRows) {
         rowData.tableData.childRows.forEach(row => {
           traverseChildrenAndUnmark(row);
-        })
+        });
       }
       rowData.tableData.markedForTreeRemove = false;
-    }
+    };
 
     // for all data rows, restore initial expand if no search term is available and remove items that shouldn't be there
     this.data.forEach(rowData => {
@@ -700,7 +700,7 @@ export default class DataManager {
     // preserve all children of nodes that are matched by search
     this.data.forEach(rowData => {
       if (this.searchedData.indexOf(rowData) > -1) {
-        traverseChildrenAndUnmark(rowData)
+        traverseChildrenAndUnmark(rowData);
       }
     });
 
@@ -713,7 +713,7 @@ export default class DataManager {
         if (item.tableData.markedForTreeRemove)
           rowDataArray.splice(i, 1);
       }
-    }
+    };
 
     traverseTreeAndDeleteMarked(this.treefiedData);
 

--- a/src/utils/data-manager.js
+++ b/src/utils/data-manager.js
@@ -561,7 +561,7 @@ export default class DataManager {
       })
       this.searchedData = this.searchedData.filter(row => {
         return this.columns
-          .filter(columnDef => { return columnDef.searchable === undefined ? !columnDef.hidden : columnDef.searchable })
+          .filter(columnDef => { return columnDef.searchable === undefined ? !columnDef.hidden : columnDef.searchable; })
           .some(columnDef => {
             if (columnDef.customFilterAndSearch) {
               return !!columnDef.customFilterAndSearch(this.searchText, row, columnDef);


### PR DESCRIPTION
## Related Issue
#717

## Description
Reworked the logic for searching in tree views. With these changes, the following rows are shown:

- all items that match the search, regardless of their level in the tree
- all their parent items, regardless of whether they match the search
- all child items of matched items, in a collapsed state

I consider this an intuitive way to search in a tree. Either a leaf node is the target, or some branch node where I want to be able to explore the deeper structure

## Additional Notes
the data-manager is getting awfully large. It might benefit from splitting up into search-manager, filter-manager, etc.