### PR TITLE
Add picker localization

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -105,7 +105,7 @@ class App extends Component {
                   parentChildData={(row, rows) => rows.find(a => a.id === row.parentId)}
                   options={{
                     selection: true,
-                    filtering: 'true'
+                    filtering: true
                   }}
                 />
               </Grid>
@@ -150,6 +150,7 @@ class App extends Component {
                     })
                   })
               })}
+              
             />
 
           </div>

--- a/src/components/m-table-body.js
+++ b/src/components/m-table-body.js
@@ -45,7 +45,7 @@ class MTableBody extends React.Component {
             components={this.props.components}
             data={data}
             icons={this.props.icons}
-            localization={{ ...MTableBody.defaultProps.localization.editRow, ...this.props.localization.editRow }}
+            localization={{ ...MTableBody.defaultProps.localization.editRow, ...this.props.localization.editRow, ...this.props.localization.picker }}
             key={index}
             mode={data.tableData.editing}
             options={this.props.options}
@@ -137,7 +137,7 @@ class MTableBody extends React.Component {
             actionsColumnIndex={this.props.options.actionsColumnIndex}
             onFilterChanged={this.props.onFilterChanged}
             selection={this.props.options.selection}
-            localization={{ ...MTableBody.defaultProps.localization.filterRow, ...this.props.localization.filterRow }}
+            localization={{ ...MTableBody.defaultProps.localization.filterRow, ...this.props.localization.filterRow, ...this.props.localization.picker }}
             hasDetailPanel={!!this.props.detailPanel}
             isTreeData={this.props.isTreeData}
             filterCellStyle={this.props.options.filterCellStyle}
@@ -152,7 +152,7 @@ class MTableBody extends React.Component {
             icons={this.props.icons}
             key="key-add-row"
             mode="add"
-            localization={{ ...MTableBody.defaultProps.localization.editRow, ...this.props.localization.editRow }}
+            localization={{ ...MTableBody.defaultProps.localization.editRow, ...this.props.localization.editRow, ...this.props.localization.picker }}
             options={this.props.options}
             isTreeData={this.props.isTreeData}
             detailPanel={this.props.detailPanel}
@@ -175,7 +175,7 @@ class MTableBody extends React.Component {
             icons={this.props.icons}
             key="key-add-row"
             mode="add"
-            localization={{ ...MTableBody.defaultProps.localization.editRow, ...this.props.localization.editRow }}
+            localization={{ ...MTableBody.defaultProps.localization.editRow, ...this.props.localization.editRow, ...this.props.localization.picker }}
             options={this.props.options}
             isTreeData={this.props.isTreeData}
             detailPanel={this.props.detailPanel}

--- a/src/components/m-table-edit-field.js
+++ b/src/components/m-table-edit-field.js
@@ -49,6 +49,7 @@ class MTableEditField extends React.Component {
       <MuiPickersUtilsProvider utils={DateFnsUtils}>
         <DatePicker
           {...this.getProps()}
+          {...this.props.localization}
           format="dd.MM.yyyy"
           value={this.props.value || null}
           onChange={this.props.onChange}
@@ -68,6 +69,7 @@ class MTableEditField extends React.Component {
       <MuiPickersUtilsProvider utils={DateFnsUtils}>
         <TimePicker
           {...this.getProps()}
+          {...this.props.localization}
           format="HH:mm:ss"
           value={this.props.value || null}
           onChange={this.props.onChange}
@@ -87,6 +89,7 @@ class MTableEditField extends React.Component {
       <MuiPickersUtilsProvider utils={DateFnsUtils}>
         <DateTimePicker
           {...this.getProps()}
+          {...this.props.localization}
           format="dd.MM.yyyy HH:mm:ss"
           value={this.props.value || null}
           onChange={this.props.onChange}
@@ -156,7 +159,8 @@ class MTableEditField extends React.Component {
 MTableEditField.propTypes = {
   value: PropTypes.any,
   onChange: PropTypes.func.isRequired,
-  columnDef: PropTypes.object.isRequired
+  columnDef: PropTypes.object.isRequired,
+  localization: PropTypes.object.isRequired
 };
 
 export default MTableEditField;

--- a/src/components/m-table-edit-row.js
+++ b/src/components/m-table-edit-row.js
@@ -58,6 +58,14 @@ export default class MTableEditRow extends React.Component {
         else {
           const { editComponent, ...cellProps } = columnDef;
           const EditComponent = editComponent || this.props.components.EditField;
+          const localization = { ...MTableEditRow.defaultProps.localization, ...this.props.localization };
+          const pickerLabels = {
+              okLabel: localization.okLabel,
+              cancelLabel: localization.cancelLabel,
+              clearLabel: localization.clearLabel,
+              todayLabel: localization.todayLabel
+            };
+
           return (
             <TableCell
               key={columnDef.tableData.id}
@@ -68,6 +76,7 @@ export default class MTableEditRow extends React.Component {
                 columnDef={cellProps}
                 value={value}
                 rowData={this.state.data}
+                localization={pickerLabels}
                 onChange={value => {
                   const data = { ...this.state.data };
                   setByString(data, columnDef.field, value);

--- a/src/components/m-table-filter-row.js
+++ b/src/components/m-table-filter-row.js
@@ -90,6 +90,13 @@ class MTableFilterRow extends React.Component {
   renderDateTypeFilter = (columnDef) => {
     let dateInputElement = null;
     const onDateInputChange = date => this.props.onFilterChanged(columnDef.tableData.id, date);
+    const localization = { ...MTableFilterRow.defaultProps.localization, ...this.props.localization };
+    const pickerLabels = {
+      okLabel: localization.okLabel,
+      cancelLabel: localization.cancelLabel,
+      clearLabel: localization.clearLabel,
+      todayLabel: localization.todayLabel
+    };
 
     if (columnDef.type === 'date') {
       dateInputElement = (
@@ -97,6 +104,7 @@ class MTableFilterRow extends React.Component {
           value={columnDef.tableData.filterValue || null}
           onChange={onDateInputChange}
           clearable
+          {...pickerLabels}
         />
       );
     } else if (columnDef.type === 'datetime') {
@@ -105,6 +113,7 @@ class MTableFilterRow extends React.Component {
           value={columnDef.tableData.filterValue || null}
           onChange={onDateInputChange}
           clearable
+          {...pickerLabels}
         />
       );
     } else if (columnDef.type === 'time') {
@@ -113,6 +122,7 @@ class MTableFilterRow extends React.Component {
           value={columnDef.tableData.filterValue || null}
           onChange={onDateInputChange}
           clearable
+          {...pickerLabels}
         />
       );
     }

--- a/src/default-props.js
+++ b/src/default-props.js
@@ -116,6 +116,12 @@ export const defaultProps = {
         cancelTooltip: 'Cancel',
         deleteText: 'Are you sure delete this row?',
       },
+      picker: {
+        okLabel: 'Ok',
+        cancelLabel: 'Cancel',
+        clearLabel: 'Clear',
+        todayLabel: 'Today'
+      },
       addTooltip: 'Add',
       deleteTooltip: 'Delete',
       editTooltip: 'Edit'

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -226,7 +226,13 @@ export interface Localization {
       saveTooltip?: string;
       cancelTooltip?: string;
       deleteText?: string;
-    },
+    };
+    picker?: {
+      okLabel?: string;
+      cancelLabel?: string;
+      clearLabel?: string;
+      todayLabel?: string;
+    };
     addTooltip?: string;
     deleteTooltip?: string;
     editTooltip?: string;


### PR DESCRIPTION
## Related Issue
#531

## Description
Make the localization attribute available for the date picker.

## Impacted Areas in Application
List general components of the application that this PR will affect:

* types/index.d.ts
* src/default-props.js
* src/components/m-table-body.js
* src/components/m-table-edit-field.js
* src/components/m-table-edit-row.js
* src/components/m-table-filter-row.js

Small fix on demo.js: `filtering` value was a string instead of a boolean value, there was an error message for invalid proptype.

## Additional Notes
I really love this library, thank you for your great work! I wish I can help to improve it with this contribution.
I had never used TypeScript before, I just added some types for the picker localization. Maybe it's not done right.
I'm a junior developer with only 1 year of experience as a professional (but passionate for years), I wish there won't be too much errors. And if there are some I'll be happy to follow your advices to fix it.