### PR TITLE
Feature

### DIFF
--- a/src/material-table.js
+++ b/src/material-table.js
@@ -119,6 +119,7 @@ export default class MaterialTable extends React.Component {
         calculatedProps.actions.push(rowData => ({
           icon: calculatedProps.icons.Edit,
           tooltip: localization.editTooltip,
+          hidden: calculatedProps.editable.isEditableHidden && calculatedProps.editable.isEditableHidden(rowData),
           disabled: calculatedProps.editable.isEditable && !calculatedProps.editable.isEditable(rowData),
           onClick: (e, rowData) => {
             this.dataManager.changeRowEditing(rowData, "update");
@@ -133,6 +134,7 @@ export default class MaterialTable extends React.Component {
         calculatedProps.actions.push(rowData => ({
           icon: calculatedProps.icons.Delete,
           tooltip: localization.deleteTooltip,
+          hidden: calculatedProps.editable.isDeletableHidden && calculatedProps.editable.isDeletableHidden(rowData),
           disabled: calculatedProps.editable.isDeletable && !calculatedProps.editable.isDeletable(rowData),
           onClick: (e, rowData) => {
             this.dataManager.changeRowEditing(rowData, "delete");


### PR DESCRIPTION
- Ability to hide the delete and edit icons

## Description
I had a need to hide the delete and edit icons when using the tree view because I am using the first level in the tree to group child records

## Impacted Areas in Application
List general components of the application that this PR will affect:

src/material-table.js
