### PR TITLE
Add styled footer row

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -47,7 +47,11 @@ class App extends Component {
       { id: 6, name: 'A6', surname: 'C', isMarried: true, birthDate: new Date(1989, 1, 1), birthCity: 34, sex: 'Female', type: 'child', insertDateTime: new Date(2018, 1, 1, 12, 23, 44), time: new Date(1900, 1, 1, 14, 23, 35), parentId: 5 },
     ],
     columns: [
-      { title: 'Adı', field: 'name' },
+      { title: 'Adı', field: 'name', 
+      footerCellStyle: {
+        fontWeight: 'bold'
+      }
+    },
       { title: 'Soyadı', field: 'surname', grouping: false },
       { title: 'Evli', field: 'isMarried', type: 'boolean' },
       { title: 'Cinsiyet', field: 'sex', disableClick: true, editable: 'onAdd' },

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -62,6 +62,9 @@ class App extends Component {
       { title: 'Id', field: 'id' },
       { title: 'First Name', field: 'first_name' },
       { title: 'Last Name', field: 'last_name' },
+    ],
+    footerData: [
+      { name: '5 unique', surname: '2 unique', sex: '2 male / 3 female', type: '2 adult / 3 children' }
     ]
   }
 
@@ -78,7 +81,8 @@ class App extends Component {
                   tableRef={this.tableRef}
                   columns={this.state.columns}
                   data={this.state.data}
-                  title="Demo Title"
+                  title="Demo Title"              
+                  footerData={this.state.footerData}
                 />
               </Grid>
             </Grid>

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -83,6 +83,13 @@ class App extends Component {
                   data={this.state.data}
                   title="Demo Title"              
                   footerData={this.state.footerData}
+                  options={{
+                    footerStyle: {
+                      backgroundColor: '#EEE',
+                      borderTop: "2px black solid",
+                      fontWeight: 'bold'
+                    }
+                  }}
                 />
               </Grid>
             </Grid>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json2d/material-table",
-  "version": "1.36.6-footer.1",
+  "version": "1.36.6-footer.2",
   "description": "Datatable for React based on https://material-ui.com/api/table/ with additional features",
   "main": "dist/index.js",
   "types": "types/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@eataly/material-table",
-  "version": "1.36.6-footer",
+  "name": "@json2d/material-table",
+  "version": "1.36.6-footer.1",
   "description": "Datatable for React based on https://material-ui.com/api/table/ with additional features",
   "main": "dist/index.js",
   "types": "types/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json2d/material-table",
-  "version": "1.36.6-footer.2",
+  "version": "1.36.6-footer.3",
   "description": "Datatable for React based on https://material-ui.com/api/table/ with additional features",
   "main": "dist/index.js",
   "types": "types/index.d.ts",
@@ -17,7 +17,8 @@
     "lint": "npm run eslint && npm run tsc",
     "eslint": "eslint src/** -c ./configs/.eslintrc",
     "tsc": "tsc --noEmit --lib es6,dom --skipLibCheck types/index.d.ts",
-    "lint:fix": "eslint src/** --fix"
+    "lint:fix": "eslint src/** --fix",
+    "prepublish": "npm run build"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "material-table",
-  "version": "1.36.6",
+  "name": "@eataly/material-table",
+  "version": "1.36.6-footer",
   "description": "Datatable for React based on https://material-ui.com/api/table/ with additional features",
   "main": "dist/index.js",
   "types": "types/index.d.ts",

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -2,6 +2,7 @@ import MTableAction from './m-table-action';
 import MTableActions from './m-table-actions';
 import MTableBody from './m-table-body';
 import MTableBodyRow from './m-table-body-row';
+import MTableBodyFooterRow from './m-table-body-footer-row';
 import MTableGroupbar from './m-table-groupbar';
 import MTableGroupRow from './m-table-group-row';
 import MTableCell from './m-table-cell';
@@ -18,6 +19,7 @@ export {
   MTableActions,
   MTableBody,
   MTableBodyRow,
+  MTableBodyFooterRow,
   MTableGroupbar,
   MTableGroupRow,
   MTableCell,

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -6,6 +6,7 @@ import MTableBodyFooterRow from './m-table-body-footer-row';
 import MTableGroupbar from './m-table-groupbar';
 import MTableGroupRow from './m-table-group-row';
 import MTableCell from './m-table-cell';
+import MTableFooterCell from './m-table-footer-cell';
 import MTableEditRow from './m-table-edit-row';
 import MTableEditField from './m-table-edit-field';
 import MTableFilterRow from './m-table-filter-row';
@@ -23,6 +24,7 @@ export {
   MTableGroupbar,
   MTableGroupRow,
   MTableCell,
+  MTableFooterCell,
   MTableEditRow,
   MTableEditField,
   MTableFilterRow,

--- a/src/components/m-table-body-footer-row.js
+++ b/src/components/m-table-body-footer-row.js
@@ -24,107 +24,9 @@ export default class MTableBodyFooterRow extends React.Component {
     return mapArr;
   }
 
-  renderActions() {
-    const actions = this.props.actions.filter(a => !a.isFreeAction && !this.props.options.selection);
-    return (
-      <TableCell padding="none" key="key-actions-column" style={{ width: 48 * actions.length, padding: '0px 5px', ...this.props.options.actionsCellStyle }}>
-        <div style={{ display: 'flex' }}>
-          <this.props.components.Actions data={this.props.data} actions={actions} components={this.props.components} />
-        </div>
-      </TableCell>
-    );
-  }
-  renderSelectionColumn() {
-    return (
-      <TableCell padding="none" key="key-selection-column" style={{ width: 48 + 12 * (this.props.treeDataMaxLevel - 1) }}>
-        <Checkbox
-          checked={this.props.data.tableData.checked === true}
-          onClick={(e) => e.stopPropagation()}
-          value={this.props.data.tableData.id.toString()}
-          onChange={(event) => this.props.onRowSelected(event, this.props.path, this.props.data)}
-          style={{
-            paddingLeft: 12 + this.props.level * 12
-          }}
-        />
-      </TableCell>
-    );
-  }
-
   rotateIconStyle = isOpen => ({
     transform: isOpen ? 'rotate(90deg)' : 'none'
   });
-
-  renderDetailPanelColumn() {
-
-    const CustomIcon = ({ icon, style }) => typeof icon === "string" ? <Icon style={style}>{icon}</Icon> : React.createElement(icon, { style });
-
-    if (typeof this.props.detailPanel == 'function') {
-      return (
-        <TableCell padding="none" key="key-detail-panel-column" style={{ width: 48, textAlign: 'center' }}>
-          <IconButton
-            style={{ transition: 'all ease 200ms', ...this.rotateIconStyle(this.props.data.tableData.showDetailPanel) }}
-            onClick={(event) => {
-              this.props.onToggleDetailPanel(this.props.path, this.props.detailPanel);
-              event.stopPropagation();
-            }}
-          >
-            <this.props.icons.DetailPanel />
-          </IconButton>
-        </TableCell>
-      );
-    }
-    else {
-      return (
-        <TableCell padding="none" key="key-detail-panel-column">
-          <div style={{ width: 48 * this.props.detailPanel.length, textAlign: 'center', display: 'inline-block' }}>
-            {this.props.detailPanel.map((panel, index) => {
-
-              if (typeof panel === "function") {
-                panel = panel(this.props.data);
-              }
-
-              const isOpen = (this.props.data.tableData.showDetailPanel || '').toString() === panel.render.toString();
-
-              let iconButton = <this.props.icons.DetailPanel />;
-              let animation = true;
-              if (isOpen) {
-                if (panel.openIcon) {
-                  iconButton = <CustomIcon icon={panel.openIcon} />;
-                  animation = false;
-                }
-                else if (panel.icon) {
-                  iconButton = <CustomIcon icon={panel.icon} />;
-                }
-              }
-              else if (panel.icon) {
-                iconButton = <CustomIcon icon={panel.icon} />;
-                animation = false;
-              }
-
-              iconButton = (
-                <IconButton
-                  key={"key-detail-panel-" + index}
-                  style={{ transition: 'all ease 200ms', ...this.rotateIconStyle(animation && isOpen) }}
-                  disabled={panel.disabled}
-                  onClick={(event) => {
-                    this.props.onToggleDetailPanel(this.props.path, panel.render);
-                    event.stopPropagation();
-                  }}
-                >
-                  {iconButton}
-                </IconButton>);
-
-              if (panel.tooltip) {
-                iconButton = <Tooltip key={"key-detail-panel-" + index} title={panel.tooltip}>{iconButton}</Tooltip>;
-              }
-
-              return iconButton;
-            })}
-          </div>
-        </TableCell>
-      );
-    }
-  }
 
   getStyle() {
     let style = {
@@ -157,54 +59,6 @@ export default class MTableBodyFooterRow extends React.Component {
 
   render() {
     const renderColumns = this.renderColumns();
-    if (this.props.options.selection) {
-      renderColumns.splice(0, 0, this.renderSelectionColumn());
-    }
-    if (this.props.actions && this.props.actions.filter(a => !a.isFreeAction && !this.props.options.selection).length > 0) {
-      if (this.props.options.actionsColumnIndex === -1) {
-        renderColumns.push(this.renderActions());
-      } else if (this.props.options.actionsColumnIndex >= 0) {
-        let endPos = 0;
-        if (this.props.options.selection) {
-          endPos = 1;
-        }
-        renderColumns.splice(this.props.options.actionsColumnIndex + endPos, 0, this.renderActions());
-      }
-    }
-
-    if (this.props.isTreeData) {
-      if (this.props.data.tableData.childRows && this.props.data.tableData.childRows.length > 0) {
-        renderColumns.splice(0, 0, (
-          <TableCell padding="none" key={"key-tree-data-column"} style={{ width: 48 + 12 * (this.props.treeDataMaxLevel - 2) }}>
-            <IconButton
-              style={{
-                transition: 'all ease 200ms',
-                marginLeft: this.props.level * 12,
-                ...this.rotateIconStyle(this.props.data.tableData.isTreeExpanded)
-              }}
-              onClick={(event) => {
-                this.props.onTreeExpandChanged(this.props.path, this.props.data);
-                event.stopPropagation();
-              }}
-            >
-              <this.props.icons.DetailPanel />
-            </IconButton>
-          </TableCell>
-        ));
-      }
-      else {
-        renderColumns.splice(0, 0, <TableCell padding="none" key={"key-tree-data-column"} />);
-      }
-    }
-
-    // Lastly we add detail panel icon
-    if (this.props.detailPanel) {
-      if (this.props.options.detailPanelColumnAlignment === 'right') {
-        renderColumns.push(this.renderDetailPanelColumn());
-      } else {
-        renderColumns.splice(0, 0, this.renderDetailPanelColumn());
-      }
-    }
 
     this.props.columns
       .filter(columnDef => columnDef.tableData.groupOrder > -1)

--- a/src/components/m-table-body-footer-row.js
+++ b/src/components/m-table-body-footer-row.js
@@ -1,0 +1,331 @@
+/* eslint-disable no-unused-vars */
+import { Checkbox, TableCell, TableRow, IconButton, Icon, Tooltip } from '@material-ui/core';
+import PropTypes from 'prop-types';
+import * as React from 'react';
+/* eslint-enable no-unused-vars */
+
+
+export default class MTableBodyFooterRow extends React.Component {
+  renderColumns() {
+    const mapArr = this.props.columns.filter(columnDef => !columnDef.hidden && !(columnDef.tableData.groupOrder > -1))
+      .sort((a, b) => a.tableData.columnOrder - b.tableData.columnOrder)
+      .map((columnDef, index) => {
+        const value = this.props.getFieldValue(this.props.data, columnDef);
+        return (
+          <this.props.components.Cell
+            icons={this.props.icons}
+            columnDef={columnDef}
+            value={value}
+            key={"cell-" + this.props.data.tableData.di + "-" + columnDef.tableData.id}
+            rowData={this.props.data}
+          />
+        );
+      });
+    return mapArr;
+  }
+
+  renderActions() {
+    const actions = this.props.actions.filter(a => !a.isFreeAction && !this.props.options.selection);
+    return (
+      <TableCell padding="none" key="key-actions-column" style={{ width: 48 * actions.length, padding: '0px 5px', ...this.props.options.actionsCellStyle }}>
+        <div style={{ display: 'flex' }}>
+          <this.props.components.Actions data={this.props.data} actions={actions} components={this.props.components} />
+        </div>
+      </TableCell>
+    );
+  }
+  renderSelectionColumn() {
+    return (
+      <TableCell padding="none" key="key-selection-column" style={{ width: 48 + 12 * (this.props.treeDataMaxLevel - 1) }}>
+        <Checkbox
+          checked={this.props.data.tableData.checked === true}
+          onClick={(e) => e.stopPropagation()}
+          value={this.props.data.tableData.id.toString()}
+          onChange={(event) => this.props.onRowSelected(event, this.props.path, this.props.data)}
+          style={{
+            paddingLeft: 12 + this.props.level * 12
+          }}
+        />
+      </TableCell>
+    );
+  }
+
+  rotateIconStyle = isOpen => ({
+    transform: isOpen ? 'rotate(90deg)' : 'none'
+  });
+
+  renderDetailPanelColumn() {
+
+    const CustomIcon = ({ icon, style }) => typeof icon === "string" ? <Icon style={style}>{icon}</Icon> : React.createElement(icon, { style });
+
+    if (typeof this.props.detailPanel == 'function') {
+      return (
+        <TableCell padding="none" key="key-detail-panel-column" style={{ width: 48, textAlign: 'center' }}>
+          <IconButton
+            style={{ transition: 'all ease 200ms', ...this.rotateIconStyle(this.props.data.tableData.showDetailPanel) }}
+            onClick={(event) => {
+              this.props.onToggleDetailPanel(this.props.path, this.props.detailPanel);
+              event.stopPropagation();
+            }}
+          >
+            <this.props.icons.DetailPanel />
+          </IconButton>
+        </TableCell>
+      );
+    }
+    else {
+      return (
+        <TableCell padding="none" key="key-detail-panel-column">
+          <div style={{ width: 48 * this.props.detailPanel.length, textAlign: 'center', display: 'inline-block' }}>
+            {this.props.detailPanel.map((panel, index) => {
+
+              if (typeof panel === "function") {
+                panel = panel(this.props.data);
+              }
+
+              const isOpen = (this.props.data.tableData.showDetailPanel || '').toString() === panel.render.toString();
+
+              let iconButton = <this.props.icons.DetailPanel />;
+              let animation = true;
+              if (isOpen) {
+                if (panel.openIcon) {
+                  iconButton = <CustomIcon icon={panel.openIcon} />;
+                  animation = false;
+                }
+                else if (panel.icon) {
+                  iconButton = <CustomIcon icon={panel.icon} />;
+                }
+              }
+              else if (panel.icon) {
+                iconButton = <CustomIcon icon={panel.icon} />;
+                animation = false;
+              }
+
+              iconButton = (
+                <IconButton
+                  key={"key-detail-panel-" + index}
+                  style={{ transition: 'all ease 200ms', ...this.rotateIconStyle(animation && isOpen) }}
+                  disabled={panel.disabled}
+                  onClick={(event) => {
+                    this.props.onToggleDetailPanel(this.props.path, panel.render);
+                    event.stopPropagation();
+                  }}
+                >
+                  {iconButton}
+                </IconButton>);
+
+              if (panel.tooltip) {
+                iconButton = <Tooltip key={"key-detail-panel-" + index} title={panel.tooltip}>{iconButton}</Tooltip>;
+              }
+
+              return iconButton;
+            })}
+          </div>
+        </TableCell>
+      );
+    }
+  }
+
+  getStyle() {
+    let style = {
+      transition: 'all ease 300ms',
+    };
+
+    if (typeof this.props.options.footerStyle === "function") {
+      style = {
+        ...style,
+        ...this.props.options.footerStyle(this.props.data)
+      };
+    }
+    else if (this.props.options.footerStyle) {
+      style = {
+        ...style,
+        ...this.props.options.footerStyle
+      };
+    }
+
+    if (this.props.onRowClick) {
+      style.cursor = 'pointer';
+    }
+
+    if (this.props.hasAnyEditingRow) {
+      style.opacity = 0.2;
+    }
+
+    return style;
+  }
+
+  render() {
+    const renderColumns = this.renderColumns();
+    if (this.props.options.selection) {
+      renderColumns.splice(0, 0, this.renderSelectionColumn());
+    }
+    if (this.props.actions && this.props.actions.filter(a => !a.isFreeAction && !this.props.options.selection).length > 0) {
+      if (this.props.options.actionsColumnIndex === -1) {
+        renderColumns.push(this.renderActions());
+      } else if (this.props.options.actionsColumnIndex >= 0) {
+        let endPos = 0;
+        if (this.props.options.selection) {
+          endPos = 1;
+        }
+        renderColumns.splice(this.props.options.actionsColumnIndex + endPos, 0, this.renderActions());
+      }
+    }
+
+    if (this.props.isTreeData) {
+      if (this.props.data.tableData.childRows && this.props.data.tableData.childRows.length > 0) {
+        renderColumns.splice(0, 0, (
+          <TableCell padding="none" key={"key-tree-data-column"} style={{ width: 48 + 12 * (this.props.treeDataMaxLevel - 2) }}>
+            <IconButton
+              style={{
+                transition: 'all ease 200ms',
+                marginLeft: this.props.level * 12,
+                ...this.rotateIconStyle(this.props.data.tableData.isTreeExpanded)
+              }}
+              onClick={(event) => {
+                this.props.onTreeExpandChanged(this.props.path, this.props.data);
+                event.stopPropagation();
+              }}
+            >
+              <this.props.icons.DetailPanel />
+            </IconButton>
+          </TableCell>
+        ));
+      }
+      else {
+        renderColumns.splice(0, 0, <TableCell padding="none" key={"key-tree-data-column"} />);
+      }
+    }
+
+    // Lastly we add detail panel icon
+    if (this.props.detailPanel) {
+      if (this.props.options.detailPanelColumnAlignment === 'right') {
+        renderColumns.push(this.renderDetailPanelColumn());
+      } else {
+        renderColumns.splice(0, 0, this.renderDetailPanelColumn());
+      }
+    }
+
+    this.props.columns
+      .filter(columnDef => columnDef.tableData.groupOrder > -1)
+      .forEach(columnDef => {
+        renderColumns.splice(0, 0, <TableCell padding="none" key={"key-group-cell" + columnDef.tableData.id} />);
+      });
+
+    const {
+      icons,
+      data,
+      columns,
+      components,
+      detailPanel,
+      getFieldValue,
+      isTreeData,
+      onRowClick,
+      onRowSelected,
+      onTreeExpandChanged,
+      onToggleDetailPanel,
+      onEditingCanceled,
+      onEditingApproved,
+      options,
+      hasAnyEditingRow,
+      treeDataMaxLevel,
+      ...rowProps } = this.props;
+
+    return (
+      <>
+        <TableRow
+          selected={hasAnyEditingRow}
+          {...rowProps}
+          hover={onRowClick ? true : false}
+          style={this.getStyle()}
+          onClick={(event) => {
+            onRowClick && onRowClick(event, this.props.data,
+              (panelIndex) => {
+                let panel = detailPanel;
+                if (Array.isArray(panel)) {
+                  panel = panel[panelIndex || 0].render;
+                }
+
+                onToggleDetailPanel(this.props.path, panel);
+              });
+          }}
+        >
+          {renderColumns}
+        </TableRow>
+        {this.props.data.tableData.childRows && this.props.data.tableData.isTreeExpanded &&
+          this.props.data.tableData.childRows.map((data, index) => {
+            if (data.tableData.editing) {
+              return (
+                <this.props.components.EditRow
+                  columns={this.props.columns.filter(columnDef => { return !columnDef.hidden })}
+                  components={this.props.components}
+                  data={data}
+                  icons={this.props.icons}
+                  localization={this.props.localization}
+                  key={index}
+                  mode={data.tableData.editing}
+                  options={this.props.options}
+                  isTreeData={this.props.isTreeData}
+                  detailPanel={this.props.detailPanel}
+                  onEditingCanceled={onEditingCanceled}
+                  onEditingApproved={onEditingApproved}
+                />
+              );
+            } else {
+              return (
+                <this.props.components.Row
+                  {...this.props}
+                  data={data}
+                  index={index}
+                  key={index}
+                  level={this.props.level + 1}
+                  path={[...this.props.path, index]}
+                  onEditingCanceled={onEditingCanceled}
+                  onEditingApproved={onEditingApproved}
+                  hasAnyEditingRow={this.props.hasAnyEditingRow}
+                  treeDataMaxLevel={treeDataMaxLevel}
+                />
+              );
+            }
+          })
+        }
+        {this.props.data.tableData && this.props.data.tableData.showDetailPanel &&
+          <TableRow
+          // selected={this.props.index % 2 === 0}
+          >
+            <TableCell colSpan={renderColumns.length} padding="none">
+              {this.props.data.tableData.showDetailPanel(this.props.data)}
+            </TableCell>
+          </TableRow>
+        }
+      </>
+    );
+  }
+}
+
+MTableBodyFooterRow.defaultProps = {
+  actions: [],
+  index: 0,
+  data: {},
+  options: {},
+  path: []
+};
+
+MTableBodyFooterRow.propTypes = {
+  actions: PropTypes.array,
+  icons: PropTypes.any.isRequired,
+  index: PropTypes.number.isRequired,
+  data: PropTypes.object.isRequired,
+  detailPanel: PropTypes.oneOfType([PropTypes.func, PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.object, PropTypes.func]))]),
+  hasAnyEditingRow: PropTypes.bool,
+  options: PropTypes.object.isRequired,
+  onRowSelected: PropTypes.func,
+  path: PropTypes.arrayOf(PropTypes.number),
+  treeDataMaxLevel: PropTypes.number,
+  getFieldValue: PropTypes.func.isRequired,
+  columns: PropTypes.array,
+  onToggleDetailPanel: PropTypes.func.isRequired,
+  onRowClick: PropTypes.func,
+  onEditingApproved: PropTypes.func,
+  onEditingCanceled: PropTypes.func,
+};

--- a/src/components/m-table-body-footer-row.js
+++ b/src/components/m-table-body-footer-row.js
@@ -24,10 +24,6 @@ export default class MTableBodyFooterRow extends React.Component {
     return mapArr;
   }
 
-  rotateIconStyle = isOpen => ({
-    transform: isOpen ? 'rotate(90deg)' : 'none'
-  });
-
   getStyle() {
     let style = {
       transition: 'all ease 300ms',
@@ -50,10 +46,6 @@ export default class MTableBodyFooterRow extends React.Component {
       style.cursor = 'pointer';
     }
 
-    if (this.props.hasAnyEditingRow) {
-      style.opacity = 0.2;
-    }
-
     return style;
   }
 
@@ -71,61 +63,25 @@ export default class MTableBodyFooterRow extends React.Component {
       data,
       columns,
       components,
-      detailPanel,
       getFieldValue,
-      isTreeData,
       onRowClick,
       onRowSelected,
-      onTreeExpandChanged,
-      onToggleDetailPanel,
-      onEditingCanceled,
-      onEditingApproved,
       options,
-      hasAnyEditingRow,
-      treeDataMaxLevel,
       ...rowProps } = this.props;
 
     return (
       <>
         <TableRow
-          selected={hasAnyEditingRow}
           {...rowProps}
           hover={onRowClick ? true : false}
           style={this.getStyle()}
-          onClick={(event) => {
-            onRowClick && onRowClick(event, this.props.data,
-              (panelIndex) => {
-                let panel = detailPanel;
-                if (Array.isArray(panel)) {
-                  panel = panel[panelIndex || 0].render;
-                }
-
-                onToggleDetailPanel(this.props.path, panel);
-              });
-          }}
+          onClick={onRowClick}
         >
           {renderColumns}
         </TableRow>
         {this.props.data.tableData.childRows && this.props.data.tableData.isTreeExpanded &&
           this.props.data.tableData.childRows.map((data, index) => {
-            if (data.tableData.editing) {
-              return (
-                <this.props.components.EditRow
-                  columns={this.props.columns.filter(columnDef => { return !columnDef.hidden })}
-                  components={this.props.components}
-                  data={data}
-                  icons={this.props.icons}
-                  localization={this.props.localization}
-                  key={index}
-                  mode={data.tableData.editing}
-                  options={this.props.options}
-                  isTreeData={this.props.isTreeData}
-                  detailPanel={this.props.detailPanel}
-                  onEditingCanceled={onEditingCanceled}
-                  onEditingApproved={onEditingApproved}
-                />
-              );
-            } else {
+            
               return (
                 <this.props.components.Row
                   {...this.props}
@@ -134,23 +90,10 @@ export default class MTableBodyFooterRow extends React.Component {
                   key={index}
                   level={this.props.level + 1}
                   path={[...this.props.path, index]}
-                  onEditingCanceled={onEditingCanceled}
-                  onEditingApproved={onEditingApproved}
-                  hasAnyEditingRow={this.props.hasAnyEditingRow}
-                  treeDataMaxLevel={treeDataMaxLevel}
                 />
               );
-            }
+            
           })
-        }
-        {this.props.data.tableData && this.props.data.tableData.showDetailPanel &&
-          <TableRow
-          // selected={this.props.index % 2 === 0}
-          >
-            <TableCell colSpan={renderColumns.length} padding="none">
-              {this.props.data.tableData.showDetailPanel(this.props.data)}
-            </TableCell>
-          </TableRow>
         }
       </>
     );
@@ -170,16 +113,10 @@ MTableBodyFooterRow.propTypes = {
   icons: PropTypes.any.isRequired,
   index: PropTypes.number.isRequired,
   data: PropTypes.object.isRequired,
-  detailPanel: PropTypes.oneOfType([PropTypes.func, PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.object, PropTypes.func]))]),
-  hasAnyEditingRow: PropTypes.bool,
   options: PropTypes.object.isRequired,
   onRowSelected: PropTypes.func,
   path: PropTypes.arrayOf(PropTypes.number),
-  treeDataMaxLevel: PropTypes.number,
   getFieldValue: PropTypes.func.isRequired,
   columns: PropTypes.array,
-  onToggleDetailPanel: PropTypes.func.isRequired,
   onRowClick: PropTypes.func,
-  onEditingApproved: PropTypes.func,
-  onEditingCanceled: PropTypes.func,
 };

--- a/src/components/m-table-body-footer-row.js
+++ b/src/components/m-table-body-footer-row.js
@@ -12,7 +12,7 @@ export default class MTableBodyFooterRow extends React.Component {
       .map((columnDef, index) => {
         const value = this.props.getFieldValue(this.props.data, columnDef);
         return (
-          <this.props.components.Cell
+          <this.props.components.FooterCell
             icons={this.props.icons}
             columnDef={columnDef}
             value={value}

--- a/src/components/m-table-body.js
+++ b/src/components/m-table-body.js
@@ -48,20 +48,11 @@ class MTableBody extends React.Component {
             level={0}
             options={this.props.options}
             localization={{ ...MTableBody.defaultProps.localization.editRow, ...this.props.localization.editRow }}
-            onRowSelected={this.props.onRowSelected}
             actions={this.props.actions}
             columns={this.props.columns}
             getFieldValue={this.props.getFieldValue}
-            detailPanel={this.props.detailPanel}
             path={[index + this.props.pageSize * this.props.currentPage]}
-            onToggleDetailPanel={this.props.onToggleDetailPanel}
             onRowClick={this.props.onRowClick}
-            isTreeData={this.props.isTreeData}
-            onTreeExpandChanged={this.props.onTreeExpandChanged}
-            onEditingCanceled={this.props.onEditingCanceled}
-            onEditingApproved={this.props.onEditingApproved}
-            hasAnyEditingRow={this.props.hasAnyEditingRow}
-            treeDataMaxLevel={this.props.treeDataMaxLevel}
           />
         );
       });

--- a/src/components/m-table-body.js
+++ b/src/components/m-table-body.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-unused-vars */
-import { TableBody, TableCell, TableRow } from '@material-ui/core';
+import { TableBody, TableCell, TableRow, Divider } from '@material-ui/core';
 import PropTypes from 'prop-types';
 import * as React from 'react';
 /* eslint-enable no-unused-vars */
@@ -33,6 +33,38 @@ class MTableBody extends React.Component {
         </React.Fragment>
       );
     }
+  }
+
+
+  renderFooterRows(renderData) {
+    return renderData.map((data, index) => {
+        return (
+          <this.props.components.FooterRow
+            components={this.props.components}
+            icons={this.props.icons}
+            data={data}
+            index={index}
+            key={"row-" + data.tableData.id}
+            level={0}
+            options={this.props.options}
+            localization={{ ...MTableBody.defaultProps.localization.editRow, ...this.props.localization.editRow }}
+            onRowSelected={this.props.onRowSelected}
+            actions={this.props.actions}
+            columns={this.props.columns}
+            getFieldValue={this.props.getFieldValue}
+            detailPanel={this.props.detailPanel}
+            path={[index + this.props.pageSize * this.props.currentPage]}
+            onToggleDetailPanel={this.props.onToggleDetailPanel}
+            onRowClick={this.props.onRowClick}
+            isTreeData={this.props.isTreeData}
+            onTreeExpandChanged={this.props.onTreeExpandChanged}
+            onEditingCanceled={this.props.onEditingCanceled}
+            onEditingApproved={this.props.onEditingApproved}
+            hasAnyEditingRow={this.props.hasAnyEditingRow}
+            treeDataMaxLevel={this.props.treeDataMaxLevel}
+          />
+        );
+      });
   }
 
   renderUngroupedRows(renderData) {
@@ -182,11 +214,8 @@ class MTableBody extends React.Component {
           />
         }
         {this.renderEmpty(emptyRowCount, renderData)}
-
-        {this.props.footerData && (groups.length > 0 ?
-          this.renderGroupedRows(groups, this.props.footerData) :
-          this.renderUngroupedRows(this.props.footerData)
-        )}
+        
+        {this.props.footerData && this.renderFooterRows(this.props.footerData)}
       </TableBody>
     );
   }

--- a/src/components/m-table-body.js
+++ b/src/components/m-table-body.js
@@ -182,6 +182,11 @@ class MTableBody extends React.Component {
           />
         }
         {this.renderEmpty(emptyRowCount, renderData)}
+
+        {this.props.footerData && (groups.length > 0 ?
+          this.renderGroupedRows(groups, this.props.footerData) :
+          this.renderUngroupedRows(this.props.footerData)
+        )}
       </TableBody>
     );
   }
@@ -215,6 +220,7 @@ MTableBody.propTypes = {
   options: PropTypes.object.isRequired,
   pageSize: PropTypes.number,
   renderData: PropTypes.array,
+  footerData: PropTypes.array,
   initialFormData: PropTypes.object,
   selection: PropTypes.bool.isRequired,
   showAddRow: PropTypes.bool,

--- a/src/components/m-table-footer-cell.js
+++ b/src/components/m-table-footer-cell.js
@@ -1,0 +1,123 @@
+/* eslint-disable no-unused-vars */
+import * as React from 'react';
+import { Icon, TableCell } from '@material-ui/core';
+import PropTypes from 'prop-types';
+/* eslint-enable no-unused-vars */
+
+export default class MTableFooterCell extends React.Component {
+  getRenderValue() {
+    if (this.props.columnDef.emptyValue !== undefined && (this.props.value === undefined || this.props.value === null)) {
+      return this.getEmptyValue(this.props.columnDef.emptyValue);
+    }
+    if (this.props.columnDef.render) {
+      if(this.props.rowData) {
+        return this.props.columnDef.render(this.props.rowData, 'row');
+      }
+      else {
+        return this.props.columnDef.render(this.props.value, 'group');
+      }
+      
+    } else if (this.props.columnDef.type === 'boolean') {
+      const style = { textAlign: 'left', verticalAlign: 'middle', width: 48 };
+      if (this.props.value) {
+        return <this.props.icons.Check style={style} />;
+      } else {
+        return <this.props.icons.ThirdStateCheck style={style} />;
+      }
+    } else if (this.props.columnDef.type === 'date') {
+      if (this.props.value instanceof Date) {
+        return this.props.value.toLocaleDateString();
+      } else {
+        return this.props.value;
+      }
+    } else if (this.props.columnDef.type === 'time') {
+      if (this.props.value instanceof Date) {
+        return this.props.value.toLocaleTimeString();
+      } else {
+        return this.props.value;
+      }
+    } else if (this.props.columnDef.type === 'datetime') {
+      if (this.props.value instanceof Date) {
+        return this.props.value.toLocaleString();
+      } else {
+        return this.props.value;
+      }
+    } else if (this.props.columnDef.type === 'currency') {
+      return this.getCurrencyValue(this.props.columnDef.currencySetting, this.props.value);
+    }
+
+    return this.props.value;
+  }
+
+  getEmptyValue(emptyValue) {
+    if (typeof emptyValue === 'function') {
+      return this.props.columnDef.emptyValue(this.props.rowData);
+    } else {
+      return emptyValue;
+    }
+  }
+
+  getCurrencyValue(currencySetting, value) {
+    if (currencySetting !== undefined) {
+      return new Intl.NumberFormat((currencySetting.locale !== undefined) ? currencySetting.locale : 'en-US',
+        {
+          style: 'currency',
+          currency: (currencySetting.currencyCode !== undefined) ? currencySetting.currencyCode : 'USD',
+          minimumFractionDigits: (currencySetting.minimumFractionDigits !== undefined) ? currencySetting.minimumFractionDigits : 2,
+          maximumFractionDigits: (currencySetting.maximumFractionDigits !== undefined) ? currencySetting.maximumFractionDigits : 2
+        }).format((value !== undefined) ? value : 0);
+    } else {
+      return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format((value !== undefined) ? value : 0);
+    }
+  }
+
+  handleClickCell = e => {
+    if (this.props.columnDef.disableClick) {
+      e.stopPropagation();
+    }
+  }
+
+  getStyle = () => {
+    let footerCellStyle = {};
+
+    if (typeof this.props.columnDef.footerCellStyle === 'function') {
+      footerCellStyle = { ...footerCellStyle, ...this.props.columnDef.footerCellStyle(this.props.value, this.props.rowData) };
+    } else {
+      footerCellStyle = { ...footerCellStyle, ...this.props.columnDef.footerCellStyle };
+    }
+
+    if (this.props.columnDef.disableClick) {
+      footerCellStyle.cursor = 'default';
+    }
+
+    return { ...this.props.style, ...footerCellStyle };
+  }
+
+  render() {
+
+    const { icons, columnDef, rowData, ...cellProps } = this.props;
+
+    return (
+      <TableCell
+        {...cellProps}
+        style={this.getStyle()}
+        align={['numeric'].indexOf(this.props.columnDef.type) !== -1 ? "right" : "left"}
+        onClick={this.handleClickCell}
+      >
+        {this.props.children}
+        {this.getRenderValue()}
+      </TableCell>
+    );
+  }
+}
+
+MTableFooterCell.defaultProps = {
+  columnDef: {},
+  value: undefined
+};
+
+MTableFooterCell.propTypes = {
+  columnDef: PropTypes.object.isRequired,
+  value: PropTypes.any,
+  rowData: PropTypes.object
+};

--- a/src/default-props.js
+++ b/src/default-props.js
@@ -26,6 +26,7 @@ export const defaultProps = {
     Actions: MComponents.MTableActions,
     Body: MComponents.MTableBody,
     Cell: MComponents.MTableCell,
+    FooterCell: MComponents.MTableFooterCell,
     Container: Container,
     EditField: MComponents.MTableEditField,
     EditRow: MComponents.MTableEditRow,

--- a/src/default-props.js
+++ b/src/default-props.js
@@ -36,6 +36,7 @@ export const defaultProps = {
     OverlayLoading: OverlayLoading,
     Pagination: TablePagination,
     Row: MComponents.MTableBodyRow,
+    FooterRow: MComponents.MTableBodyFooterRow,
     Toolbar: MComponents.MTableToolbar
   },
   data: [],

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -15,7 +15,7 @@ export default class MaterialTable extends React.Component {
     super(props);
 
     const calculatedProps = this.getProps(props);
-    this.setDataManagerFields(calculatedProps, true);
+    this.setDataManagerFields(calculatedProps, true); // ⚠️ this function mutates props
     const renderState = this.dataManager.getRenderState();
 
     this.state = {
@@ -62,6 +62,7 @@ export default class MaterialTable extends React.Component {
       this.dataManager.changeApplySearch(true);
       this.dataManager.changeApplyFilters(true);
       this.dataManager.setData(props.data);
+      this.dataManager.setFooterData(props.footerData);
     }
 
     isInit && this.dataManager.changeOrder(defaultSortColumnIndex, defaultSortDirection);
@@ -79,7 +80,7 @@ export default class MaterialTable extends React.Component {
   }
 
   getProps(props) {
-    const calculatedProps = { ...(props || this.props) };
+    const calculatedProps = { ...(props || this.props) }; // ⚠️ props are spread into a new object, but since this is not a deep clone they can still get mutated
 
     const localization = calculatedProps.localization.body;
 
@@ -520,6 +521,7 @@ export default class MaterialTable extends React.Component {
                         components={props.components}
                         icons={props.icons}
                         renderData={this.state.renderData}
+                        footerData={this.props.footerData}
                         currentPage={this.state.currentPage}
                         initialFormData={props.initialFormData}
                         pageSize={this.state.pageSize}

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -56,6 +56,7 @@ export const propTypes = {
     Toolbar: PropTypes.oneOfType([PropTypes.element, PropTypes.func])
   }),
   data: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.object), PropTypes.func]).isRequired,
+  footerData: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.object), PropTypes.func]),
   editable: PropTypes.shape({
     onRowAdd: PropTypes.func,
     onRowUpdate: PropTypes.func,

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -123,6 +123,7 @@ export const propTypes = {
     pageSizeOptions: PropTypes.arrayOf(PropTypes.number),
     paginationType: PropTypes.oneOf(['normal', 'stepped']),
     rowStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
+    footerStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
     showEmptyDataSourceMessage: PropTypes.bool,
     showSelectAllCheckbox: PropTypes.bool,
     search: PropTypes.bool,

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -10,6 +10,7 @@ export const propTypes = {
   })])),
   columns: PropTypes.arrayOf(PropTypes.shape({
     cellStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
+    footerCellStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
     currencySetting: PropTypes.shape({
       locale: PropTypes.string,
       currencyCode: PropTypes.string,

--- a/src/utils/data-manager.js
+++ b/src/utils/data-manager.js
@@ -57,6 +57,20 @@ export default class DataManager {
     this.filtered = false;
   }
 
+  setFooterData(data) { // c&p of `setData` above
+    this.selectedCount = 0;
+
+    this.footerData = data.map((row, index) => {
+      row.tableData = { ...row.tableData, id: index };
+      if (row.tableData.checked) {
+        this.selectedCount++;
+      }
+      return row;
+    });
+
+    this.filtered = false;
+  }
+
   setColumns(columns) {
     this.columns = columns.map((columnDef, index) => {
       columnDef.tableData = {


### PR DESCRIPTION
## Related Issue
#27 

## Description
The goal was to add a footer row to the tables that can be styled. The main usecase is to render summary data (like column totals)

## Impacted Areas in Application
adds props `footerData`, `options.footerStyle`, and `column.footerCellStyle`
*

## Additional Notes
I tried to base the implementation off the patterns used in the existing code