### PR TITLE
Table indents

### DIFF
--- a/src/components/m-table-body-row.js
+++ b/src/components/m-table-body-row.js
@@ -17,12 +17,20 @@ export default class MTableBodyRow extends React.Component {
       .sort((a, b) => a.tableData.columnOrder - b.tableData.columnOrder)
       .map((columnDef, index) => {
         const value = this.props.getFieldValue(this.props.data, columnDef);
+        const indentStyle = (this.props.options.indentFirstDataCell && index == 0)?(
+          size === 'medium' ? {
+            paddingLeft: this.props.level * 9
+          } : {
+            paddingLeft: 5 + this.props.level * 9
+          }
+        ):{};
         return (
           <this.props.components.Cell
             size={size}
             icons={this.props.icons}
             columnDef={columnDef}
             value={value}
+            style={indentStyle}
             key={"cell-" + this.props.data.tableData.id + "-" + columnDef.tableData.id}
             rowData={this.props.data}
           />
@@ -35,9 +43,16 @@ export default class MTableBodyRow extends React.Component {
     const size = this.getElementSize();
     const baseIconSize = size === 'medium' ? 42 : 26;
     const actions = this.props.actions.filter(a => !a.isFreeAction && !this.props.options.selection);
+
+    const indentStyle = this.props.options.indentActionsCell ?( size === 'medium' ? {
+      marginLeft: this.props.level * 9
+    } : {
+        marginLeft: 5 + this.props.level * 9
+      }):{};
+
     return (
       <TableCell size={size} padding="none" key="key-actions-column" style={{ width: baseIconSize * actions.length, padding: '0px 5px', ...this.props.options.actionsCellStyle }}>
-        <div style={{ display: 'flex' }}>
+        <div style={{ ...indentStyle, display: 'flex' }}>
           <this.props.components.Actions data={this.props.data} actions={actions} components={this.props.components} size={size} />
         </div>
       </TableCell>

--- a/src/components/m-table-body-row.js
+++ b/src/components/m-table-body-row.js
@@ -19,9 +19,9 @@ export default class MTableBodyRow extends React.Component {
         const value = this.props.getFieldValue(this.props.data, columnDef);
         const indentStyle = (this.props.options.indentFirstDataCell && index == 0)?(
           size === 'medium' ? {
-            paddingLeft: this.props.level * 9
+            paddingLeft: this.props.level * this.props.options.indentFirstDataCell
           } : {
-            paddingLeft: 5 + this.props.level * 9
+            paddingLeft: 5 + this.props.level * this.props.options.indentFirstDataCell
           }
         ):{};
         return (
@@ -45,9 +45,9 @@ export default class MTableBodyRow extends React.Component {
     const actions = this.props.actions.filter(a => !a.isFreeAction && !this.props.options.selection);
 
     const indentStyle = this.props.options.indentActionsCell ?( size === 'medium' ? {
-      marginLeft: this.props.level * 9
+      marginLeft: this.props.level * this.props.options.indentActionsCell
     } : {
-        marginLeft: 5 + this.props.level * 9
+        marginLeft: 5 + this.props.level * this.props.options.indentActionsCell
       }):{};
 
     return (

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -124,6 +124,8 @@ export const propTypes = {
     filterCellStyle: PropTypes.object,
     header: PropTypes.bool,
     headerStyle: PropTypes.object,
+    indentActionsCell: PropTypes.number,
+    indentFirstDataCell: PropTypes.number,
     initialPage: PropTypes.number,
     maxBodyHeight: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     loadingType: PropTypes.oneOf(['overlay', 'linear']),


### PR DESCRIPTION
## Related Issue
[Tree data does not indent](https://github.com/mbrn/material-table/issues/760)

## Description
Currently indentation only shows for the chevron icons and for selection checkboxes.  This PR adds two options to MaterialTable:  indentActionsCell and indentFirstDataCell.  Setting either of these to true will indent the corresponding components.

## Impacted Areas in Application

* MTableBodyRow

## Additional Notes
Only my second PR - any feedback welcome.