### PR TITLE
fix: Missing peer dep warning in yarn v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
   },
   "peerDependencies": {
     "@date-io/core": "^1.3.6",
-    "@material-ui/core": "^4.0.1",,
+    "@material-ui/core": "^4.0.1",
     "react": "^16.8.4",
     "react-dom": "^16.8.4"
   }

--- a/package.json
+++ b/package.json
@@ -83,6 +83,9 @@
     "react-double-scrollbar": "0.0.15"
   },
   "peerDependencies": {
-    "@material-ui/core": "^4.0.1"
+    "@date-io/core": "^1.3.6",
+    "@material-ui/core": "^4.0.1",,
+    "react": "^16.8.4",
+    "react-dom": "^16.8.4"
   }
 }


### PR DESCRIPTION
## Related Issue
https://github.com/yarnpkg/berry/issues/3

## Description
In the upcoming yarn v2 packages should either explicitly provide missing peer deps or forward them

## Related PRs
N/A

## Impacted Areas in Application
Installing the package

## Additional Notes
Fixes the following warnings currently created when install this package with yarn v2:

```
➤ YN0002: │ material-table@npm:1.50.0 [V] doesn't provide @date-io/core@^1.3.6 requested by @material-ui/pickers@npm:3.2.4
➤ YN0002: │ material-table@npm:1.50.0 [V] doesn't provide react@^16.8.4 requested by @material-ui/pickers@npm:3.2.4
➤ YN0002: │ material-table@npm:1.50.0 [V] doesn't provide react-dom@^16.8.4 requested by @material-ui/pickers@npm:3.2.4
➤ YN0002: │ material-table@npm:1.50.0 [V] doesn't provide react@^16.8.5 requested by react-beautiful-dnd@npm:11.0.3
➤ YN0002: │ material-table@npm:1.50.0 [V] doesn't provide react@>= 0.14.7 requested by react-double-scrollbar@npm:0.0.15
```