### PR TITLE
feat: export unstyled MaterialTable as MTable

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,8 @@ import { withStyles } from '@material-ui/core';
 MaterialTable.defaultProps = defaultProps;
 MaterialTable.propTypes = propTypes;
 
+export { MaterialTable as MTable };
+
 const styles = theme => ({
   paginationRoot: {
     width: '100%'

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -149,7 +149,7 @@ export const MTableGroupRow: () => React.ReactElement<any>;
 export const MTableHeader: () => React.ReactElement<any>;
 export const MTablePagination: () => React.ReactElement<any>;
 export const MTableToolbar: () => React.ReactElement<any>;
-
+export const MTable: () => React.ReactElement<any>;
 
 export interface Icons {
   Add?: ForwardRefExoticComponent<RefAttributes<SVGSVGElement>>;


### PR DESCRIPTION
## Related Issue
None

## Description
The single components in src/components are exposed using their unstyled variant.
MaterialTable is exported only with the applied HOC `withStyles` such refusing to extend 
the component. This PR exports the unstyled `MateralTable` as `MTable`.

## Related PRs
None

## Impacted Areas in Application
List general components of the application that this PR will affect:

* New feature

## Additional Notes
Great library - Thanks