### PR TITLE
fix bug with ForwardRefExoticComponent and RefAttributes typings

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import {ForwardRefExoticComponent, RefAttributes} from 'react';
 import { IconProps } from '@material-ui/core/Icon';
 import { string } from 'prop-types';
 


### PR DESCRIPTION
## Description
I believe there is a minor issue of typing in index.d.ts. Names ForwardRefExoticComponent and RefAttributes seem to be unknown. I imported them from react package (same as use React.ForwardRefExoticComponent, but easier to implement) and everything works fine now.
