### PR TITLE
onQueryChange added to types

### DIFF
--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -168,6 +168,7 @@ export const propTypes = {
   onOrderChange: PropTypes.func,
   onRowClick: PropTypes.func,
   onTreeExpandChange: PropTypes.func,
+  onQueryChange: PropTypes.func,
   tableRef: PropTypes.any,
   style: PropTypes.object
 };

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -32,7 +32,7 @@ export interface MaterialTableProps<RowData extends object> {
   onSearchChange?: (searchText: string) => void;
   onSelectionChange?: (data: RowData[], rowData?: RowData) => void;
   onTreeExpandChange?: (data: any, isExpanded: boolean) => void;
-  onQueryChange?: () => void;
+  onQueryChange?: (query: Query<RowData>) => void;
   style?: React.CSSProperties;
   tableRef?: any;
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -32,6 +32,7 @@ export interface MaterialTableProps<RowData extends object> {
   onSearchChange?: (searchText: string) => void;
   onSelectionChange?: (data: RowData[], rowData?: RowData) => void;
   onTreeExpandChange?: (data: any, isExpanded: boolean) => void;
+  onQueryChange?: () => void;
   style?: React.CSSProperties;
   tableRef?: any;
 }


### PR DESCRIPTION
## Description
This makes `onChangeQuery` func. available on `MaterialTableProps<RowData>` type 

Currently:
```
Property 'onQueryChange' does not exist on type 'MaterialTableProps<RowData>'
```
is being thrown.