### PR TITLE
Fix calculated width of Actions column to exclude hidden actions

### DIFF
--- a/src/components/m-table-body-row.js
+++ b/src/components/m-table-body-row.js
@@ -34,9 +34,10 @@ export default class MTableBodyRow extends React.Component {
   renderActions() {
     const size = this.getElementSize();
     const baseIconSize = size === 'medium' ? 42 : 26;
-    const actions = this.props.actions.filter(a => !a.isFreeAction && !this.props.options.selection);
+    const actions = this.props.actions.filter(a => !a.isFreeAction && !this.props.options.selection && !a.hidden);
+    const cellWidth = baseIconSize * actions.length;
     return (
-      <TableCell size={size} padding="none" key="key-actions-column" style={{ width: baseIconSize * actions.length, padding: '0px 5px', ...this.props.options.actionsCellStyle }}>
+      <TableCell size={size} padding="none" key="key-actions-column" style={{ width: cellWidth, padding: '0px 5px', ...this.props.options.actionsCellStyle }}>
         <div style={{ display: 'flex' }}>
           <this.props.components.Actions data={this.props.data} actions={actions} components={this.props.components} size={size} />
         </div>


### PR DESCRIPTION
## Description
The calculated width for the actions column includes hidden actions, which results in the column being too wide and a noticeable gap at the end of the column in the rows where the hidden actions would have been displayed.  This filters out the hidden columns from the calculation.
