### PR TITLE
Change Currency type's "ok" response to renderTextField

### DIFF
--- a/src/components/m-table-edit-field.js
+++ b/src/components/m-table-edit-field.js
@@ -1,15 +1,20 @@
-import * as React from 'react';
-import TextField from '@material-ui/core/TextField';
-import Checkbox from '@material-ui/core/Checkbox';
-import Select from '@material-ui/core/Select';
-import MenuItem from '@material-ui/core/MenuItem';
-import DateFnsUtils from '@date-io/date-fns';
-import { MuiPickersUtilsProvider, TimePicker, DatePicker, DateTimePicker } from '@material-ui/pickers';
-import PropTypes from 'prop-types';
+import * as React from "react";
+import TextField from "@material-ui/core/TextField";
+import Checkbox from "@material-ui/core/Checkbox";
+import Select from "@material-ui/core/Select";
+import MenuItem from "@material-ui/core/MenuItem";
+import DateFnsUtils from "@date-io/date-fns";
+import {
+  MuiPickersUtilsProvider,
+  TimePicker,
+  DatePicker,
+  DateTimePicker
+} from "@material-ui/pickers";
+import PropTypes from "prop-types";
 
 class MTableEditField extends React.Component {
   getProps() {
-    const { columnDef, rowData, onRowDataChange,  ...props } = this.props;
+    const { columnDef, rowData, onRowDataChange, ...props } = this.props;
     return props;
   }
 
@@ -17,18 +22,19 @@ class MTableEditField extends React.Component {
     return (
       <Select
         {...this.getProps()}
-        value={this.props.value === undefined ? '' : this.props.value}
+        value={this.props.value === undefined ? "" : this.props.value}
         onChange={event => this.props.onChange(event.target.value)}
         style={{
-          fontSize: 13,
+          fontSize: 13
         }}
       >
         {Object.keys(this.props.columnDef.lookup).map(key => (
-          <MenuItem key={key} value={key}>{this.props.columnDef.lookup[key]}</MenuItem>)
-        )}
+          <MenuItem key={key} value={key}>
+            {this.props.columnDef.lookup[key]}
+          </MenuItem>
+        ))}
       </Select>
     );
-
   }
 
   renderBooleanField() {
@@ -58,7 +64,7 @@ class MTableEditField extends React.Component {
           clearable
           InputProps={{
             style: {
-              fontSize: 13,
+              fontSize: 13
             }
           }}
         />
@@ -77,7 +83,7 @@ class MTableEditField extends React.Component {
           clearable
           InputProps={{
             style: {
-              fontSize: 13,
+              fontSize: 13
             }
           }}
         />
@@ -96,7 +102,7 @@ class MTableEditField extends React.Component {
           clearable
           InputProps={{
             style: {
-              fontSize: 13,
+              fontSize: 13
             }
           }}
         />
@@ -108,14 +114,16 @@ class MTableEditField extends React.Component {
     return (
       <TextField
         {...this.getProps()}
-        style={this.props.columnDef.type === 'numeric' ? { float: 'right' } : {}}
-        type={this.props.columnDef.type === 'numeric' ? 'number' : 'text'}
+        style={
+          this.props.columnDef.type === "numeric" ? { float: "right" } : {}
+        }
+        type={this.props.columnDef.type === "numeric" ? "number" : "text"}
         placeholder={this.props.columnDef.title}
-        value={this.props.value === undefined ? '' : this.props.value}
+        value={this.props.value === undefined ? "" : this.props.value}
         onChange={event => this.props.onChange(event.target.value)}
         InputProps={{
           style: {
-            fontSize: 13,
+            fontSize: 13
           }
         }}
       />
@@ -123,7 +131,7 @@ class MTableEditField extends React.Component {
   }
 
   renderCurrencyField() {
-    return "ok";
+    return this.renderTextField();
   }
 
   render() {
@@ -131,28 +139,21 @@ class MTableEditField extends React.Component {
 
     if (this.props.columnDef.lookup) {
       component = this.renderLookupField();
-    }
-    else if (this.props.columnDef.type === "boolean") {
+    } else if (this.props.columnDef.type === "boolean") {
       component = this.renderBooleanField();
-    }
-    else if (this.props.columnDef.type === "date") {
+    } else if (this.props.columnDef.type === "date") {
       component = this.renderDateField();
-    }
-    else if (this.props.columnDef.type === "time") {
+    } else if (this.props.columnDef.type === "time") {
       component = this.renderTimeField();
-    }
-    else if (this.props.columnDef.type === "datetime") {
+    } else if (this.props.columnDef.type === "datetime") {
       component = this.renderDateTimeField();
-    }
-    else if (this.props.columnDef.type === "currency") {
+    } else if (this.props.columnDef.type === "currency") {
       component = this.renderCurrencyField();
-    }
-    else {
+    } else {
       component = this.renderTextField();
     }
 
     return component;
-
   }
 }
 


### PR DESCRIPTION
## Related Issue
#534 - Editable Currency type render "ok"

## Description
Instead of returning "ok", simply have renderCurrencyField return the result of renderTextField.

## Impacted Areas in Application
List general components of the application that this PR will affect:

* Affects MTableEditField

## Additional Notes

* This is my first git commit.  I have no idea what I'm doing.  Please let me know if there's anything I should change.
* This commit included a TON of formatting (line breaks, spacing, quotes) changes that a VSCode extension added automatically.  Not sure if that's bad form, or if there's any way to fix it.
* I need this change for my own project, but I was easily working around it.  One of the reasons for this pull request is as a dry run for a slightly more complex edit I'd like to make soon.  So, please - any feedback or suggestions would be appreciated.