### PR TITLE
add multi column sort feature

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -87,7 +87,31 @@ class App extends Component {
       { title: 'Id', field: 'id' },
       { title: 'First Name', field: 'first_name', defaultFilter: 'De' },
       { title: 'Last Name', field: 'last_name' },
-    ]
+    ],
+    multiSort: {
+      columns: [
+        { title: 'strings', field: 'strings', defaultSort: 'asc', defaultSortOrder: 0 },
+        { title: 'letters', field: 'letters', defaultSort: 'desc', defaultSortOrder: 1 },
+        { title: 'bools', field: 'bools', defaultSort: 'asc', defaultSortOrder: 2, type: 'boolean' },
+        { title: 'dates', field: 'dates', defaultSort: 'desc', defaultSortOrder: 3, type: 'date' },
+        { title: 'date & time', field: 'datetime', defaultSort: 'asc', defaultSortOrder: 4, type: 'datetime' },
+        { title: 'times', field: 'time', defaultSort: 'desc', defaultSortOrder: 5, type: 'time' },
+        { title: 'numbers', field: 'numbers', defaultSort: 'asc', defaultSortOrder: 6, type: 'numeric' },
+        { title: 'currencies', field: 'currencies', type: 'currency' }
+      ],
+      data: [
+        { strings: "material-table", letters: "A", bools: false, dates: new Date(2001, 1, 1), datetime: new Date(2019, 1, 1, 12, 1, 0), time: new Date(1900, 1, 1, 17, 0, 0), numbers: 99, currencies: 0.99 },
+        { strings: "material-table", letters: "A", bools: true, dates: new Date(2001, 1, 1), datetime: new Date(2019, 1, 1, 12, 1, 0), time: new Date(1900, 1, 1, 17, 1, 0), numbers: 99 , currencies: 9.99 },
+        { strings: "material-table", letters: "A", bools: true, dates: new Date(2001, 1, 1), datetime: new Date(2019, 1, 1, 12, 2, 0), time: new Date(1900, 1, 1, 18, 0, 0), numbers: 10, currencies: 0.00 },
+        { strings: "material-table", letters: "A", bools: true, dates: new Date(2001, 1, 1), datetime: new Date(2019, 1, 1, 12, 2, 0), time: new Date(1900, 1, 1, 17, 0, 0), numbers: 99 , currencies: 9.99 },
+        { strings: "material-table", letters: "A", bools: true, dates: new Date(2001, 1, 1), datetime: new Date(2019, 1, 1, 12, 2, 0), time: new Date(1900, 1, 1, 18, 0, 0), numbers: 10, currencies: 0.00 },
+        { strings: "material-table", letters: "X", bools: false, dates: new Date(2001, 2, 2), datetime: new Date(2019, 1, 1, 12, 2, 0), time: new Date(1900, 1, 1, 18, 1, 0), numbers: 10, currencies: 100.00 },
+        { strings: "material-table", letters: "X", bools: true, dates: new Date(2001, 2, 2), datetime: new Date(2019, 1, 1, 12, 2, 0), time: new Date(1900, 1, 1, 19, 0, 0), numbers: 999, currencies: 1000.00 },
+        { strings: "material-ui", letters: "X", bools: false, dates: new Date(2001, 2, 2), datetime: new Date(2019, 1, 1, 12, 2, 0), time: new Date(1900, 1, 1, 18, 1, 0), numbers: 10, currencies: 100.00 },
+        { strings: "material-ui", letters: "X", bools: true, dates: new Date(2001, 2, 2), datetime: new Date(2019, 1, 1, 12, 2, 0), time: new Date(1900, 1, 1, 19, 0, 0), numbers: 999, currencies: 1000.00 },
+        { strings: "material-ui", letters: "X", bools: false, dates: new Date(2001, 3, 3), datetime: new Date(2019, 1, 1, 12, 10, 1), time: new Date(1900, 1, 1, 20, 0, 1), numbers: 1000, currencies: 1000.01 },
+      ]
+    }
   }
 
   render() {
@@ -151,7 +175,16 @@ class App extends Component {
                   })
               })}
             />
-
+            <MaterialTable
+              tableRef={this.tableRef}
+              columns={this.state.multiSort.columns}
+              data={this.state.multiSort.data}
+              title="MultiSort Columns"
+              options={{
+                pageSize: 10,
+                grouping: true,
+              }}
+            />
           </div>
         </MuiThemeProvider>
       </>

--- a/src/components/m-table-header.js
+++ b/src/components/m-table-header.js
@@ -52,13 +52,22 @@ export class MTableHeader extends React.Component {
         // }
 
         if (columnDef.sorting !== false && this.props.sorting) {
+          let active = false;
+          let direction = 'asc';
+  
+          const existingSortedIndex = this.props.sortOrder.findIndex(item => item.orderBy === columnDef.tableData.id);
+          if (existingSortedIndex > -1) {
+            active = true;
+            direction = this.props.sortOrder[existingSortedIndex].orderDirection;
+          }
+
           content = (
             <TableSortLabel
-              active={this.props.orderBy === columnDef.tableData.id}
-              direction={this.props.orderDirection || 'asc'}
-              onClick={() => {
+              active={active}
+              direction={direction}
+              onClick={(event) => {
                 const orderDirection = columnDef.tableData.id !== this.props.orderBy ? 'asc' : this.props.orderDirection === 'asc' ? 'desc' : 'asc';
-                this.props.onOrderChange(columnDef.tableData.id, orderDirection);
+                this.props.onOrderChange(columnDef.tableData.id, orderDirection, event.shiftKey);
               }}
             >
               {content}
@@ -203,6 +212,7 @@ MTableHeader.propTypes = {
   onOrderChange: PropTypes.func,
   orderBy: PropTypes.number,
   orderDirection: PropTypes.string,
+  sortOrder: PropTypes.array,
   actionsHeaderIndex: PropTypes.number,
   showActionsColumn: PropTypes.bool,
   showSelectAllCheckbox: PropTypes.bool,

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -28,6 +28,7 @@ export const propTypes = {
     customSort: PropTypes.func,
     defaultFilter: PropTypes.any,
     defaultSort: PropTypes.oneOf(['asc', 'desc']),
+    defaultSortOrder: PropTypes.number,
     editComponent: PropTypes.oneOfType([PropTypes.element, PropTypes.func]),
     emptyValue: PropTypes.oneOfType([PropTypes.string, PropTypes.node, PropTypes.func]),
     export: PropTypes.bool,


### PR DESCRIPTION
## Related Issue
#116 

## Description
Adds column multi-sort feature.

## Additional Notes
- multi-sort is available by default as long as sorting is enabled for table/columns, just hold SHIFT key clicking on header and multi-sort is active.  
- Don't hold SHIFT key when clicking header and it defaults back to single sort.
- There is a new prop for column, 'defaultSortOrder', give it a number which allows default multi-sort.
- Also for onQueryChange a 'sortOrder' property was added which gives the current sort order and for onOrderChange there is an additional argument which is the current sort order.

This could have been a bit cleaner as orderBy and orderDirection aren't necessarily needed anymore as they are both tracked in sortOrder but I left them as is as this would have meant breaking changes for onQueryChange and onOrderChange.

One last note.... I had a 'skip' orderDirection in place where sorting was ignored/reset for the column after clicking header which was previously sorted 'desc', but this would have been a breaking change as well for orderBy and orderDirection I would assume.  Maybe this could be a table option, to opt into 'skip' sorting along with 'asc', 'desc'.

If this works for you I'd be happy to update the docs and throw in an example.  I did add a new table to the demo in the project rather than mucking up with the other tables/data.