### PR TITLE
Add totalCount as a prop for non-remote data

### DIFF
--- a/src/material-table.js
+++ b/src/material-table.js
@@ -87,8 +87,14 @@ export default class MaterialTable extends React.Component {
     this.setState(this.dataManager.getRenderState());
   }
 
+  getTotalCount() {
+    return this.isRemoteData() ?
+      this.state.query.totalCount :
+      (this.props.totalCount || this.state.data.length);
+  }
+
   componentDidUpdate() {
-    const count = this.isRemoteData() ? this.state.query.totalCount : this.state.data.length;
+    const count = this.getTotalCount();
     const currentPage = this.isRemoteData() ? this.state.query.page : this.state.currentPage;
     const pageSize = this.isRemoteData() ? this.state.query.pageSize : this.state.pageSize;
 
@@ -442,7 +448,7 @@ export default class MaterialTable extends React.Component {
                 }}
                 style={{ float: props.theme.direction === "rtl" ? "" : "right", overflowX: 'auto' }}
                 colSpan={3}
-                count={this.isRemoteData() ? this.state.query.totalCount : this.state.data.length}
+                count={this.getTotalCount()}
                 icons={props.icons}
                 rowsPerPage={this.state.pageSize}
                 rowsPerPageOptions={props.options.pageSizeOptions}

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -169,5 +169,6 @@ export const propTypes = {
   onRowClick: PropTypes.func,
   onTreeExpandChange: PropTypes.func,
   tableRef: PropTypes.any,
-  style: PropTypes.object
+  style: PropTypes.object,
+  totalCount: PropTypes.number
 };


### PR DESCRIPTION
## Related Issue
#976 

## Description
Allow passing a `totalCount` prop when not using `remoteData`. This will help Redux users that are using remote data but not with the `remoteData` option.


## Impacted Areas in Application
* MaterialTable component
* PropTypes
