### PR TITLE
Update set sort direction logic on table header component, to enable …

### DIFF
--- a/src/components/m-table-header.js
+++ b/src/components/m-table-header.js
@@ -63,8 +63,18 @@ export class MTableHeader extends React.Component {
               active={this.props.orderBy === columnDef.tableData.id}
               direction={this.props.orderDirection || 'asc'}
               onClick={() => {
-                const orderDirection = columnDef.tableData.id !== this.props.orderBy ? 'asc' : this.props.orderDirection === 'asc' ? 'desc' : 'asc';
-                this.props.onOrderChange(columnDef.tableData.id, orderDirection);
+                // Update set sort direction logic to cycle on asc -> desc -> <blank> instead of just switch direction from asc to desc or desc to asc
+                switch(this.props.orderDirection){
+                  case 'asc':
+                      this.props.onOrderChange(columnDef.tableData.id, 'desc');
+                      break;
+                  case 'desc':
+                      this.props.onOrderChange(-1, '');
+                      break;
+                  default:
+                      this.props.onOrderChange(columnDef.tableData.id, 'asc');
+                      break;
+                }                
               }}
             >
               {content}


### PR DESCRIPTION
…reset sort direction when a column with sort direction 'desc' clicked

## Related Issue
Relate the Github issue with this PR using `#`
#936 

## Description
Update the logic on m-table header component to enable functionality to reset the sort direction by clicking the column header with sort direction 'desc'. 
The flow for sort direction will be like this: "asc" => "desc" => "" => "asc" => ...

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------

## Impacted Areas in Application
List general components of the application that this PR will affect:
src/components/m-table-header.js
*

## Additional Notes