### PR TITLE
Feature: Initial Search Text

### DIFF
--- a/src/material-table.js
+++ b/src/material-table.js
@@ -79,6 +79,7 @@ export default class MaterialTable extends React.Component {
     isInit && this.dataManager.changePaging(props.options.paging);
     isInit && this.dataManager.changeParentFunc(props.parentChildData);
     this.dataManager.changeDetailPanelType(props.options.detailPanelType);
+    this.dataManager.setSearchInitialText(props.searchInitialText);
   }
 
   UNSAFE_componentWillReceiveProps(nextProps) {

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -50,6 +50,7 @@ export default class MaterialTable extends React.Component {
         this.onQueryChange(this.state.query);
       }
     });
+    if (this.state.searchInitialText) {this.onSearchChange(this.state.searchInitialText)}
   }
 
   setDataManagerFields(props, isInit) {

--- a/src/utils/data-manager.js
+++ b/src/utils/data-manager.js
@@ -158,6 +158,10 @@ export default class DataManager {
     this.currentPage = 0;
   }
 
+  setSearchInitialText(searchInitialText) {
+    this.searchInitialText = searchInitialText;
+  }
+
   changeRowEditing(rowData, mode) {
     if (rowData) {
       rowData.tableData.editing = mode;
@@ -474,6 +478,7 @@ export default class DataManager {
       pageSize: this.pageSize,
       renderData: this.pagedData,
       searchText: this.searchText,
+      searchInitialText: this.searchInitialText,
       selectedCount: this.selectedCount,
       treefiedDataLength: this.treefiedDataLength,
       treeDataMaxLevel: this.treeDataMaxLevel


### PR DESCRIPTION
## Related Issue
#725 

## Description
This PR enables passing an initial search value as a prop to `<MaterialTable/>`. This can for example be used to deep link to a search result in the table.

## Impacted Areas in Application
List general components of the application that this PR will affect:

* `data-manager.js` - has a new property carrying the initial search text
* `material-table.js` - needs to pass initial search text from props to data manger and trigger a search right after the component was mounted

## Additional Notes
I would have loved to update the respective documentation, but couldn't find material-table.com sources. If you can point me there, I will be happy to update.