### PR TITLE
support setting the initialPage option in conjunction with remote data 

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -45,6 +45,10 @@ class App extends Component {
       { id: 4, name: 'A4', surname: 'Dede', isMarried: true, birthDate: new Date(1987, 1, 1), birthCity: 34, sex: 'Female', type: 'child', insertDateTime: new Date(2018, 1, 1, 12, 23, 44), time: new Date(1900, 1, 1, 14, 23, 35), parentId: 3 },
       { id: 5, name: 'A5', surname: 'C', isMarried: false, birthDate: new Date(1987, 1, 1), birthCity: 34, sex: 'Female', type: 'child', insertDateTime: new Date(2018, 1, 1, 12, 23, 44), time: new Date(1900, 1, 1, 14, 23, 35) },
       { id: 6, name: 'A6', surname: 'C', isMarried: true, birthDate: new Date(1989, 1, 1), birthCity: 34, sex: 'Female', type: 'child', insertDateTime: new Date(2018, 1, 1, 12, 23, 44), time: new Date(1900, 1, 1, 14, 23, 35), parentId: 5 },
+      { id: 7, name: 'A7', surname: 'C', isMarried: false, birthDate: new Date(1987, 1, 1), birthCity: 34, sex: 'Female', type: 'adult', insertDateTime: new Date(2018, 1, 1, 12, 23, 44), time: new Date(1900, 1, 1, 14, 23, 35) },
+      { id: 8, name: 'A8', surname: 'C', isMarried: false, birthDate: new Date(1987, 1, 1), birthCity: 34, sex: 'Female', type: 'adult', insertDateTime: new Date(2018, 1, 1, 12, 23, 44), time: new Date(1900, 1, 1, 14, 23, 35) },
+      { id: 9, name: 'A9', surname: 'C', isMarried: false, birthDate: new Date(1987, 1, 1), birthCity: 34, sex: 'Female', type: 'adult', insertDateTime: new Date(2018, 1, 1, 12, 23, 44), time: new Date(1900, 1, 1, 14, 23, 35) },
+      { id: 10, name: 'A10', surname: 'C', isMarried: false, birthDate: new Date(1987, 1, 1), birthCity: 34, sex: 'Female', type: 'adult', insertDateTime: new Date(2018, 1, 1, 12, 23, 44), time: new Date(1900, 1, 1, 14, 23, 35) },
     ],
     columns: [
       {
@@ -135,6 +139,7 @@ class App extends Component {
               options={{
                 grouping: true,
                 filtering: true,
+                initialPage: 1
               }}
               data={query => new Promise((resolve, reject) => {
                 let url = 'https://reqres.in/api/users?'

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "scripts": {
     "start": "webpack-dev-server --config ./demo/webpack.config.js --mode development",
     "build": "babel src --out-dir dist",
+    "postinstall": "babel src --out-dir dist",
     "lint": "npm run eslint && npm run tsc",
     "eslint": "eslint src/** -c ./configs/.eslintrc",
     "tsc": "tsc --noEmit --lib es6,dom --skipLibCheck types/index.d.ts",

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -34,7 +34,7 @@ export default class MaterialTable extends React.Component {
           })),
         orderBy: renderState.columns.find(a => a.tableData.id === renderState.orderBy),
         orderDirection: renderState.orderDirection,
-        page: 0,
+        page: calculatedProps.options.initialPage || 0,
         pageSize: calculatedProps.options.pageSize,
         search: renderState.searchText,
 
@@ -92,7 +92,7 @@ export default class MaterialTable extends React.Component {
     const currentPage = this.isRemoteData() ? this.state.query.page : this.state.currentPage;
     const pageSize = this.isRemoteData() ? this.state.query.pageSize : this.state.pageSize;
 
-    if (count <= pageSize * currentPage && currentPage !== 0) {
+    if (count <= pageSize * currentPage && (!this.isRemoteData() || !this.state.isLoading)) {
       this.onChangePage(null, Math.max(0, Math.ceil(count / pageSize) - 1));
     }
   }
@@ -440,7 +440,7 @@ export default class MaterialTable extends React.Component {
                 SelectProps={{
                   renderValue: value => <div style={{ padding: '0px 5px' }}>{value + ' ' + localization.labelRowsSelect + ' '}</div>
                 }}
-                page={this.isRemoteData() ? this.state.query.page : this.state.currentPage}
+                page={this.isRemoteData() ? (Math.min(this.state.query.page, this.state.query.totalCount)) : this.state.currentPage}
                 onChangePage={this.onChangePage}
                 onChangeRowsPerPage={this.onChangeRowsPerPage}
                 ActionsComponent={(subProps) => props.options.paginationType === 'normal' ?
@@ -477,7 +477,7 @@ export default class MaterialTable extends React.Component {
               exportCsv={props.options.exportCsv}
               getFieldValue={this.dataManager.getFieldValue}
               data={this.state.data}
-              renderData={this.state.renderData}
+              renderData={this.isRemoteData() ? this.state.data : this.state.renderData}
               search={props.options.search}
               showTitle={props.options.showTitle}
               showTextRowsSelected={props.options.showTextRowsSelected}
@@ -536,7 +536,7 @@ export default class MaterialTable extends React.Component {
                         actions={props.actions}
                         components={props.components}
                         icons={props.icons}
-                        renderData={this.state.renderData}
+                        renderData={this.isRemoteData() ? this.state.data : this.state.renderData}
                         currentPage={this.state.currentPage}
                         initialFormData={props.initialFormData}
                         pageSize={this.state.pageSize}


### PR DESCRIPTION
Fixes issue #964 

This PR adds support to setting `intialPage` in conjuction with a remote data source.
It also adds a `postinstall` hook to allow getting the dependency directly from the git repository via npm or yarn. I added some additional entries in the in-memory data demo so that the demo showcases working pagination for both in-memory and remote data examples.