### PR TITLE
Enhancement: Use path imports for @material-ui/core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist
 node_modules
 package-lock.json
 yarn.lock
+.idea

--- a/src/components/m-table-action.js
+++ b/src/components/m-table-action.js
@@ -1,7 +1,9 @@
 /* eslint-disable no-unused-vars */
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { Icon, IconButton, Tooltip } from '@material-ui/core';
+import Icon from '@material-ui/core/Icon';
+import IconButton from '@material-ui/core/IconButton';
+import Tooltip from '@material-ui/core/Tooltip';
 /* eslint-enable no-unused-vars */
 
 class MTableAction extends React.Component {

--- a/src/components/m-table-body-row.js
+++ b/src/components/m-table-body-row.js
@@ -1,5 +1,10 @@
 /* eslint-disable no-unused-vars */
-import { Checkbox, TableCell, TableRow, IconButton, Icon, Tooltip } from '@material-ui/core';
+import Checkbox from '@material-ui/core/Checkbox';
+import TableCell from '@material-ui/core/TableCell';
+import TableRow from '@material-ui/core/TableRow';
+import IconButton from '@material-ui/core/IconButton';
+import Icon from '@material-ui/core/Icon';
+import Tooltip from '@material-ui/core/Tooltip';
 import PropTypes from 'prop-types';
 import * as React from 'react';
 /* eslint-enable no-unused-vars */

--- a/src/components/m-table-body.js
+++ b/src/components/m-table-body.js
@@ -1,5 +1,7 @@
 /* eslint-disable no-unused-vars */
-import { TableBody, TableCell, TableRow } from '@material-ui/core';
+import TableBody from '@material-ui/core/TableBody';
+import TableCell from '@material-ui/core/TableCell';
+import TableRow from '@material-ui/core/TableRow';
 import PropTypes from 'prop-types';
 import * as React from 'react';
 /* eslint-enable no-unused-vars */

--- a/src/components/m-table-cell.js
+++ b/src/components/m-table-cell.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-unused-vars */
 import * as React from 'react';
-import { Icon, TableCell } from '@material-ui/core';
+import TableCell from '@material-ui/core/TableCell';
 import PropTypes from 'prop-types';
 /* eslint-enable no-unused-vars */
 

--- a/src/components/m-table-edit-field.js
+++ b/src/components/m-table-edit-field.js
@@ -1,5 +1,8 @@
 import * as React from 'react';
-import { TextField, Checkbox, Select, MenuItem } from '@material-ui/core';
+import TextField from '@material-ui/core/TextField';
+import Checkbox from '@material-ui/core/Checkbox';
+import Select from '@material-ui/core/Select';
+import MenuItem from '@material-ui/core/MenuItem';
 import DateFnsUtils from '@date-io/date-fns';
 import { MuiPickersUtilsProvider, TimePicker, DatePicker, DateTimePicker } from '@material-ui/pickers';
 import PropTypes from 'prop-types';

--- a/src/components/m-table-edit-row.js
+++ b/src/components/m-table-edit-row.js
@@ -1,5 +1,7 @@
 /* eslint-disable no-unused-vars */
-import { Checkbox, TableCell, TableRow, IconButton, Icon, Tooltip, Typography } from '@material-ui/core';
+import TableCell from '@material-ui/core/TableCell';
+import TableRow from '@material-ui/core/TableRow';
+import Typography from '@material-ui/core/Typography';
 import PropTypes from 'prop-types';
 import * as React from 'react';
 import { byString, setByString } from '../utils';

--- a/src/components/m-table-filter-row.js
+++ b/src/components/m-table-filter-row.js
@@ -1,12 +1,17 @@
 /* eslint-disable no-unused-vars */
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import {
-  TableCell, TableRow, TextField,
-  FormControl, Select, Input,
-  MenuItem, Checkbox, ListItemText,
-  InputAdornment, Icon, Tooltip,
-} from '@material-ui/core';
+import TableCell from '@material-ui/core/TableCell';
+import TableRow from '@material-ui/core/TableRow';
+import TextField from '@material-ui/core/TextField';
+import FormControl from '@material-ui/core/FormControl';
+import Select from '@material-ui/core/Select';
+import Input from '@material-ui/core/Input';
+import MenuItem from '@material-ui/core/MenuItem';
+import Checkbox from '@material-ui/core/Checkbox';
+import ListItemText from '@material-ui/core/ListItemText';
+import InputAdornment from '@material-ui/core/InputAdornment';
+import Tooltip from '@material-ui/core/Tooltip';
 import DateFnsUtils from '@date-io/date-fns';
 import { MuiPickersUtilsProvider, TimePicker, DatePicker, DateTimePicker } from '@material-ui/pickers';
 

--- a/src/components/m-table-group-row.js
+++ b/src/components/m-table-group-row.js
@@ -1,5 +1,7 @@
 /* eslint-disable no-unused-vars */
-import { TableCell, TableRow, IconButton } from '@material-ui/core';
+import TableCell from '@material-ui/core/TableCell';
+import TableRow from '@material-ui/core/TableRow';
+import IconButton from '@material-ui/core/IconButton';
 import PropTypes from 'prop-types';
 import * as React from 'react';
 /* eslint-enable no-unused-vars */

--- a/src/components/m-table-groupbar.js
+++ b/src/components/m-table-groupbar.js
@@ -1,5 +1,7 @@
 /* eslint-disable no-unused-vars */
-import { Icon, Toolbar, Chip, Typography } from '@material-ui/core';
+import Toolbar from '@material-ui/core/Toolbar';
+import Chip from '@material-ui/core/Chip';
+import Typography from '@material-ui/core/Typography';
 import PropTypes from 'prop-types';
 import * as React from 'react';
 import { Droppable, Draggable } from 'react-beautiful-dnd';

--- a/src/components/m-table-header.js
+++ b/src/components/m-table-header.js
@@ -1,10 +1,12 @@
 /* eslint-disable no-unused-vars */
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import {
-  TableHead, TableRow, TableCell,
-  TableSortLabel, Checkbox, withStyles
-} from '@material-ui/core';
+import TableHead from '@material-ui/core/TableHead';
+import TableRow from '@material-ui/core/TableRow';
+import TableCell from '@material-ui/core/TableCell';
+import TableSortLabel from '@material-ui/core/TableSortLabel';
+import Checkbox from '@material-ui/core/Checkbox';
+import withStyles from '@material-ui/core/styles/withStyles';
 import { Droppable, Draggable } from 'react-beautiful-dnd';
 /* eslint-enable no-unused-vars */
 

--- a/src/components/m-table-pagination.js
+++ b/src/components/m-table-pagination.js
@@ -1,5 +1,8 @@
 /* eslint-disable no-unused-vars */
-import { Icon, IconButton, withStyles, Tooltip, Typography } from '@material-ui/core';
+import IconButton from '@material-ui/core/IconButton';
+import withStyles from '@material-ui/core/styles/withStyles';
+import Tooltip from '@material-ui/core/Tooltip';
+import Typography from '@material-ui/core/Typography';
 import PropTypes from 'prop-types';
 import * as React from 'react';
 /* eslint-enable no-unused-vars */

--- a/src/components/m-table-stepped-pagination.js
+++ b/src/components/m-table-stepped-pagination.js
@@ -1,5 +1,9 @@
 /* eslint-disable no-unused-vars */
-import { Icon, IconButton, withStyles, Tooltip, Hidden, Typography, Button } from '@material-ui/core';
+import IconButton from '@material-ui/core/IconButton';
+import withStyles from '@material-ui/core/styles/withStyles';
+import Tooltip from '@material-ui/core/Tooltip';
+import Hidden from '@material-ui/core/Hidden';
+import Button from '@material-ui/core/Button';
 import PropTypes from 'prop-types';
 import * as React from 'react';
 /* eslint-enable no-unused-vars */

--- a/src/components/m-table-toolbar.js
+++ b/src/components/m-table-toolbar.js
@@ -1,5 +1,15 @@
 /* eslint-disable no-unused-vars */
-import { Checkbox, FormControlLabel, Icon, IconButton, InputAdornment, Menu, MenuItem, TextField, Toolbar, Tooltip, Typography, withStyles } from '@material-ui/core';
+import Checkbox from '@material-ui/core/Checkbox';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
+import IconButton from '@material-ui/core/IconButton';
+import InputAdornment from '@material-ui/core/InputAdornment';
+import Menu from '@material-ui/core/Menu';
+import MenuItem from '@material-ui/core/MenuItem';
+import TextField from '@material-ui/core/TextField';
+import Toolbar from '@material-ui/core/Toolbar';
+import Tooltip from '@material-ui/core/Tooltip';
+import Typography from '@material-ui/core/Typography';
+import withStyles from '@material-ui/core/styles/withStyles';
 import { lighten } from '@material-ui/core/styles/colorManipulator';
 import classNames from 'classnames';
 import { CsvBuilder } from 'filefy';

--- a/src/default-props.js
+++ b/src/default-props.js
@@ -1,5 +1,8 @@
 import React from 'react';
-import { CircularProgress, Icon, Paper, TablePagination } from '@material-ui/core';
+import CircularProgress from '@material-ui/core/CircularProgress';
+import Icon from '@material-ui/core/Icon';
+import Paper from '@material-ui/core/Paper';
+import TablePagination from '@material-ui/core/TablePagination';
 import * as MComponents from './components';
 import PropTypes from 'prop-types';
 import { fade } from '@material-ui/core/styles/colorManipulator';

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { defaultProps } from './default-props';
 import { propTypes } from './prop-types';
 import MaterialTable from './material-table';
-import { withStyles } from '@material-ui/core';
+import withStyles from '@material-ui/core/styles/withStyles';
 
 MaterialTable.defaultProps = defaultProps;
 MaterialTable.propTypes = propTypes;

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -1,5 +1,8 @@
 /* eslint-disable no-unused-vars */
-import { Table, TableFooter, TableRow, LinearProgress } from '@material-ui/core';
+import Table from '@material-ui/core/Table';
+import TableFooter from '@material-ui/core/TableFooter';
+import TableRow from '@material-ui/core/TableRow';
+import LinearProgress from '@material-ui/core/LinearProgress';
 import DoubleScrollbar from "react-double-scrollbar";
 import * as React from 'react';
 import { MTablePagination, MTableSteppedPagination } from './components';


### PR DESCRIPTION
## Description
The [material ui docs state](https://material-ui.com/guides/minimizing-bundle-size/) that in order to minimize bundle sizes you can use full path instead of named imports. For production builds named imports will most likely not be a big issue as webpack's tree shaking solves this. For development builds tree shaking is not enabled and causes the whole `@material-ui/core` module to be imported which could cause slower build speeds and larger bundle sizes. 

This pull request fixes that by replacing the following
```js
import { Button, TextField } from '@material-ui/core';
```
with
```js
import Button from '@material-ui/core/Button';
import TextField from '@material-ui/core/TextField';
```

I was not happy with the build times I was getting on my development builds and tried to optimize all my imports and noticed material-table was not using path imports and that's why I created this pull request

## Additional Notes

This is my first pull request ever :). Feel free to give me feedback on anything about this pull request.