### PR TITLE
Feature: show / hide column callback (#668)

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -105,9 +105,11 @@ class App extends Component {
                   parentChildData={(row, rows) => rows.find(a => a.id === row.parentId)}
                   options={{
                     selection: true,
+                    columnsButton: true,
                     filtering: 'true'
                   }}
                   onSearchChange={(e) => console.log("search changed: " + e)}
+                  onChangeColumnHidden={(columnId, hidden) => console.log("column " + columnId + " is now hidden:" + hidden)}
                 />
               </Grid>
             </Grid>

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -163,11 +163,10 @@ export default class MaterialTable extends React.Component {
   }
 
   onChangeColumnHidden = (columnId, hidden) => {
-    if (this.props.onChangeColumnHidden) {
-      this.props.onChangeColumnHidden(columnId, hidden);
-    }
     this.dataManager.changeColumnHidden(columnId, hidden);
-    this.setState(this.dataManager.getRenderState());
+    this.setState(this.dataManager.getRenderState(), () => {
+      this.props.onChangeColumnHidden && this.props.onChangeColumnHidden(columnId, hidden);
+    });
   }
 
   onChangeGroupOrder = (groupedColumn) => {

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -163,6 +163,9 @@ export default class MaterialTable extends React.Component {
   }
 
   onChangeColumnHidden = (columnId, hidden) => {
+    if (this.props.onChangeColumnHidden) {
+      this.props.onChangeColumnHidden(columnId, hidden);
+    }
     this.dataManager.changeColumnHidden(columnId, hidden);
     this.setState(this.dataManager.getRenderState());
   }

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -161,6 +161,7 @@ export const propTypes = {
   onSelectionChange: PropTypes.func,
   onChangeRowsPerPage: PropTypes.func,
   onChangePage: PropTypes.func,
+  onChangeColumnHidden: PropTypes.func,
   onOrderChange: PropTypes.func,
   onRowClick: PropTypes.func,
   onTreeExpandChange: PropTypes.func,


### PR DESCRIPTION
## Description
An optional callback property for the MaterialTable component to inform about shown / hidden columns. This makes it easy to persist the current user settings.

branch | PR
------ | ------
column-hidden-callback | [Link](https://github.com/dnn5b/material-table/tree/feature/column-hidden-callback)

## Additional Notes
This feature has been often requested (e.g. in [here](https://github.com/mbrn/material-table/issues/668)). 