### PR TITLE
added iconProps prop to CustomIcon, removed style (undocumented)

### DIFF
--- a/src/components/m-table-body-row.js
+++ b/src/components/m-table-body-row.js
@@ -80,7 +80,7 @@ export default class MTableBodyRow extends React.Component {
 
   renderDetailPanelColumn() {
 
-    const CustomIcon = ({ icon, style }) => typeof icon === "string" ? <Icon style={style}>{icon}</Icon> : React.createElement(icon, { style });
+    const CustomIcon = ({ icon, iconProps, }) => typeof icon === "string" ? <Icon {...iconProps}>{icon}</Icon> : React.createElement(icon, { ...iconProps });
 
     if (typeof this.props.detailPanel == 'function') {
       return (
@@ -114,15 +114,19 @@ export default class MTableBodyRow extends React.Component {
               let animation = true;
               if (isOpen) {
                 if (panel.openIcon) {
-                  iconButton = <CustomIcon icon={panel.openIcon} />;
+                  iconButton = <CustomIcon icon={panel.openIcon} iconProps={panel.iconProps} />;
                   animation = false;
                 }
                 else if (panel.icon) {
-                  iconButton = <CustomIcon icon={panel.icon} />;
+                  iconButton = (
+                    <CustomIcon icon={panel.icon} iconProps={panel.iconProps} />
+                  );
                 }
               }
               else if (panel.icon) {
-                iconButton = <CustomIcon icon={panel.icon} />;
+                iconButton = (
+                  <CustomIcon icon={panel.icon} iconProps={panel.iconProps} />
+                );
                 animation = false;
               }
 


### PR DESCRIPTION
## Related Issue
Relate the Github issue with this PR using `#`

#998 

## Description
A custom icon passed through the `detailPanel` prop should accept the prop `iconProps` which are then passed to the custom icon. Previously `iconProps` was not being passed to the custom icon.

## Related PRs
List related PRs against other branches:

None(?)

branch | PR
------ | ------
other_pr_production | [link]()
other_pr_master | [link]()

## Impacted Areas in Application
List general components of the application that this PR will affect:

* detailPanel icons

## Additional Notes
Kind of new to making PRs for OSS, let me know if I'm missing anything.