### PR TITLE
Fix for failing jests due to outdated material-pickers babel config error

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   },
   "dependencies": {
     "@date-io/date-fns": "^1.1.0",
-    "@material-ui/pickers": "^3.0.0",
+    "@material-ui/pickers": "^3.2.2",
     "classnames": "^2.2.6",
     "date-fns": "^2.0.0-alpha.27",
     "debounce": "^1.2.0",


### PR DESCRIPTION
## Related Issue
https://github.com/mbrn/material-table/issues/907
https://github.com/mui-org/material-ui-pickers/issues/1219

## Description
Material table depends on material-ui pickers, which had a babel compilation issue. Material UI pickers fixed there issue, and material-table should update its dependency.

## Related PRs
https://github.com/mui-org/material-ui-pickers/pull/1223

## Impacted Areas in Application
List general components of the application that this PR will affect:

* Testing
* Babel transpilation
* Webpack builds
