### PR TITLE
Add third state to sort column

### DIFF
--- a/src/components/m-table-header.js
+++ b/src/components/m-table-header.js
@@ -63,7 +63,16 @@ export class MTableHeader extends React.Component {
               active={this.props.orderBy === columnDef.tableData.id}
               direction={this.props.orderDirection || 'asc'}
               onClick={() => {
-                const orderDirection = columnDef.tableData.id !== this.props.orderBy ? 'asc' : this.props.orderDirection === 'asc' ? 'desc' : 'asc';
+                const orderDirection =
+                  columnDef.tableData.id !== this.props.orderBy
+                    ? 'asc'
+                    : this.props.orderDirection === 'asc'
+                    ? 'desc'
+                    : this.props.orderDirection === 'desc'
+                    ? ''
+                    : this.props.orderDirection === ''
+                    ? 'asc'
+                    : 'desc';
                 this.props.onOrderChange(columnDef.tableData.id, orderDirection);
               }}
             >

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -173,20 +173,20 @@ export default class MaterialTable extends React.Component {
   }
 
   onChangeOrder = (orderBy, orderDirection) => {
-    this.dataManager.changeOrder(orderBy, orderDirection);
+    const newOrderBy = orderDirection === '' ? -1 : orderBy;
+    this.dataManager.changeOrder(newOrderBy, orderDirection);
 
     if (this.isRemoteData()) {
       const query = { ...this.state.query };
       query.page = 0;
-      query.orderBy = this.state.columns.find(a => a.tableData.id === orderBy);
+      query.orderBy = this.state.columns.find(a => a.tableData.id === newOrderBy);
       query.orderDirection = orderDirection;
       this.onQueryChange(query, () => {
-        this.props.onOrderChange && this.props.onOrderChange(orderBy, orderDirection);
+        this.props.onOrderChange && this.props.onOrderChange(newOrderBy, orderDirection);
       });
-    }
-    else {
+    } else {
       this.setState(this.dataManager.getRenderState(), () => {
-        this.props.onOrderChange && this.props.onOrderChange(orderBy, orderDirection);
+        this.props.onOrderChange && this.props.onOrderChange(newOrderBy, orderDirection);
       });
     }
   }


### PR DESCRIPTION
## Related Issue
Relate the Github issue with this PR using `#936`

## Description
In #936 I wanted to be able to sort with 3 states. In this PR it's now possible.

## Impacted Areas in Application
It's now possible to have three states to sort one column.