### PR TITLE
`freeCells` key added

### DIFF
--- a/src/components/m-table-group-row.js
+++ b/src/components/m-table-group-row.js
@@ -77,7 +77,7 @@ export default class MTableGroupRow extends React.Component {
 
     const freeCells = [];
     for (let i = 0; i < this.props.level; i++) {
-      freeCells.push(<TableCell padding="checkbox" />);
+      freeCells.push(<TableCell padding="checkbox" key={ i } />);
     }
 
     let value = this.props.groupData.value;


### PR DESCRIPTION
## Related Issue
-

## Description
When you try to group then sometimes you get the warning "Warning: Each child in a list should have a unique "key" prop." because the `freeCells` array renders elements without key. Fixed in this file change

## Related PRs
-

## Impacted Areas in Application

* grouping

## Additional Notes
-