### PR TITLE
Fix issue #1049 and keeps the fix for issue #910 in tact

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -70,6 +70,66 @@ class App extends Component {
       <>
         <MuiThemeProvider theme={theme}>
           <div style={{ maxWidth: '100%', direction }}>
+            <MaterialTable
+              title="Free Action Demo"
+              columns={[
+                { title: 'Name', field: 'name' },
+                { title: 'Surname', field: 'surname' },
+                { title: 'Birth Year', field: 'birthYear', type: 'numeric' },
+                {
+                  title: 'Birth Place',
+                  field: 'birthCity',
+                  lookup: { 34: 'İstanbul', 63: 'Şanlıurfa' },
+                },
+              ]}
+              editable={{
+                isEditable: rowData => true,
+                onRowUpdate: (newData, oldData) => Promise.resolve()
+              }}
+              data={[
+                { name: 'Mehmet', surname: 'Baran', birthYear: 1987, birthCity: 63 },
+                { name: 'Zerya Betül', surname: 'Baran', birthYear: 2017, birthCity: 34 },
+              ]}
+              actions={[
+                {
+                  icon: 'add',
+                  tooltip: 'Add User',
+                  isFreeAction: true,
+                  onClick: (event) => alert("You want to add a new row")
+                }
+              ]}
+            />
+            <MaterialTable
+              title="Editable With Disabled Row Demo"
+              data={[
+                {
+                  name: "Rock",
+                  id: 1
+                },
+                {
+                  name: "Paper",
+                  id: 2
+                },
+                {
+                  name: "Scissors",
+                  id: 3
+                }
+              ]}
+              columns={[
+                {
+                  title: "Item",
+                  field: "name"
+                },
+                {
+                  title: "Item ID",
+                  field: "id"
+                }
+              ]}
+              editable={{
+                isEditable: rowData => false,
+                onRowUpdate: (newData, oldData) => Promise.resolve()
+              }}
+            />
             <Grid container>
               <Grid item xs={12}>
                 <MaterialTable

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -70,66 +70,6 @@ class App extends Component {
       <>
         <MuiThemeProvider theme={theme}>
           <div style={{ maxWidth: '100%', direction }}>
-            <MaterialTable
-              title="Free Action Demo"
-              columns={[
-                { title: 'Name', field: 'name' },
-                { title: 'Surname', field: 'surname' },
-                { title: 'Birth Year', field: 'birthYear', type: 'numeric' },
-                {
-                  title: 'Birth Place',
-                  field: 'birthCity',
-                  lookup: { 34: 'İstanbul', 63: 'Şanlıurfa' },
-                },
-              ]}
-              editable={{
-                isEditable: rowData => true,
-                onRowUpdate: (newData, oldData) => Promise.resolve()
-              }}
-              data={[
-                { name: 'Mehmet', surname: 'Baran', birthYear: 1987, birthCity: 63 },
-                { name: 'Zerya Betül', surname: 'Baran', birthYear: 2017, birthCity: 34 },
-              ]}
-              actions={[
-                {
-                  icon: 'add',
-                  tooltip: 'Add User',
-                  isFreeAction: true,
-                  onClick: (event) => alert("You want to add a new row")
-                }
-              ]}
-            />
-            <MaterialTable
-              title="Editable With Disabled Row Demo"
-              data={[
-                {
-                  name: "Rock",
-                  id: 1
-                },
-                {
-                  name: "Paper",
-                  id: 2
-                },
-                {
-                  name: "Scissors",
-                  id: 3
-                }
-              ]}
-              columns={[
-                {
-                  title: "Item",
-                  field: "name"
-                },
-                {
-                  title: "Item ID",
-                  field: "id"
-                }
-              ]}
-              editable={{
-                isEditable: rowData => false,
-                onRowUpdate: (newData, oldData) => Promise.resolve()
-              }}
-            />
             <Grid container>
               <Grid item xs={12}>
                 <MaterialTable

--- a/src/components/m-table-action.js
+++ b/src/components/m-table-action.js
@@ -47,7 +47,11 @@ class MTableAction extends React.Component {
     );
 
     if (action.tooltip) {
-      return <Tooltip title={action.tooltip}>{button}</Tooltip>;
+      // fix for issue #1049
+      // https://github.com/mbrn/material-table/issues/1049
+      return action.disabled
+        ? <Tooltip title={action.tooltip}><span>{button}</span></Tooltip>
+        : <Tooltip title={action.tooltip}>{button}</Tooltip>;
     } else {
       return button;
     }


### PR DESCRIPTION
## Related Issue
#910 [keeps the previous fix for this in tact]
#1049 [resolves this issue]

## Description
Fix issue #1049 and keeps the fix for issue #910 in tact

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
master | [Fixes issue #910 ](https://github.com/mbrn/material-table/pull/956)

## Impacted Areas in Application
* ~/src/components/m-table-action.js
* ~/demo/demo.js

## Additional Notes
In issue #910 the tooltip for free actions was displaying very close to the icon button, [the fix for this was removing the span that surrounded the icon button](https://github.com/mbrn/material-table/pull/956).  

This caused a warning on disabled actions per issue #1049.  Adding a ternary to check whether the action is enabled or disabled, so we can add/remove the span, resolves issue #1049 while keeping the fix for issue #910 in tact.

I have created 2 demos showing how the fix for #910 is still in tact, while fixing issue #1049.