### PR TITLE
Add approve to edit Component

### DIFF
--- a/src/components/m-table-edit-row.js
+++ b/src/components/m-table-edit-row.js
@@ -16,13 +16,14 @@ export default class MTableEditRow extends React.Component {
     this.state = {
       data: props.data ? JSON.parse(JSON.stringify(props.data)) : this.createRowData()
     };
+    this.approveEdit = this.approveEdit.bind(this);
   }
 
-  createRowData(){
-    return this.props.columns.filter(column=>column.initialEditValue && column.field).reduce((prev,column)=>{
-      prev[column.field]=column.initialEditValue;
+  createRowData() {
+    return this.props.columns.filter(column => column.initialEditValue && column.field).reduce((prev, column) => {
+      prev[column.field] = column.initialEditValue;
       return prev;
-    },{});
+    }, {});
   }
 
   renderColumns() {
@@ -49,8 +50,8 @@ export default class MTableEditRow extends React.Component {
         if (columnDef.editable === 'onUpdate' && this.props.mode === 'update') {
           allowEditing = true;
         }
-        if (typeof columnDef.editable == 'function'){
-            allowEditing = columnDef.editable(columnDef, this.props.data);
+        if (typeof columnDef.editable == 'function') {
+          allowEditing = columnDef.editable(columnDef, this.props.data);
         }
         if (!columnDef.field || !allowEditing) {
           const readonlyValue = this.props.getFieldValue(this.state.data, columnDef);
@@ -76,6 +77,7 @@ export default class MTableEditRow extends React.Component {
                 key={columnDef.tableData.id}
                 columnDef={cellProps}
                 value={value}
+                approve={this.props.components.EditField ? this.approveEdit : undefined}
                 rowData={this.state.data}
                 onChange={value => {
                   const data = { ...this.state.data };
@@ -100,11 +102,7 @@ export default class MTableEditRow extends React.Component {
       {
         icon: this.props.icons.Check,
         tooltip: localization.saveTooltip,
-        onClick: () => {
-          const newData = this.state.data;
-          delete newData.tableData;
-          this.props.onEditingApproved(this.props.mode, this.state.data, this.props.data);
-        }
+        onClick: this.approveEdit
       },
       {
         icon: this.props.icons.Clear,
@@ -121,6 +119,12 @@ export default class MTableEditRow extends React.Component {
         </div>
       </TableCell>
     );
+  }
+
+  approveEdit() {
+    const newData = this.state.data;
+    delete newData.tableData;
+    this.props.onEditingApproved(this.props.mode, this.state.data, this.props.data);
   }
 
   getStyle() {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -23,10 +23,10 @@ export interface MaterialTableProps<RowData extends object> {
   localization?: Localization;
   onChangeRowsPerPage?: (pageSize: number) => void;
   onChangePage?: (page: number) => void;
-  onChangeColumnHidden?: (column:Column<RowData>, hidden:boolean) => void;
+  onChangeColumnHidden?: (column: Column<RowData>, hidden: boolean) => void;
   onColumnDragged?: (sourceIndex: number, destinationIndex: number) => void;
   onOrderChange?: (orderBy: number, orderDirection: ("asc" | "desc")) => void;
-  onGroupRemoved?: (column:Column<RowData>, index:boolean) => void;
+  onGroupRemoved?: (column: Column<RowData>, index: boolean) => void;
   onRowClick?: (event?: React.MouseEvent, rowData?: RowData, toggleDetailPanel?: (panelIndex?: number) => void) => void;
   onRowSelected?: (rowData: RowData) => void;
   onSearchChange?: (searchText: string) => void;
@@ -77,9 +77,10 @@ export interface Action<RowData extends object> {
 
 export interface EditComponentProps<RowData extends object> {
   rowData: RowData;
-  value: any,
-  onChange: (newValue: any) => void,
-  columnDef: EditCellColumnDef,
+  value: any;
+  onChange: (newValue: any) => void;
+  columnDef: EditCellColumnDef;
+  approve: () => void;
 }
 
 export interface EditCellColumnDef {
@@ -271,4 +272,4 @@ export interface Localization {
   };
 }
 
-export default class MaterialTable<RowData extends object> extends React.Component<MaterialTableProps<RowData>> {}
+export default class MaterialTable<RowData extends object> extends React.Component<MaterialTableProps<RowData>> { }


### PR DESCRIPTION
## Related Issue
[Issuse](https://stackoverflow.com/questions/58099237/add-new-row-with-a-key-press-like-enter)

## Description
This PR adds the approve function to the column editComponent props so that the the developer can execute the approving of an edit manually or on a certain key hit. For example on enter.

The props of editComponent not contain the approveEdit function, which triggers `onEditingApproved`

## Impacted Areas in Application
* Edit Row
