### PR TITLE
Updated the theme to use the new api

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -1,4 +1,5 @@
-import { Grid, MuiThemeProvider, Button } from '@material-ui/core';
+import { Grid, Button } from '@material-ui/core';
+import { ThemeProvider as MuiThemeProvider } from '@material-ui/styles';
 import { createMuiTheme } from '@material-ui/core/styles';
 import React, { Component } from 'react';
 import ReactDOM from 'react-dom';
@@ -9,7 +10,8 @@ let direction = 'ltr';
 const theme = createMuiTheme({
   direction: direction,
   palette: {
-    type: 'light'
+    type: 'light',
+    primary: {main: '#ff0000'}
   }
 });
 

--- a/src/components/m-table-header.js
+++ b/src/components/m-table-header.js
@@ -3,8 +3,11 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import {
   TableHead, TableRow, TableCell,
-  TableSortLabel, Checkbox, withStyles
+  TableSortLabel, Checkbox
 } from '@material-ui/core';
+import {
+  withStyles
+} from '@material-ui/core/styles';
 import { Droppable, Draggable } from 'react-beautiful-dnd';
 /* eslint-enable no-unused-vars */
 

--- a/src/components/m-table-pagination.js
+++ b/src/components/m-table-pagination.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-unused-vars */
-import { Icon, IconButton, withStyles, Tooltip, Typography } from '@material-ui/core';
+import { Icon, IconButton, Tooltip, Typography } from '@material-ui/core';
+import { withStyles } from '@material-ui/core/styles';
 import PropTypes from 'prop-types';
 import * as React from 'react';
 /* eslint-enable no-unused-vars */
@@ -65,7 +66,7 @@ class MTablePaginationInner extends React.Component {
             </IconButton>
           </span>
         </Tooltip>
-        {showFirstLastPageButtons && 
+        {showFirstLastPageButtons &&
           <Tooltip title={localization.lastTooltip}>
             <span>
               <IconButton
@@ -87,7 +88,7 @@ const actionsStyles = theme => ({
   root: {
     flexShrink: 0,
     color: theme.palette.text.secondary,
-    display: 'flex', 
+    display: 'flex',
     // lineHeight: '48px'
   }
 });

--- a/src/components/m-table-stepped-pagination.js
+++ b/src/components/m-table-stepped-pagination.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-unused-vars */
-import { Icon, IconButton, withStyles, Tooltip, Hidden, Typography, Button } from '@material-ui/core';
+import { Icon, IconButton, Tooltip, Hidden, Typography, Button } from '@material-ui/core';
+import { withStyles } from '@material-ui/core/styles';
 import PropTypes from 'prop-types';
 import * as React from 'react';
 /* eslint-enable no-unused-vars */

--- a/src/components/m-table-toolbar.js
+++ b/src/components/m-table-toolbar.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-unused-vars */
-import { Checkbox, FormControlLabel, Icon, IconButton, InputAdornment, Menu, MenuItem, TextField, Toolbar, Tooltip, Typography, withStyles } from '@material-ui/core';
+import { Checkbox, FormControlLabel, Icon, IconButton, InputAdornment, Menu, MenuItem, TextField, Toolbar, Tooltip, Typography } from '@material-ui/core';
+import { withStyles } from '@material-ui/core/styles';
 import { lighten } from '@material-ui/core/styles/colorManipulator';
 import classNames from 'classnames';
 import { CsvBuilder } from 'filefy';

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { defaultProps } from './default-props';
 import { propTypes } from './prop-types';
 import MaterialTable from './material-table';
-import { withStyles } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 
 MaterialTable.defaultProps = defaultProps;
 MaterialTable.propTypes = propTypes;

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { defaultProps } from './default-props';
 import { propTypes } from './prop-types';
 import MaterialTable from './material-table';
-import { withStyles } from '@material-ui/styles';
+import { withStyles } from '@material-ui/core/styles';
 
 MaterialTable.defaultProps = defaultProps;
 MaterialTable.propTypes = propTypes;


### PR DESCRIPTION
## Related Issue
#667 
#628 
#513 

## Description
Update the name space to the proper name space in Material UI Docs

## Related PRs
None

## Impacted Areas in Application
List general components of the application that this PR will affect:

* Changed the namespace of `withStyles` to reflect the proper path

## Additional Notes
This may not fix the theme problem some are seeing, but will help future proof the library. If you are having problems with the themes not merging, do the following:

1. run `yarn list @material-ui/styles` and verify that there are multiple styles imported
2. navigate to your `yarn.lock` file and find the version of `@material-ui/core` material-table is using
3. update your package.json file to have the same version, run `yarn`, and then reboot your dev server. Your styles should be merged.

Unfortunately, that is the process you need to go through up until this gets approved:
https://github.com/mbrn/material-table/pull/851

So... yeah. Let's approve that one.