### PR TITLE
Add height option to empty row

### DIFF
--- a/src/components/m-table-body-row.js
+++ b/src/components/m-table-body-row.js
@@ -33,7 +33,7 @@ export default class MTableBodyRow extends React.Component {
 
   renderActions() {
     const size = this.getElementSize();
-    const baseIconSize = size === 'medium' ? 42 : 26;
+    const baseIconSize = size === 'medium' ? this.props.options.emptyRowHeightMedium || 42 : this.props.options.emptyRowHeight || 26;
     const actions = this.props.actions.filter(a => !a.isFreeAction && !this.props.options.selection);
     return (
       <TableCell size={size} padding="none" key="key-actions-column" style={{ width: baseIconSize * actions.length, padding: '0px 5px', ...this.props.options.actionsCellStyle }}>

--- a/src/default-props.js
+++ b/src/default-props.js
@@ -98,7 +98,9 @@ export const defaultProps = {
     sorting: true,
     toolbar: true,
     defaultExpanded: false,
-    detailPanelColumnAlignment: 'left'
+    detailPanelColumnAlignment: 'left',
+    emptyRowMediumHeight: 42,
+    emptyRowMedium: 26
   },
   localization: {
     grouping: {


### PR DESCRIPTION
## Related Issue 
Related Issue #1005 

## Description
When a row is empty, there should be a way to specify the height; currently, it is hardcoded. Created two properties that allow specifying the height: emptyRowHeightMedium (default 42) and emptyRowHeight (default 26).

## Related PRs
none

## Impacted Areas in Application
Only affects the empty table row.
