### PR TITLE
Footer implemented - activated by 'footerData' prop

### DIFF
--- a/src/components/index.js
+++ b/src/components/index.js
@@ -8,6 +8,7 @@ import MTableCell from './m-table-cell';
 import MTableEditRow from './m-table-edit-row';
 import MTableEditField from './m-table-edit-field';
 import MTableFilterRow from './m-table-filter-row';
+import MTableFooter from './m-table-footer';
 import MTableHeader from './m-table-header';
 import MTablePagination from './m-table-pagination';
 import MTableSteppedPagination from './m-table-stepped-pagination';
@@ -24,6 +25,7 @@ export {
   MTableEditRow,
   MTableEditField,
   MTableFilterRow,
+  MTableFooter,
   MTableHeader,
   MTablePagination,
   MTableSteppedPagination,

--- a/src/components/m-table-footer.js
+++ b/src/components/m-table-footer.js
@@ -1,0 +1,193 @@
+/* eslint-disable no-unused-vars */
+import Checkbox from '@material-ui/core/Checkbox';
+import TableCell from '@material-ui/core/TableCell';
+import TableRow from '@material-ui/core/TableRow';
+import TableFooter from '@material-ui/core/TableFooter';
+import IconButton from '@material-ui/core/IconButton';
+import Icon from '@material-ui/core/Icon';
+import Tooltip from '@material-ui/core/Tooltip';
+import PropTypes from 'prop-types';
+import * as React from 'react';
+/* eslint-enable no-unused-vars */
+
+
+export default class MTableFooter extends React.Component {
+  renderColumns() {
+    const size = this.getElementSize();
+    const mapArr = this.props.columns.filter(columnDef => !columnDef.hidden)
+      .sort((a, b) => a.tableData.columnOrder - b.tableData.columnOrder)
+      .map((columnDef, index) => {
+        const value = this.props.getFieldValue(this.props.data, columnDef);
+        return (
+          <this.props.components.Cell
+            size={size}
+            columnDef={columnDef}
+            value={value}
+            style={this.getStyle()}
+            key={"footer-cell-" + columnDef.tableData.id}
+            rowData={this.props.data}
+            isFooterCell={true}
+          />
+        );
+      });
+    return mapArr;
+  }
+
+  getStyle() {
+    let style = {
+      transition: 'all ease 300ms',
+      position: 'sticky',
+      bottom: '-1px',
+      zIndex: 4,
+      backgroundColor: 'whitesmoke'
+    };
+
+    if (typeof this.props.options.footerStyle === "function") {
+      style = {
+        ...style,
+        ...this.props.options.footerStyle(this.props.data)
+      };
+    }
+    else if (this.props.options.footerStyle) {
+      style = {
+        ...style,
+        ...this.props.options.footerStyle
+      };
+    }
+
+    if (this.props.onRowClick) {
+      style.cursor = 'pointer';
+    }
+    return style;
+  }
+
+  getElementSize = () => {
+    return this.props.options.padding === 'default' ? 'medium' : 'small';
+  }
+
+  renderActionPlaceholders() {
+    const size = this.getElementSize();
+    const baseIconSize = size === 'medium' ? 42 : 26;
+    const actions = this.props.actions.filter(a => !a.isFreeAction && !this.props.options.selection);
+    return (
+      <TableCell 
+        size={size} 
+        padding="none" 
+        key="footer-actions-column-placeholder" 
+        style={{ width: baseIconSize * actions.length, padding: '0px 5px' }}
+      >
+      </TableCell>
+    );
+  }
+
+  renderSelectionColumnPlaceholder() {
+    const size = this.getElementSize();
+    const baseIconSize = size === 'medium' ? 42 : 26;
+
+    return (
+      <TableCell 
+        size={this.getElementSize()} 
+        padding="none" 
+        key="footer-key-selection-column-placeholder" 
+        style={{ width: baseIconSize + 9 * (this.props.treeDataMaxLevel - 1) }}
+      />
+    );
+  }
+
+  render() {
+    const renderColumns = this.renderColumns();
+    
+    // 
+    // Add placeholder columns
+    //
+
+    if (this.props.options.selection) {
+      renderColumns.splice(0, 0, this.renderSelectionColumnPlaceholder());
+    }
+    if (this.props.actions && this.props.actions.filter(a => !a.isFreeAction && !this.props.options.selection).length > 0) {
+      if (this.props.options.actionsColumnIndex === -1) {
+        renderColumns.push(this.renderActionPlaceholders());
+      } else if (this.props.options.actionsColumnIndex >= 0) {
+        let endPos = 0;
+        if (this.props.options.selection) {
+          endPos = 1;
+        }
+        renderColumns.splice(this.props.options.actionsColumnIndex + endPos, 0, this.renderActionPlaceholders());
+      }
+    }
+
+    if(this.props.isTreeData){
+      renderColumns.splice(0, 0, 
+        <TableCell style={this.getStyle()} padding="none" key={"footer-tree-data-placeholder"} />
+      )
+    }
+    if(this.props.detailPanel){
+      if (this.props.options.detailPanelColumnAlignment === 'right') {
+        renderColumns.push(
+          <TableCell 
+            size={this.getElementSize()} 
+            padding="none" 
+            key="footer-detail-panel-placeholder" 
+            style={{ width: 42, textAlign: 'center' }}
+          />
+        );
+      } else {
+        renderColumns.splice(0, 0, 
+          <TableCell 
+            size={this.getElementSize()} 
+            padding="none" 
+            key="footer-detail-panel-placeholder" 
+            style={{ width: 42, textAlign: 'center' }}
+          />
+        );
+      }
+    }
+    this.props.columns
+      .filter(columnDef => columnDef.tableData.groupOrder > -1)
+      .forEach(columnDef => {
+        renderColumns.splice(0, 0, <TableCell size={this.getElementSize()} padding="none" key={"key-group-cell-placeholder-" +   columnDef.tableData.id} />);
+      });
+    //
+    // End placeholders
+    //
+    const {
+      data,
+      treeDataMaxLevel,
+      isTreeData,
+      columns,
+      components,
+      getFieldValue,
+      onRowClick,
+      options,
+      ...rowProps } = this.props;
+    return (
+      <>
+        <TableFooter style={this.getStyle()}>
+            <TableRow
+              {...rowProps}
+              hover={onRowClick ? true : false}
+              style={this.getStyle()}
+              onClick={(event) => {
+                onRowClick && onRowClick(event, this.props.data)
+              }}
+            >
+              {renderColumns}
+            </TableRow>
+        </TableFooter>
+      </>
+    );
+  }
+}
+
+MTableFooter.defaultProps = {
+  options: {},
+};
+
+MTableFooter.propTypes = {
+  options: PropTypes.object.isRequired,
+  columns: PropTypes.array,
+  components: PropTypes.object,
+  onRowClick: PropTypes.func,
+  getFieldValue: PropTypes.func.isRequired,
+  data: PropTypes.object.isRequired,
+};

--- a/src/components/m-table-footer.js
+++ b/src/components/m-table-footer.js
@@ -119,7 +119,7 @@ export default class MTableFooter extends React.Component {
     if(this.props.isTreeData){
       renderColumns.splice(0, 0, 
         <TableCell style={this.getStyle()} padding="none" key={"footer-tree-data-placeholder"} />
-      )
+      );
     }
     if(this.props.detailPanel){
       if (this.props.options.detailPanelColumnAlignment === 'right') {
@@ -168,7 +168,7 @@ export default class MTableFooter extends React.Component {
               hover={onRowClick ? true : false}
               style={this.getStyle()}
               onClick={(event) => {
-                onRowClick && onRowClick(event, this.props.data)
+                onRowClick && onRowClick(event, this.props.data);
               }}
             >
               {renderColumns}

--- a/src/components/m-table-footer.js
+++ b/src/components/m-table-footer.js
@@ -26,7 +26,6 @@ export default class MTableFooter extends React.Component {
             style={this.getStyle()}
             key={"footer-cell-" + columnDef.tableData.id}
             rowData={this.props.data}
-            isFooterCell={true}
           />
         );
       });

--- a/src/default-props.js
+++ b/src/default-props.js
@@ -33,6 +33,7 @@ export const defaultProps = {
     EditField: MComponents.MTableEditField,
     EditRow: MComponents.MTableEditRow,
     FilterRow: MComponents.MTableFilterRow,
+    Footer: MComponents.MTableFooter,
     Groupbar: MComponents.MTableGroupbar,
     GroupRow: MComponents.MTableGroupRow,
     Header: MComponents.MTableHeader,
@@ -42,6 +43,7 @@ export const defaultProps = {
     Toolbar: MComponents.MTableToolbar
   },
   data: [],
+  footerData: null,
   icons: {
     /* eslint-disable react/display-name */
     Add: React.forwardRef((props, ref) => <Icon {...props} ref={ref}>add_box</Icon>),

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -542,6 +542,18 @@ export default class MaterialTable extends React.Component {
                           draggable={props.options.draggable}
                         />
                       }
+                    {props.footerData && 
+                       <props.components.Footer
+                          options={props.options}
+                          columns={this.state.columns}
+                          components={props.components}
+                          onRowClick={this.props.onRowClick}
+                          getFieldValue={this.dataManager.getFieldValue}
+                          isTreeData={this.props.parentChildData !== undefined}
+                          treeDataMaxLevel={this.state.treeDataMaxLevel}
+                          data={props.footerData}
+                         />
+                     }
                       <props.components.Body
                         actions={props.actions}
                         components={props.components}

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -57,6 +57,7 @@ export const propTypes = {
     EditField: PropTypes.oneOfType([PropTypes.element, PropTypes.func, StyledComponent]),
     EditRow: PropTypes.oneOfType([PropTypes.element, PropTypes.func, StyledComponent]),
     FilterRow: PropTypes.oneOfType([PropTypes.element, PropTypes.func, StyledComponent]),
+    Footer: PropTypes.oneOfType([PropTypes.element, PropTypes.func, StyledComponent]),
     Groupbar: PropTypes.oneOfType([PropTypes.element, PropTypes.func, StyledComponent]),
     GroupRow: PropTypes.oneOfType([PropTypes.element, PropTypes.func, StyledComponent]),
     Header: PropTypes.oneOfType([PropTypes.element, PropTypes.func, StyledComponent]),
@@ -66,6 +67,7 @@ export const propTypes = {
     Toolbar: PropTypes.oneOfType([PropTypes.element, PropTypes.func, StyledComponent])
   }),
   data: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.object), PropTypes.func]).isRequired,
+  footerData: PropTypes.object,
   editable: PropTypes.shape({
     onRowAdd: PropTypes.func,
     onRowUpdate: PropTypes.func,
@@ -133,6 +135,7 @@ export const propTypes = {
     pageSizeOptions: PropTypes.arrayOf(PropTypes.number),
     paginationType: PropTypes.oneOf(['normal', 'stepped']),
     rowStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
+    footerStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
     search: PropTypes.bool,
     toolbarButtonAlignment: PropTypes.oneOf(['left', 'right']),
     searchFieldAlignment: PropTypes.oneOf(['left', 'right']),

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -7,6 +7,7 @@ export interface MaterialTableProps<RowData extends object> {
   columns: Column<RowData>[];
   components?: Components;
   data: RowData[] | ((query: Query<RowData>) => Promise<QueryResult<RowData>>);
+  footerData?: {[key in keyof RowData]: string | number | React.ReactElement | null};
   detailPanel?: ((rowData: RowData) => React.ReactNode) | (DetailPanel<RowData> | ((rowData: RowData) => DetailPanel<RowData>))[];
   editable?: {
     isEditable?: (rowData: RowData) => boolean;
@@ -133,6 +134,7 @@ export interface Components {
   EditField?: React.ComponentType<any>;
   EditRow?: React.ComponentType<any>;
   FilterRow?: React.ComponentType<any>;
+  Footer?: React.ComponentType<any>;
   Groupbar?: React.ComponentType<any>;
   GroupRow?: React.ComponentType<any>;
   Header?: React.ComponentType<any>;


### PR DESCRIPTION
## Related Issue
#573 

## Description
This PR adds a `footerData` prop to `MaterialTable`, and implemented the `MtTableFooter` component. The `footerData` prop is of type `{[key in keyof RowData]: string | number | React.ReactElement | null`. The **keys** in `footerData` will be used to align the **values** with the correct columns in the footer cells, taking into account "placeholder cells" for features such as grouping, actions, detailPanel, etc.  If `footerData === null` the footer will not be rendered.

## Related PRs
Nada

## Impacted Areas in Application
List general components of the application that this PR will affect:

* `MaterialTable`
    * Adds `footerData` prop to component API.
 
_Most of this is new functionality, not affecting old code_

## Additional Notes
I think this is a *good enough* step towards a long-term `Footer` implementation.  Most users will be able to access this API quite easily, by passing an object via `footerData` that has the same shape as the rest of the data passed to the table. Future improvements could include:
1. Automatic aggregations (i.e. avg., sum., stdev., etc.)
2. Multiple footer rows
3. A 'label' for a footer row (_often times you want to do something like *Avg:* `123` | `10.6` | `9.5`|_)