### PR TITLE
Add locale to datepicker

### DIFF
--- a/src/components/m-table-body.js
+++ b/src/components/m-table-body.js
@@ -47,7 +47,7 @@ class MTableBody extends React.Component {
             components={this.props.components}
             data={data}
             icons={this.props.icons}
-            localization={{ ...MTableBody.defaultProps.localization.editRow, ...this.props.localization.editRow }}
+            localization={{ ...MTableBody.defaultProps.localization.editRow, ...this.props.localization.editRow, dateTimePickerLocalization: this.props.localization.dateTimePickerLocalization }}
             key={index}
             mode={data.tableData.editing}
             options={this.props.options}

--- a/src/components/m-table-body.js
+++ b/src/components/m-table-body.js
@@ -47,7 +47,7 @@ class MTableBody extends React.Component {
             components={this.props.components}
             data={data}
             icons={this.props.icons}
-            localization={{ ...MTableBody.defaultProps.localization.editRow, ...this.props.localization.editRow, locale: this.props.localization.locale }}
+            localization={{ ...MTableBody.defaultProps.localization.editRow, ...this.props.localization.editRow, dateTimePickerLocalization: this.props.localization.dateTimePickerLocalization }}
             key={index}
             mode={data.tableData.editing}
             options={this.props.options}

--- a/src/components/m-table-body.js
+++ b/src/components/m-table-body.js
@@ -140,7 +140,7 @@ class MTableBody extends React.Component {
             actionsColumnIndex={this.props.options.actionsColumnIndex}
             onFilterChanged={this.props.onFilterChanged}
             selection={this.props.options.selection}
-            localization={{ ...MTableBody.defaultProps.localization.filterRow, ...this.props.localization.filterRow, locale: this.props.localization.locale }}
+            localization={{ ...MTableBody.defaultProps.localization.filterRow, ...this.props.localization.filterRow, dateTimePickerLocalization: this.props.localization.dateTimePickerLocalization }}
             hasDetailPanel={!!this.props.detailPanel}
             isTreeData={this.props.isTreeData}
             filterCellStyle={this.props.options.filterCellStyle}

--- a/src/components/m-table-body.js
+++ b/src/components/m-table-body.js
@@ -47,7 +47,7 @@ class MTableBody extends React.Component {
             components={this.props.components}
             data={data}
             icons={this.props.icons}
-            localization={{ ...MTableBody.defaultProps.localization.editRow, ...this.props.localization.editRow }}
+            localization={{ ...MTableBody.defaultProps.localization.editRow, ...this.props.localization.editRow, locale: this.props.localization.locale }}
             key={index}
             mode={data.tableData.editing}
             options={this.props.options}
@@ -140,7 +140,7 @@ class MTableBody extends React.Component {
             actionsColumnIndex={this.props.options.actionsColumnIndex}
             onFilterChanged={this.props.onFilterChanged}
             selection={this.props.options.selection}
-            localization={{ ...MTableBody.defaultProps.localization.filterRow, ...this.props.localization.filterRow }}
+            localization={{ ...MTableBody.defaultProps.localization.filterRow, ...this.props.localization.filterRow, locale: this.props.localization.locale }}
             hasDetailPanel={!!this.props.detailPanel}
             isTreeData={this.props.isTreeData}
             filterCellStyle={this.props.options.filterCellStyle}

--- a/src/components/m-table-body.js
+++ b/src/components/m-table-body.js
@@ -46,7 +46,7 @@ class MTableBody extends React.Component {
             columns={this.props.columns.filter(columnDef => { return !columnDef.hidden })}
             components={this.props.components}
             data={data}
-            icons={this.props.icons}            
+            icons={this.props.icons}
             localization={{ ...MTableBody.defaultProps.localization.editRow, ...this.props.localization.editRow }}
             key={index}
             mode={data.tableData.editing}

--- a/src/components/m-table-body.js
+++ b/src/components/m-table-body.js
@@ -46,8 +46,8 @@ class MTableBody extends React.Component {
             columns={this.props.columns.filter(columnDef => { return !columnDef.hidden })}
             components={this.props.components}
             data={data}
-            icons={this.props.icons}
-            localization={{ ...MTableBody.defaultProps.localization.editRow, ...this.props.localization.editRow, dateTimePickerLocalization: this.props.localization.dateTimePickerLocalization }}
+            icons={this.props.icons}            
+            localization={{ ...MTableBody.defaultProps.localization.editRow, ...this.props.localization.editRow }}
             key={index}
             mode={data.tableData.editing}
             options={this.props.options}

--- a/src/components/m-table-edit-field.js
+++ b/src/components/m-table-edit-field.js
@@ -9,7 +9,7 @@ import PropTypes from 'prop-types';
 
 class MTableEditField extends React.Component {
   getProps() {
-    const { columnDef, rowData, onRowDataChange,  ...props } = this.props;
+    const { columnDef, rowData, onRowDataChange, ...props } = this.props;
     return props;
   }
 
@@ -49,7 +49,8 @@ class MTableEditField extends React.Component {
 
   renderDateField() {
     return (
-      <MuiPickersUtilsProvider utils={DateFnsUtils}>
+      <MuiPickersUtilsProvider utils={DateFnsUtils}
+        locale={this.props.locale}>
         <DatePicker
           {...this.getProps()}
           format="dd.MM.yyyy"
@@ -65,10 +66,11 @@ class MTableEditField extends React.Component {
       </MuiPickersUtilsProvider>
     );
   }
-
   renderTimeField() {
     return (
-      <MuiPickersUtilsProvider utils={DateFnsUtils}>
+      <MuiPickersUtilsProvider
+        utils={DateFnsUtils}
+        locale={this.props.locale}>
         <TimePicker
           {...this.getProps()}
           format="HH:mm:ss"
@@ -87,7 +89,8 @@ class MTableEditField extends React.Component {
 
   renderDateTimeField() {
     return (
-      <MuiPickersUtilsProvider utils={DateFnsUtils}>
+      <MuiPickersUtilsProvider utils={DateFnsUtils}
+        locale={this.props.locale}>
         <DateTimePicker
           {...this.getProps()}
           format="dd.MM.yyyy HH:mm:ss"
@@ -159,7 +162,8 @@ class MTableEditField extends React.Component {
 MTableEditField.propTypes = {
   value: PropTypes.any,
   onChange: PropTypes.func.isRequired,
-  columnDef: PropTypes.object.isRequired
+  columnDef: PropTypes.object.isRequired,
+  locale: PropTypes.object
 };
 
 export default MTableEditField;

--- a/src/components/m-table-edit-field.js
+++ b/src/components/m-table-edit-field.js
@@ -50,7 +50,7 @@ class MTableEditField extends React.Component {
   renderDateField() {
     return (
       <MuiPickersUtilsProvider utils={DateFnsUtils}
-        locale={this.props.locale}>
+        locale={this.props.dateTimePickerLocalization}>
         <DatePicker
           {...this.getProps()}
           format="dd.MM.yyyy"
@@ -70,7 +70,7 @@ class MTableEditField extends React.Component {
     return (
       <MuiPickersUtilsProvider
         utils={DateFnsUtils}
-        locale={this.props.locale}>
+        locale={this.props.dateTimePickerLocalization}>
         <TimePicker
           {...this.getProps()}
           format="HH:mm:ss"
@@ -90,7 +90,7 @@ class MTableEditField extends React.Component {
   renderDateTimeField() {
     return (
       <MuiPickersUtilsProvider utils={DateFnsUtils}
-        locale={this.props.locale}>
+        locale={this.props.dateTimePickerLocalization}>
         <DateTimePicker
           {...this.getProps()}
           format="dd.MM.yyyy HH:mm:ss"
@@ -163,7 +163,7 @@ MTableEditField.propTypes = {
   value: PropTypes.any,
   onChange: PropTypes.func.isRequired,
   columnDef: PropTypes.object.isRequired,
-  locale: PropTypes.object
+  dateTimePickerLocalization: PropTypes.object
 };
 
 export default MTableEditField;

--- a/src/components/m-table-edit-row.js
+++ b/src/components/m-table-edit-row.js
@@ -76,7 +76,7 @@ export default class MTableEditRow extends React.Component {
                 key={columnDef.tableData.id}
                 columnDef={cellProps}
                 value={value}
-                locale={this.props.localization.locale}
+                locale={this.props.localization.dateTimePickerLocalization}
                 rowData={this.state.data}
                 onChange={value => {
                   const data = { ...this.state.data };

--- a/src/components/m-table-edit-row.js
+++ b/src/components/m-table-edit-row.js
@@ -76,6 +76,7 @@ export default class MTableEditRow extends React.Component {
                 key={columnDef.tableData.id}
                 columnDef={cellProps}
                 value={value}
+                locale={this.props.localization.locale}
                 rowData={this.state.data}
                 onChange={value => {
                   const data = { ...this.state.data };
@@ -134,7 +135,6 @@ export default class MTableEditRow extends React.Component {
 
   render() {
     const localization = { ...MTableEditRow.defaultProps.localization, ...this.props.localization };
-
     let columns;
     if (this.props.mode === "add" || this.props.mode === "update") {
       columns = this.renderColumns();

--- a/src/components/m-table-filter-row.js
+++ b/src/components/m-table-filter-row.js
@@ -126,7 +126,7 @@ class MTableFilterRow extends React.Component {
     return (
       <MuiPickersUtilsProvider
         utils={DateFnsUtils}
-        locale={this.props.localization.locale}>
+        locale={this.props.localization.dateTimePickerLocalization}>
         {dateInputElement}
       </MuiPickersUtilsProvider>
     );

--- a/src/components/m-table-filter-row.js
+++ b/src/components/m-table-filter-row.js
@@ -98,7 +98,6 @@ class MTableFilterRow extends React.Component {
   renderDateTypeFilter = (columnDef) => {
     let dateInputElement = null;
     const onDateInputChange = date => this.props.onFilterChanged(columnDef.tableData.id, date);
-
     if (columnDef.type === 'date') {
       dateInputElement = (
         <DatePicker
@@ -124,9 +123,10 @@ class MTableFilterRow extends React.Component {
         />
       );
     }
-
     return (
-      <MuiPickersUtilsProvider utils={DateFnsUtils}>
+      <MuiPickersUtilsProvider
+        utils={DateFnsUtils}
+        locale={this.props.localization.locale}>
         {dateInputElement}
       </MuiPickersUtilsProvider>
     );
@@ -161,9 +161,9 @@ class MTableFilterRow extends React.Component {
       ));
 
     if (this.props.selection) {
-      columns.splice(0, 0, <TableCell padding="none" key="key-selection-column"/>);
+      columns.splice(0, 0, <TableCell padding="none" key="key-selection-column" />);
     }
-    
+
     if (this.props.emptyCell && this.props.hasActions) {
       if (this.props.actionsColumnIndex === -1) {
         columns.push(<TableCell key="key-action-column" />);

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -225,7 +225,7 @@ export interface Options {
 
 export interface Localization {
   body?: {
-    locale?: object; // The date-fns locale object applied to the datepickers
+    dateTimePickerLocalization?: object; // The date-fns locale object applied to the datepickers
     emptyDataSourceMessage?: string;
     filterRow?: {
       filterTooltip?: string;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -225,6 +225,7 @@ export interface Options {
 
 export interface Localization {
   body?: {
+    locale?: object; // The date-fns locale object applied to the datepickers
     emptyDataSourceMessage?: string;
     filterRow?: {
       filterTooltip?: string;


### PR DESCRIPTION

## Related Issue
#1129 

## Description
This adds a localisation prop to pass a date-fns locale object within the body to enable datepicker localisation.
Like this: 
` import frLocale from 'date-fns/locale/fr';`
...

`localisation={{body: {locale: frLocale }}}`

This will result in a french datepicker.

![image](https://user-images.githubusercontent.com/17567991/65963335-d7c96380-e45a-11e9-98f6-612456c0f250.png)


## Impacted Areas in Application
List general components of the application that this PR will affect:

* Body
* Edit Field
* Edit Row
* Filter Row
* index.d.ts
