### PR TITLE
fixed issue #945

### DIFF
--- a/src/components/m-table-body.js
+++ b/src/components/m-table-body.js
@@ -114,6 +114,7 @@ class MTableBody extends React.Component {
         options={this.props.options}
         isTreeData={this.props.isTreeData}
         hasAnyEditingRow={this.props.hasAnyEditingRow}
+        localization={{ ...MTableBody.defaultProps.localization.editRow, ...this.props.localization.editRow }}
       />
     ));
   }

--- a/src/components/m-table-group-row.js
+++ b/src/components/m-table-group-row.js
@@ -50,28 +50,51 @@ export default class MTableGroupRow extends React.Component {
         ));
       }
       else {
-        detail = this.props.groupData.data.map((rowData, index) => (
-          <this.props.components.Row
-            actions={this.props.actions}
-            key={index}
-            columns={this.props.columns}
-            components={this.props.components}
-            data={rowData}
-            detailPanel={this.props.detailPanel}
-            getFieldValue={this.props.getFieldValue}
-            icons={this.props.icons}
-            path={[...this.props.path, index]}
-            onRowSelected={this.props.onRowSelected}
-            onRowClick={this.props.onRowClick}
-            onToggleDetailPanel={this.props.onToggleDetailPanel}
-            options={this.props.options}
-            isTreeData={this.props.isTreeData}
-            onTreeExpandChanged={this.props.onTreeExpandChanged}
-            onEditingCanceled={this.props.onEditingCanceled}
-            onEditingApproved={this.props.onEditingApproved}
-            hasAnyEditingRow={this.props.hasAnyEditingRow}
-          />
-        ));
+        detail = this.props.groupData.data.map((rowData, index) => {
+          if (rowData.tableData.editing) {
+            return (
+              <this.props.components.EditRow
+                columns={this.props.columns}
+                components={this.props.components}
+                data={rowData}
+                icons={this.props.icons}
+                path={[...this.props.path, index]}
+                localization={this.props.localization}
+                key={index}
+                mode={rowData.tableData.editing}
+                options={this.props.options}
+                isTreeData={this.props.isTreeData}
+                detailPanel={this.props.detailPanel}
+                onEditingCanceled={this.props.onEditingCanceled}
+                onEditingApproved={this.props.onEditingApproved}
+                getFieldValue={this.props.getFieldValue}
+              />
+            );
+          } else {
+            return (
+              <this.props.components.Row
+                actions={this.props.actions}
+                key={index}
+                columns={this.props.columns}
+                components={this.props.components}
+                data={rowData}
+                detailPanel={this.props.detailPanel}
+                getFieldValue={this.props.getFieldValue}
+                icons={this.props.icons}
+                path={[...this.props.path, index]}
+                onRowSelected={this.props.onRowSelected}
+                onRowClick={this.props.onRowClick}
+                onToggleDetailPanel={this.props.onToggleDetailPanel}
+                options={this.props.options}
+                isTreeData={this.props.isTreeData}
+                onTreeExpandChanged={this.props.onTreeExpandChanged}
+                onEditingCanceled={this.props.onEditingCanceled}
+                onEditingApproved={this.props.onEditingApproved}
+                hasAnyEditingRow={this.props.hasAnyEditingRow}
+              />
+            );
+          }
+        });
       }
     }
 
@@ -137,6 +160,7 @@ MTableGroupRow.propTypes = {
   icons: PropTypes.object,
   isTreeData: PropTypes.bool.isRequired,
   level: PropTypes.number,
+  localization: PropTypes.object,
   onGroupExpandChanged: PropTypes.func,
   onRowSelected: PropTypes.func,
   onRowClick: PropTypes.func,  


### PR DESCRIPTION
fixed #945: When rows are grouped by a column, editing does not work

## Related Issue
#945
#778
#327

## Description
Found this issue a few days before and already fixed it.
Creation of EditRow was not implemented in GroupRow.

## Impacted Areas in Application
m-table-group-row