### PR TITLE
Fixes issue #703

### DIFF
--- a/src/material-table.js
+++ b/src/material-table.js
@@ -72,7 +72,7 @@ export default class MaterialTable extends React.Component {
 
     isInit && this.dataManager.changeOrder(defaultSortColumnIndex, defaultSortDirection);
     isInit && this.dataManager.changeCurrentPage(props.options.initialPage ? props.options.initialPage : 0);
-    isInit && this.dataManager.changePageSize(props.options.pageSize);
+    this.dataManager.changePageSize(props.options.pageSize);
     isInit && this.dataManager.changePaging(props.options.paging);
     isInit && this.dataManager.changeParentFunc(props.parentChildData);
     this.dataManager.changeDetailPanelType(props.options.detailPanelType);


### PR DESCRIPTION

## Related Issue
#703 

## Description
Removing 'isInit' from changePageSize to upload the pageSize when using remote data

## Impacted Areas in Application
* material-table.js

## Additional Notes
Hi!
I need to update pageSize dynamically with ContextAPI, and the "isInit" don't let me do it.