### PR TITLE
feat: foreign handling of pagination counters

### DIFF
--- a/src/material-table.js
+++ b/src/material-table.js
@@ -157,6 +157,8 @@ export default class MaterialTable extends React.Component {
 
   isRemoteData = (props) => !Array.isArray((props || this.props).data)
 
+  isOutsidePageNumbers = (props) => (props.page !== undefined && props.totalCount !== undefined);
+
   onAllSelected = (checked) => {
     this.dataManager.changeAllSelected(checked);
     this.setState(this.dataManager.getRenderState(), () => this.onSelectionChange());
@@ -200,7 +202,9 @@ export default class MaterialTable extends React.Component {
       });
     }
     else {
-      this.dataManager.changeCurrentPage(page);
+      if (!this.isOutsidePageNumbers(this.props)) {
+        this.dataManager.changeCurrentPage(page);
+      }
       this.setState(this.dataManager.getRenderState(), () => {
         this.props.onChangePage && this.props.onChangePage(page);
       });
@@ -420,6 +424,15 @@ export default class MaterialTable extends React.Component {
     const props = this.getProps();
     if (props.options.paging) {
       const localization = { ...MaterialTable.defaultProps.localization.pagination, ...this.props.localization.pagination };
+
+      const isOutsidePageNumbers = this.isOutsidePageNumbers(props);
+      const currentPage = isOutsidePageNumbers
+        ? Math.min(props.page, Math.floor(props.totalCount / this.state.pageSize))
+        : this.state.currentPage;
+      const totalCount = isOutsidePageNumbers
+        ? props.totalCount
+        : this.state.data.length;
+
       return (
         <Table>
           <TableFooter style={{ display: 'grid' }}>
@@ -433,14 +446,14 @@ export default class MaterialTable extends React.Component {
                 }}
                 style={{ float: props.theme.direction === "rtl" ? "" : "right", overflowX: 'auto' }}
                 colSpan={3}
-                count={this.isRemoteData() ? this.state.query.totalCount : this.state.data.length}
+                count={this.isRemoteData() ? this.state.query.totalCount : totalCount}
                 icons={props.icons}
                 rowsPerPage={this.state.pageSize}
                 rowsPerPageOptions={props.options.pageSizeOptions}
                 SelectProps={{
                   renderValue: value => <div style={{ padding: '0px 5px' }}>{value + ' ' + localization.labelRowsSelect + ' '}</div>
                 }}
-                page={this.isRemoteData() ? this.state.query.page : this.state.currentPage}
+                page={this.isRemoteData() ? this.state.query.page : currentPage}
                 onChangePage={this.onChangePage}
                 onChangeRowsPerPage={this.onChangeRowsPerPage}
                 ActionsComponent={(subProps) => props.options.paginationType === 'normal' ?

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -165,5 +165,7 @@ export const propTypes = {
   onRowClick: PropTypes.func,
   onTreeExpandChange: PropTypes.func,
   tableRef: PropTypes.any,
-  style: PropTypes.object
+  style: PropTypes.object,
+  page: PropTypes.number,
+  totalCount: PropTypes.number
 };

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -31,6 +31,8 @@ export interface MaterialTableProps<RowData extends object> {
   onTreeExpandChange?: (data: any, isExpanded: boolean) => void;
   style?: React.CSSProperties;
   tableRef?: any;
+  page?: number;
+  totalCount?: number;
 }
 
 export interface Filter<RowData extends object> {


### PR DESCRIPTION
## Related Issue
None

## Description
We would like to manage remote data fetching outside the offered Promise based approach by making use of flux/redux like patterns.
For this we need to manage the pagination counters on our own independently of the given `data.length`. Usually {skip, limit, count} response parameters would give the page number and the totalCount.
This PR offers two new properties on `MaterialTable`:

- `prop.page` the number of the page the data-set is related
- `prop.totalCount` the total count of possible data sets

Only if both props are defined, the current behaviour of `MaterialTable` is changed such that the pagination values are managed outside the component. 

The change proposed is fully backwards compatible.

## Related PRs
None

## Impacted Areas in Application
List general components of the application that this PR will affect:

* MaterialTable.TableFooter

## Additional Notes