### PR TITLE
Fixe bug where onChangeColumnHidden is called twice when clicking label

### DIFF
--- a/src/components/m-table-toolbar.js
+++ b/src/components/m-table-toolbar.js
@@ -96,6 +96,8 @@ export class MTableToolbar extends React.Component {
 
   renderDefaultActions() {
     const localization = { ...MTableToolbar.defaultProps.localization, ...this.props.localization };
+    const {classes} = this.props;
+
     return (
       <div>
         {this.props.columnsButton &&
@@ -119,14 +121,21 @@ export class MTableToolbar extends React.Component {
               {
                 this.props.columns.map((col) => {
                   return (
-                    <MenuItem key={col.tableData.id} disabled={col.removable === false}
-                      onClick={() => this.props.onColumnsChanged(col, !col.hidden)}
-                    >
-                      <FormControlLabel
-                        label={col.title}
-                        control={<Checkbox checked={!col.hidden} />}
-                      />
-                    </MenuItem>
+                    <li key={col.tableData.id}>
+                      <MenuItem
+                        className={classes.formControlLabel}
+                        component="label"
+                        htmlFor={`column-toggle-${col.tableData.id}`}
+                        disabled={col.removable === false}
+                      >
+                        <Checkbox
+                          checked={!col.hidden}
+                          id={`column-toggle-${col.tableData.id}`}
+                          onChange={() => this.props.onColumnsChanged(col, !col.hidden)}
+                        />
+                        <span>{col.title}</span>
+                      </MenuItem>
+                    </li>
                   );
                 })
               }
@@ -282,6 +291,10 @@ export const styles = theme => ({
   },
   searchField: {
     paddingLeft: theme.spacing(2)
+  },
+  formControlLabel: {
+    paddingLeft: theme.spacing(1),
+    paddingRight: theme.spacing(1),
   }
 });
 


### PR DESCRIPTION
## Related Issue
Didn't find any issue with this.

## Description
Prevents `onChangeColumnHidden` callback from being triggered twice as a result of having a label with checkbox inside a container with a click listener.

## Impacted Areas in Application

* Toolbar
* Actions (Column toggler)

## Additional Notes

When having a click listener on a container and label + checkbox as children the event listener will be called twice when clicking the label. Once for the direct listener itself, and another time for the label causing the checkbox to change, triggering an `onClick` and the event bubbling up to the parent.

Ideally, the checkbox should have the listener (as an interactive element) and label can be used as a button with larger click area. This PR updates the structure and fixes this issue.

See reduced and reproduced issue with an explanation here: https://codesandbox.io/s/gifted-monad-4zod5


Edit: Found an existing PR on this after creating it:

## Related PRs

branch | PR
------ | ------
`Paktusin:fix-render-column-click` #1059 | [link](https://github.com/mbrn/material-table/pull/1059)

But the existing PR is kind of doing a workaround from the existing problem. It also reduces the semantic value in the process. I think this PR should be preferred, but I'll confer with the author of the original PR.