### PR TITLE
Make @material-ui/core a peer dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,12 @@ If you use an older version of react we suggest to upgrade your dependencies or 
 To install material-table with `npm`:
 
     npm install material-table --save
+    npm install @material-ui/core --save
 
 To install material-table with `yarn`:
 
     yarn add material-table
+    yarn add @material-ui/core
 
 #### 2.Add material icons
 

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@babel/plugin-transform-runtime": "7.1.0",
     "@babel/preset-env": "^7.2.0",
     "@babel/preset-react": "7.0.0",
+    "@material-ui/core": "^4.0.1",
     "babel-eslint": "10.0.1",
     "babel-loader": "^8.0.4",
     "babel-polyfill": "^6.26.0",
@@ -72,7 +73,6 @@
   },
   "dependencies": {
     "@date-io/date-fns": "^1.1.0",
-    "@material-ui/core": "^4.0.1",
     "@material-ui/pickers": "^3.0.0",
     "classnames": "^2.2.6",
     "date-fns": "^2.0.0-alpha.27",
@@ -81,5 +81,8 @@
     "prop-types": "^15.6.2",
     "react-beautiful-dnd": "11.0.3",
     "react-double-scrollbar": "0.0.15"
+  },
+  "peerDependencies": {
+    "@material-ui/core": "^4.0.1"
   }
 }


### PR DESCRIPTION
## Description
Material UI complains when multiple library instances are initialized in a single application.
The issue can be easily solved by making `@material-ui/core` a peer dependency plus development dependency, instead of having it as a production dependency only.