### PR TITLE
Change column rendering structure for grouped columns

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -126,6 +126,13 @@ class App extends Component {
                       src={rowData.avatar}
                     />
                   ),
+                  renderGroup: (avatar, groupData) => (
+                    <img
+                      style={{ height: 36, borderRadius: '50%', bottom: -10, position: 'relative' }}
+                      src={avatar}
+                    />
+
+                  )
                 },
                 { title: 'Id', field: 'id', filterPlaceholder: 'placeholder' },
                 { title: 'First Name', field: 'first_name' },

--- a/src/components/m-table-cell.js
+++ b/src/components/m-table-cell.js
@@ -9,13 +9,11 @@ export default class MTableCell extends React.Component {
     if (this.props.columnDef.emptyValue !== undefined && (this.props.value === undefined || this.props.value === null)) {
       return this.getEmptyValue(this.props.columnDef.emptyValue);
     }
-    if (this.props.columnDef.render) {
-      if (this.props.rowData) {
-        return this.props.columnDef.render(this.props.rowData, 'row');
-      }
-      else {
-        return this.props.columnDef.render(this.props.value, 'group');
-      }
+    if (this.props.columnDef.render && this.props.rowData) {
+      return this.props.columnDef.render(this.props.rowData);
+
+    } else if (this.props.columnDef.renderGroup && this.props.groupData) {
+      return this.props.columnDef.renderGroup(this.props.value, this.props.groupData);
 
     } else if (this.props.columnDef.type === 'boolean') {
       const style = { textAlign: 'left', verticalAlign: 'middle', width: 48 };
@@ -120,5 +118,6 @@ MTableCell.defaultProps = {
 MTableCell.propTypes = {
   columnDef: PropTypes.object.isRequired,
   value: PropTypes.any,
-  rowData: PropTypes.object
+  rowData: PropTypes.object,
+  groupData: PropTypes.object
 };

--- a/src/components/m-table-group-row.js
+++ b/src/components/m-table-group-row.js
@@ -92,6 +92,7 @@ export default class MTableGroupRow extends React.Component {
             padding="none" 
             columnDef={column} 
             value={value}
+            groupData={this.props.groupData.data}
             icons={this.props.icons}
           >
             <IconButton

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -111,7 +111,8 @@ export interface Column {
   lookup?: object;
   editable?: ('always' | 'onUpdate' | 'onAdd' | 'never' | ((columnDef: Column, rowData: any) => boolean));
   removable?: boolean;
-  render?: (data: any, type: ('row' | 'group')) => any;
+  render?: (data: any) => any;
+  renderGroup?: (data: any, groupData: any[]) => any;
   searchable?: boolean;
   sorting?: boolean;
   title?: string | React.ReactElement<any>;


### PR DESCRIPTION
## Related Issue
#466 

## Description
When grouping values the render function, provided by the column
definition, no longer receives the whole data from the row element just
the value used to group rows.

This behavior was troublesome since some columns used different values
from the row to properly render its information, therefore it would be
impossible to render based on just the grouping value.

Now the group rendering was moved to a specific rendering function named
renderGroup which receives the grouped value and all rows from that
specific group.

## Impacted Areas in Application
List general components of the application that this PR will affect:

* TableCell
* TableGroupRow

## Additional Notes
This introduces an API change for the render function, so it might break existing applications