### PR TITLE
Deep selector in column field #1130

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -106,7 +106,7 @@ export interface Column<RowData extends object> {
   editComponent?: ((props: EditComponentProps<RowData>) => React.ReactElement<any>);
   emptyValue?: string | React.ReactElement<any> | ((data: any) => React.ReactElement<any> | string);
   export?: boolean;
-  field?: keyof RowData;
+  field?: keyof RowData | string;
   filtering?: boolean;
   filterPlaceholder?: string;
   filterCellStyle?: React.CSSProperties;


### PR DESCRIPTION
Fix bug where only object keys can be used as "field" value.
Now should be possible to use field "a.b.c.d" for find key "a" in row and key "b" inside "a", ...

## Related Issue
#1130 