### PR TITLE
Feature/column dragged callback

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -108,6 +108,7 @@ class App extends Component {
                     filtering: 'true'
                   }}
                   onSearchChange={(e) => console.log("search changed: " + e)}
+                  onColumnDragged={(oldPos, newPos) => console.log("Dropped column from " + oldPos + " to position " + newPos)}
                 />
               </Grid>
             </Grid>

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -229,6 +229,9 @@ export default class MaterialTable extends React.Component {
   }
 
   onDragEnd = result => {
+    if (this.props.onColumnDragged) {
+      this.props.onColumnDragged(result.source.index, result.destination.index);
+    }
     this.dataManager.changeByDrag(result);
     this.setState(this.dataManager.getRenderState());
   }

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -229,11 +229,10 @@ export default class MaterialTable extends React.Component {
   }
 
   onDragEnd = result => {
-    if (this.props.onColumnDragged) {
-      this.props.onColumnDragged(result.source.index, result.destination.index);
-    }
     this.dataManager.changeByDrag(result);
-    this.setState(this.dataManager.getRenderState());
+    this.setState(this.dataManager.getRenderState(), () => {
+      this.props.onColumnDragged && this.props.onColumnDragged(result.source.index, result.destination.index);
+    });
   }
 
   onGroupExpandChanged = (path) => {

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -158,6 +158,7 @@ export const propTypes = {
   }),
   initialFormData: PropTypes.object,
   onSearchChange: PropTypes.func,
+  onColumnDragged: PropTypes.func,
   onSelectionChange: PropTypes.func,
   onChangeRowsPerPage: PropTypes.func,
   onChangePage: PropTypes.func,


### PR DESCRIPTION
## Description
An optional callback property for the MaterialTable component to notify when a column is moved. New and old positions are also provided.

branch | PR
------ | ------
column-dragged-callback | [Link](https://github.com/dnn5b/material-table/tree/feature/column-dragged-callback)

## Additional Notes
This feature allows persisting the user's current setting.