### PR TITLE
Feature/fix columns

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -47,7 +47,7 @@ class App extends Component {
       { id: 6, name: 'A6', surname: 'C', isMarried: true, birthDate: new Date(1989, 1, 1), birthCity: 34, sex: 'Female', type: 'child', insertDateTime: new Date(2018, 1, 1, 12, 23, 44), time: new Date(1900, 1, 1, 14, 23, 35), parentId: 5 },
     ],
     columns: [
-      { title: 'Adı', field: 'name', filterPlaceholder: 'Adı filter' },
+      { title: 'Adı', field: 'name', filterPlaceholder: 'Adı filter', fixed: true },
       { title: 'Soyadı', field: 'surname', initialEditValue: 'test' },
       { title: 'Evli', field: 'isMarried', type: 'boolean' },
       { title: 'Cinsiyet', field: 'sex', disableClick: true, editable: 'onAdd' },

--- a/src/components/m-table-header.js
+++ b/src/components/m-table-header.js
@@ -18,7 +18,7 @@ export class MTableHeader extends React.Component {
         let content = columnDef.title;
 
         if(this.props.draggable) {
-          content = (
+          content = (columnDef.fixed ? <>{columnDef.title}</> : 
             <Draggable
               key={columnDef.tableData.id}
               draggableId={columnDef.tableData.id.toString()}

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -38,6 +38,7 @@ export const propTypes = {
     grouping: PropTypes.bool,
     headerStyle: PropTypes.object,
     hidden: PropTypes.bool,
+    fixed: PropTypes.bool,
     initialEditValue: PropTypes.any,
     lookup: PropTypes.object,
     editable: PropTypes.oneOf(['always', 'onUpdate', 'onAdd', 'never', PropTypes.func]),


### PR DESCRIPTION
## Related Issue
https://github.com/mbrn/material-table/issues/765

## Description
Added a `fixed` property to column definition. If this property is true a column is not moveable to another position. Other columns are not affected by this property. 
It's useful if e.g. the first column of a table has to be fixed at the position.

branch | PR
------ | ------
Branch| [https://github.com/dnn5b/material-table/tree/feature/fix-columns]()