### PR TITLE
Add aria-label type definition to localization interface

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -247,11 +247,15 @@ export interface Localization {
   };
   pagination?: {
     firstTooltip?: string;
+    firstAriaLabel?: string;
     previousTooltip?: string;
+    previousAriaLabel?: string,
     nextTooltip?: string;
+    nextAriaLabel?: string,
     labelDisplayedRows?: string;
     labelRowsPerPage?: string;
     lastTooltip?: string;
+    lastAriaLabel?: string,
     labelRowsSelect?: string;
   };
   toolbar?: {


### PR DESCRIPTION
## Related Issue
Related Issue  [`#1002`](https://github.com/mbrn/material-table/issues/1002)

## Description
The goal is to add the missing types for the aria-labels of the pagination object within the localization interface.

## Related PRs
None

## Impacted Areas in Application
* The Type definitions index.d.ts