### PR TITLE
Fix Currency field Issues - Edit and alignment

### DIFF
--- a/src/components/m-table-cell.js
+++ b/src/components/m-table-cell.js
@@ -102,7 +102,7 @@ export default class MTableCell extends React.Component {
         size={this.props.size}
         {...cellProps}
         style={this.getStyle()}
-        align={['numeric'].indexOf(this.props.columnDef.type) !== -1 ? "right" : "left"}
+        align={['numeric','currency'].indexOf(this.props.columnDef.type) !== -1 ? "right" : "left"}
         onClick={this.handleClickCell}
       >
         {this.props.children}

--- a/src/components/m-table-edit-field.js
+++ b/src/components/m-table-edit-field.js
@@ -123,7 +123,20 @@ class MTableEditField extends React.Component {
   }
 
   renderCurrencyField() {
-    return "ok";
+    return (
+      <TextField
+        {...this.getProps()}
+        placeholder={this.props.columnDef.title}
+        value={this.props.value === undefined ? '' : this.props.value}
+        onChange={event => this.props.onChange(event.target.value)}
+        inputProps={{
+          style: {
+            fontSize: 13,
+            textAlign: "right"
+          }
+        }}
+      />
+    );
   }
 
   render() {


### PR DESCRIPTION
## Related Issue
[#534](https://github.com/mbrn/material-table/issues/534) - Editable Currency type render "ok"

## Description
When editing a currency field, instead of returning "ok", show a right-aligned textField.  Also, right align currency field render when not in Edit mode.


## Impacted Areas in Application
List general components of the application that this PR will affect:

* Affects MTableEditField and MTableCell

## Additional Notes
I attempted a previous PR for the same issue earlier - this is a new and improved version.  Still though, I'm new to working with GitHub so would appreciate any feedback.