### PR TITLE
Possibility to sort column with 2 or 3 states

### DIFF
--- a/src/components/m-table-header.js
+++ b/src/components/m-table-header.js
@@ -48,9 +48,9 @@ export class MTableHeader extends React.Component {
                     ? 'asc'
                     : this.props.orderDirection === 'asc'
                     ? 'desc'
-                    : this.props.orderDirection === 'desc' && this.props.sortBackToNormal
+                    : this.props.orderDirection === 'desc' && this.props.thirdSortClick
                     ? ''
-                    : this.props.orderDirection === 'desc' && !this.props.sortBackToNormal
+                    : this.props.orderDirection === 'desc' && !this.props.thirdSortClick
                     ? 'asc'
                     : this.props.orderDirection === ''
                     ? 'asc'
@@ -185,7 +185,7 @@ MTableHeader.defaultProps = {
   actionsHeaderIndex: 0,
   detailPanelColumnAlignment: "left",
   draggable: true,
-  sortBackToNormal: true,
+  thirdSortClick: true,
 };
 
 MTableHeader.propTypes = {
@@ -206,7 +206,7 @@ MTableHeader.propTypes = {
   showActionsColumn: PropTypes.bool,
   showSelectAllCheckbox: PropTypes.bool,
   draggable: PropTypes.bool,
-  sortBackToNormal: PropTypes.bool,
+  thirdSortClick: PropTypes.bool,
 };
 
 

--- a/src/components/m-table-header.js
+++ b/src/components/m-table-header.js
@@ -48,8 +48,10 @@ export class MTableHeader extends React.Component {
                     ? 'asc'
                     : this.props.orderDirection === 'asc'
                     ? 'desc'
-                    : this.props.orderDirection === 'desc'
+                    : this.props.orderDirection === 'desc' && this.props.sortBackToNormal
                     ? ''
+                    : this.props.orderDirection === 'desc' && !this.props.sortBackToNormal
+                    ? 'asc'
                     : this.props.orderDirection === ''
                     ? 'asc'
                     : 'desc';
@@ -183,6 +185,7 @@ MTableHeader.defaultProps = {
   actionsHeaderIndex: 0,
   detailPanelColumnAlignment: "left",
   draggable: true,
+  sortBackToNormal: true,
 };
 
 MTableHeader.propTypes = {
@@ -203,6 +206,7 @@ MTableHeader.propTypes = {
   showActionsColumn: PropTypes.bool,
   showSelectAllCheckbox: PropTypes.bool,
   draggable: PropTypes.bool,
+  sortBackToNormal: PropTypes.bool,
 };
 
 

--- a/src/default-props.js
+++ b/src/default-props.js
@@ -99,7 +99,7 @@ export const defaultProps = {
     toolbar: true,
     defaultExpanded: false,
     detailPanelColumnAlignment: 'left',
-    sortBackToNormal: true,
+    thirdSortClick: true,
   },
   localization: {
     grouping: {

--- a/src/default-props.js
+++ b/src/default-props.js
@@ -98,7 +98,8 @@ export const defaultProps = {
     sorting: true,
     toolbar: true,
     defaultExpanded: false,
-    detailPanelColumnAlignment: 'left'
+    detailPanelColumnAlignment: 'left',
+    sortBackToNormal: true,
   },
   localization: {
     grouping: {

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -540,6 +540,7 @@ export default class MaterialTable extends React.Component {
                           grouping={props.options.grouping}
                           isTreeData={this.props.parentChildData !== undefined}
                           draggable={props.options.draggable}
+                          sortBackToNormal={props.options.sortBackToNormal}
                         />
                       }
                       <props.components.Body

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -540,7 +540,7 @@ export default class MaterialTable extends React.Component {
                           grouping={props.options.grouping}
                           isTreeData={this.props.parentChildData !== undefined}
                           draggable={props.options.draggable}
-                          sortBackToNormal={props.options.sortBackToNormal}
+                          thirdSortClick={props.options.thirdSortClick}
                         />
                       }
                       <props.components.Body

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -146,7 +146,7 @@ export const propTypes = {
     showTextRowsSelected: PropTypes.bool,
     sorting: PropTypes.bool,
     toolbar: PropTypes.bool,
-    sortBackToNormal: PropTypes.bool,
+    thirdSortClick: PropTypes.bool,
   }),
   localization: PropTypes.shape({
     grouping: PropTypes.shape({

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -146,6 +146,7 @@ export const propTypes = {
     showTextRowsSelected: PropTypes.bool,
     sorting: PropTypes.bool,
     toolbar: PropTypes.bool,
+    sortBackToNormal: PropTypes.bool,
   }),
   localization: PropTypes.shape({
     grouping: PropTypes.shape({


### PR DESCRIPTION
## Related Issue
#985 

## Description
It's now possible to sort the table columns with 3 or 2 states. By default `thirdSortClick = true` which makes it possible to sort the table to the state it was in when it was first rendered. 
With `thirdSortClick = false`, it's only possible to sort 'ASC' or 'DESC'.

## Impacted Areas in Application
m-table-header

## Additional Notes
I set `thirdSortClick` to `true`, because this is the natively behavior of a table. It should allow the user to sort ascending, descending and be able to return to the initial state. If this is not the desired behavior, through the options it is possible to revert:
```jsx
<MaterialTable
  data={data}
  options={{
    thirdSortClick : false
  }}
/>
```

## Edit
Change `sortBackToNormal` to `thirdSortClick` prop name.
Waiting for merge @mbrn 