### PR TITLE
Added props to disable draggable header

### DIFF
--- a/src/components/m-table-header.js
+++ b/src/components/m-table-header.js
@@ -17,7 +17,8 @@ export class MTableHeader extends React.Component {
           <Draggable
             key={columnDef.tableData.id}
             draggableId={columnDef.tableData.id.toString()}
-            index={index}>
+            index={index}
+            isDragDisabled={!this.props.draggable}>
             {(provided, snapshot) => (
               <div
                 ref={provided.innerRef}

--- a/src/default-props.js
+++ b/src/default-props.js
@@ -93,6 +93,7 @@ export const defaultProps = {
     selection: false,
     selectionProps: {},
     sorting: true,
+    draggable: true,
     toolbar: true,
     defaultExpanded: false,
     detailPanelColumnAlignment: 'left'

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -499,7 +499,7 @@ export default class MaterialTable extends React.Component {
             />
           }
           <ScrollBar double={props.options.doubleHorizontalScroll}>
-            <Droppable droppableId="headers" direction="horizontal">
+            <Droppable droppableId="headers" direction="horizontal" isDropDisabled={!props.options.draggable}>
               {(provided, snapshot) => (
                 <div ref={provided.innerRef}>
                   <div style={{ maxHeight: props.options.maxBodyHeight, overflowY: 'auto' }}>
@@ -523,6 +523,7 @@ export default class MaterialTable extends React.Component {
                           actionsHeaderIndex={props.options.actionsColumnIndex}
                           sorting={props.options.sorting}
                           grouping={props.options.grouping}
+                          draggable={props.options.draggable}
                           isTreeData={this.props.parentChildData !== undefined}
                         />
                       }


### PR DESCRIPTION
## Related Issue
#626

## Description
This enables the option to disable the drag-and-drop feature in Table Header.