### PR TITLE
Fix custom actions' size

### DIFF
--- a/src/components/m-table-action.js
+++ b/src/components/m-table-action.js
@@ -34,7 +34,7 @@ class MTableAction extends React.Component {
           onClick={(event) => handleOnClick(event)}
         >
           {typeof action.icon === "string" ? (
-            <Icon {...action.iconProps} fontSize="small">{action.icon}</Icon>
+            <Icon {...action.iconProps}>{action.icon}</Icon>
           ) : (
               <action.icon
                 {...action.iconProps}


### PR DESCRIPTION
Fix custom actions being smaller than the default ones and being unable to resize

## Related Issue
Fixes #839 

## Description
Custom actions' size is smaller than the default actions and being applied after the `iconProps` property, which makes it to override the size (if any) applied by the developer.

## Impacted Areas in Application
List general components of the application that this PR will affect:

* src/components/m-table-action.js