### PR TITLE
add the wait time for typing in search box

### DIFF
--- a/src/default-props.js
+++ b/src/default-props.js
@@ -85,6 +85,9 @@ export const defaultProps = {
     showFirstLastPageButtons: true,
     showSelectAllCheckbox: true,
     search: true,
+    searchProps: {
+      waitForTyping: 500
+    },
     showTitle: true,
     showTextRowsSelected: true,
     toolbarButtonAlignment: 'right',

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -364,13 +364,12 @@ export default class MaterialTable extends React.Component {
 
   onSearchChange = searchText => {
     var _this = this;
-    this.setState({ searchText })
+    this.setState({ searchText });
     clearTimeout(timeoutForSearching);
 
-    timeoutForSearching = setTimeout(function () {
-      _this.setState(_this.onSearchChangeDebounce)
+    timeoutForSearching = setTimeout( function () {
+      _this.setState(_this.onSearchChangeDebounce);
     }, this.props.searchProps.waitForTyping);
-
   }
 
   onSearchChangeDebounce = debounce(() => {

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -367,7 +367,7 @@ export default class MaterialTable extends React.Component {
     this.setState({ searchText });
     clearTimeout(timeoutForSearching);
 
-    timeoutForSearching = setTimeout( function () {
+    timeoutForSearching = setTimeout(function(){
       _this.setState(_this.onSearchChangeDebounce);
     }, this.props.searchProps.waitForTyping);
   }

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -6,6 +6,9 @@ import { MTablePagination, MTableSteppedPagination } from './components';
 import { DragDropContext, Droppable } from 'react-beautiful-dnd';
 import DataManager from './utils/data-manager';
 import { debounce } from 'debounce';
+
+    
+var timeoutForSearching = null;
 /* eslint-enable no-unused-vars */
 
 export default class MaterialTable extends React.Component {
@@ -359,7 +362,16 @@ export default class MaterialTable extends React.Component {
     }
   }
 
-  onSearchChange = searchText => this.setState({ searchText }, this.onSearchChangeDebounce)
+  onSearchChange = searchText => {
+    var _this = this;
+    this.setState({ searchText })
+    clearTimeout(timeoutForSearching);
+
+    timeoutForSearching = setTimeout(function () {
+      _this.setState(_this.onSearchChangeDebounce)
+    }, this.props.searchProps.waitForTyping);
+
+  }
 
   onSearchChangeDebounce = debounce(() => {
     this.dataManager.changeSearchText(this.state.searchText);


### PR DESCRIPTION
## Related Issue
Relate the Github issue with this PR using `#860`

## Description
This PR is to fix the issue for search: `#860 The search feature should wait for user to stop typing`

When I implement the search box with remote data. It is always jerky when I type the text. Because It always make the update the search text and do a query to get data when I type.

Solution to fix this issue is make the timeout to wait for user to stop typing at least 500 milliseconds. So the search will be called after user stop typing 500 ms.

Actually we will have options to user set the time if they want to custom:

options: {
  ..
  search: true,
  searchProps: {
    waitForTyping: 500
  },
 ..
}
