### PR TITLE
adds className to MaterialTable props

### DIFF
--- a/src/material-table.js
+++ b/src/material-table.js
@@ -456,7 +456,7 @@ export default class MaterialTable extends React.Component {
 
     return (
       <DragDropContext onDragEnd={this.onDragEnd}>
-        <props.components.Container style={{ position: 'relative', ...props.style }}>
+        <props.components.Container className={props.className} style={{ position: 'relative', ...props.style }}>
           {props.options.toolbar &&
             <props.components.Toolbar
               actions={props.actions}


### PR DESCRIPTION
## Related Issue
#766

## Description
Adds the prop className to MaterialTable so people can use className instead of style prop


## Impacted Areas in Application
List general components of the application that this PR will affect:

* MaterialTable Component
