### PR TITLE
Fix `togglePanel` of `onRowClick` event handler

### DIFF
--- a/src/components/m-table-body-row.js
+++ b/src/components/m-table-body-row.js
@@ -274,7 +274,11 @@ export default class MTableBodyRow extends React.Component {
               (panelIndex) => {
                 let panel = detailPanel;
                 if (Array.isArray(panel)) {
-                  panel = panel[panelIndex || 0].render;
+                  panel = panel[panelIndex || 0]
+                  if (typeof panel === "function") {
+                    panel = panel(this.props.data)
+                  }
+                  panel = panel.render;
                 }
 
                 onToggleDetailPanel(this.props.path, panel);

--- a/src/components/m-table-body-row.js
+++ b/src/components/m-table-body-row.js
@@ -274,9 +274,9 @@ export default class MTableBodyRow extends React.Component {
               (panelIndex) => {
                 let panel = detailPanel;
                 if (Array.isArray(panel)) {
-                  panel = panel[panelIndex || 0]
+                  panel = panel[panelIndex || 0];
                   if (typeof panel === "function") {
-                    panel = panel(this.props.data)
+                    panel = panel(this.props.data);
                   }
                   panel = panel.render;
                 }


### PR DESCRIPTION
## Related Issue
I cannot find issues related with this. If you find anything related, feel free to add it please.

## Description
Fix the bug in `onRowClick` handler (i.e., how `togglePanel` is implemented)

The type of `detailPanel` is described as ` ((rowData: RowData) => React.ReactNode) | (DetailPanel<RowData> | ((rowData: RowData) => DetailPanel<RowData>))[]`. Current version of `togglePanel` of `onRowClick` handler correctly handles the former 2 cases (i.e., `(rowData: RowData) => React.ReactNode)` and `DetailPanel<RowData>[]`) but it has bug on the later case (i.e., `((rowData: RowData) => DetailPanel<RowData>)[]`). This PR tries to fix the bug.

## Related PRs
**Same as related issues**

## Impacted Areas in Application
List general components of the application that this PR will affect:

* `m-table-body-row.js`: After this PR, `togglePanel` of `onRowClick` handler will correctly work even if `detailPanel` property is given as `((rowData: RowData) => DetailPanel<RowData>)[]` type

## Additional Notes
I found this bug when I'm using the library, but I couldn't find the issue on this repository. Since it was easy to fix, I created this PR directly without creating an related issues.