### PR TITLE
Fix type definition for "parentChildData"

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -19,7 +19,7 @@ export interface MaterialTableProps<RowData extends object> {
   isLoading?: boolean;
   title?: string | React.ReactElement<any>;
   options?: Options;
-  parentChildData?: (row: RowData, rows: RowData[]) => RowData;
+  parentChildData?: (row: RowData, rows: RowData[]) => RowData | undefined;
   localization?: Localization;
   onChangeRowsPerPage?: (pageSize: number) => void;
   onChangePage?: (page: number) => void;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -19,7 +19,7 @@ export interface MaterialTableProps<RowData extends object> {
   isLoading?: boolean;
   title?: string | React.ReactElement<any>;
   options?: Options;
-  parentChildData?: (row: RowData, rows: RowData[]) => RowData[];
+  parentChildData?: (row: RowData, rows: RowData[]) => RowData;
   localization?: Localization;
   onChangeRowsPerPage?: (pageSize: number) => void;
   onChangePage?: (page: number) => void;


### PR DESCRIPTION
## Related Issue
https://github.com/mbrn/material-table/issues/948#issuecomment-519097335

## Description
According to the [example for tree data](https://material-table.com/#/docs/features/tree-data). parentChildData should take a function that returns RowData not RowData[]