### PR TITLE
ActionFeedback as a component prop

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -89,6 +89,16 @@ class App extends Component {
                           resolve();
                         }, 1000);
                       }),
+                      onRowDelete: id =>
+                      new Promise((resolve, reject) => {
+                        setTimeout(() => {
+                          {
+                            /* 
+                            this.setState({ data }, () => resolve()); */
+                          }
+                          resolve();
+                        }, 1000);
+                      }),
                   }}
                 />
               </Grid>

--- a/src/components/m-table-edit-row.js
+++ b/src/components/m-table-edit-row.js
@@ -1,15 +1,14 @@
 /* eslint-disable no-unused-vars */
 import TableCell from '@material-ui/core/TableCell';
 import TableRow from '@material-ui/core/TableRow';
-import Typography from '@material-ui/core/Typography';
 import PropTypes from 'prop-types';
 import * as React from 'react';
 import { byString, setByString } from '../utils';
 /* eslint-enable no-unused-vars */
 
 
-export default class MTableEditRow extends React.Component {
 
+export default class MTableEditRow extends React.Component {
   constructor(props) {
     super(props);
 
@@ -95,7 +94,7 @@ export default class MTableEditRow extends React.Component {
   }
 
   renderActions() {
-    const localization = { ...MTableEditRow.defaultProps.localization, ...this.props.localization };
+    const {localization} = this.props;
     const actions = [
       {
         icon: this.props.icons.Check,
@@ -146,9 +145,9 @@ export default class MTableEditRow extends React.Component {
           padding={this.props.options.actionsColumnIndex === 0 ? "none" : undefined}
           key="key-selection-cell"
           colSpan={colSpan}>
-          <Typography variant="h6">
+          <this.props.components.ActionFeedback>
             {localization.deleteText}
-          </Typography>
+          </this.props.components.ActionFeedback>
         </TableCell>
       ];
     }
@@ -219,11 +218,6 @@ MTableEditRow.defaultProps = {
   index: 0,
   options: {},
   path: [],
-  localization: {
-    saveTooltip: 'Save',
-    cancelTooltip: 'Cancel',
-    deleteText: 'Are you sure delete this row?',
-  }
 };
 
 MTableEditRow.propTypes = {

--- a/src/default-props.js
+++ b/src/default-props.js
@@ -1,8 +1,11 @@
 import React from 'react';
-import CircularProgress from '@material-ui/core/CircularProgress';
-import Icon from '@material-ui/core/Icon';
-import Paper from '@material-ui/core/Paper';
-import TablePagination from '@material-ui/core/TablePagination';
+import {
+	Icon,
+	Paper,
+	TablePagination,
+	CircularProgress,
+	Typography,
+} from "@material-ui/core";
 import * as MComponents from './components';
 import PropTypes from 'prop-types';
 import { fade } from '@material-ui/core/styles/colorManipulator';
@@ -19,6 +22,7 @@ OverlayLoading.propTypes = {
 };
 
 const Container = (props) => <Paper elevation={2} {...props} />;
+const ActionFeedback = props => <Typography variant="h6" {...props} />;
 
 export const defaultProps = {
   actions: [],
@@ -27,6 +31,7 @@ export const defaultProps = {
   components: {
     Action: MComponents.MTableAction,
     Actions: MComponents.MTableActions,
+    ActionFeedback: ActionFeedback,
     Body: MComponents.MTableBody,
     Cell: MComponents.MTableCell,
     Container: Container,

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -419,7 +419,7 @@ export default class MaterialTable extends React.Component {
   renderFooter() {
     const props = this.getProps();
     if (props.options.paging) {
-      const localization = { ...MaterialTable.defaultProps.localization.pagination, ...this.props.localization.pagination };
+      const localization = this.props.localization.pagination;
       return (
         <Table>
           <TableFooter style={{ display: 'grid' }}>

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -51,6 +51,7 @@ export const propTypes = {
   components: PropTypes.shape({
     Action: PropTypes.oneOfType([PropTypes.element, PropTypes.func, StyledComponent]),
     Actions: PropTypes.oneOfType([PropTypes.element, PropTypes.func, StyledComponent]),
+    ActionFeedback: PropTypes.oneOfType([ PropTypes.element, PropTypes.func, StyledComponent, ]),
     Body: PropTypes.oneOfType([PropTypes.element, PropTypes.func, StyledComponent]),
     Cell: PropTypes.oneOfType([PropTypes.element, PropTypes.func, StyledComponent]),
     Container: PropTypes.oneOfType([PropTypes.element, PropTypes.func, StyledComponent]),


### PR DESCRIPTION
## Related Issue
- No related issues. 

## Description
- Added a prop to `components` called `ActionFeedback`. This allows users to supply their own Typography component for the prompt that is shown when trying to update or delete a row.
- I fixed the propagation of the localized props regarding the editRow, to avoid these being declared at multiple places, and mismatching.
- Added a dummy onRowDelete to the demo.js to display this functionality.

## Related PRs
- No related PRs

## Impacted Areas in Application
* MTableEditRow

## Additional Notes
As this is a new feature it will probably not break anything.