### PR TITLE
Add position field to action

### DIFF
--- a/src/components/m-table-action.js
+++ b/src/components/m-table-action.js
@@ -16,6 +16,13 @@ class MTableAction extends React.Component {
       }
     }
 
+    if (action.action) {
+      action = action.action(this.props.data);
+      if (!action) {
+        return null;
+      }
+    }
+
     if (action.hidden) {
       return null;
     }

--- a/src/components/m-table-action.js
+++ b/src/components/m-table-action.js
@@ -16,13 +16,6 @@ class MTableAction extends React.Component {
       }
     }
 
-    if (action.action) {
-      action = action.action(this.props.data);
-      if (!action) {
-        return null;
-      }
-    }
-
     if (action.hidden) {
       return null;
     }

--- a/src/components/m-table-action.js
+++ b/src/components/m-table-action.js
@@ -16,6 +16,13 @@ class MTableAction extends React.Component {
       }
     }
 
+    if (action.action) {
+      action = action.action(this.props.data);
+      if (!action) {
+        return null;
+      }
+    }
+    
     if (action.hidden) {
       return null;
     }

--- a/src/components/m-table-body-row.js
+++ b/src/components/m-table-body-row.js
@@ -34,9 +34,7 @@ export default class MTableBodyRow extends React.Component {
   renderActions() {
     const size = this.getElementSize();
     const baseIconSize = size === 'medium' ? 42 : 26;
-    const actions = this.props.options.selection
-      ? this.props.actions.filter(a => a.position === "row")
-      : this.props.actions.filter(a => !a.isFreeAction || a.position === "auto" || a.position === "row");
+    const actions = this.props.actions.filter(a => a.position === "row");
     return (
       <TableCell size={size} padding="none" key="key-actions-column" style={{ width: baseIconSize * actions.length, padding: '0px 5px', ...this.props.options.actionsCellStyle }}>
         <div style={{ display: 'flex' }}>
@@ -192,9 +190,7 @@ export default class MTableBodyRow extends React.Component {
     if (this.props.options.selection) {
       renderColumns.splice(0, 0, this.renderSelectionColumn());
     }
-    if (this.props.actions && this.props.options.selection
-        ? this.props.actions.filter(a => a.position === "row").length > 0
-        : this.props.actions.filter(a => !a.isFreeAction || a.position === "auto" || a.position === "row").length > 0) {
+    if (this.props.actions && this.props.actions.filter(a => a.position === "row").length > 0) {
       if (this.props.options.actionsColumnIndex === -1) {
         renderColumns.push(this.renderActions());
       } else if (this.props.options.actionsColumnIndex >= 0) {

--- a/src/components/m-table-body-row.js
+++ b/src/components/m-table-body-row.js
@@ -34,7 +34,9 @@ export default class MTableBodyRow extends React.Component {
   renderActions() {
     const size = this.getElementSize();
     const baseIconSize = size === 'medium' ? 42 : 26;
-    const actions = this.props.actions.filter(a => !a.isFreeAction && !this.props.options.selection);
+    const actions = this.props.options.selection
+      ? this.props.actions.filter(a => a.position === "row")
+      : this.props.actions.filter(a => !a.isFreeAction || a.position === "auto" || a.position === "row");
     return (
       <TableCell size={size} padding="none" key="key-actions-column" style={{ width: baseIconSize * actions.length, padding: '0px 5px', ...this.props.options.actionsCellStyle }}>
         <div style={{ display: 'flex' }}>
@@ -190,7 +192,9 @@ export default class MTableBodyRow extends React.Component {
     if (this.props.options.selection) {
       renderColumns.splice(0, 0, this.renderSelectionColumn());
     }
-    if (this.props.actions && this.props.actions.filter(a => !a.isFreeAction && !this.props.options.selection).length > 0) {
+    if (this.props.actions && this.props.options.selection
+        ? this.props.actions.filter(a => a.position === "row").length > 0
+        : this.props.actions.filter(a => !a.isFreeAction || a.position === "auto" || a.position === "row").length > 0) {
       if (this.props.options.actionsColumnIndex === -1) {
         renderColumns.push(this.renderActions());
       } else if (this.props.options.actionsColumnIndex >= 0) {

--- a/src/components/m-table-body.js
+++ b/src/components/m-table-body.js
@@ -12,7 +12,12 @@ class MTableBody extends React.Component {
     const localization = { ...MTableBody.defaultProps.localization, ...this.props.localization };
     if (this.props.options.showEmptyDataSourceMessage && renderData.length === 0) {
       let addColumn = 0;
-      if (this.props.options.selection || (this.props.actions && this.props.actions.filter(a => !a.isFreeAction && !this.props.options.selection).length > 0)) {
+      if (this.props.options.selection) {
+        addColumn++;
+      }
+      if (this.props.actions && this.props.options.selection
+        ? this.props.actions.filter(a => a.position === "row").length > 0
+        : this.props.actions.filter(a => !a.isFreeAction || a.position === "auto" || a.position === "row").length > 0) {
         addColumn++;
       }
       if (this.props.hasDetailPanel) {
@@ -129,14 +134,18 @@ class MTableBody extends React.Component {
     if (this.props.options.paging) {
       emptyRowCount = this.props.pageSize - renderData.length;
     }
+
+    let hasActions = this.props.actions && this.props.options.selection
+      ? this.props.actions.filter(a => a.position === "row").length > 0
+      : this.props.actions.filter(a => !a.isFreeAction || a.position === "auto" || a.position === "row").length > 0;
+
     return (
       <TableBody>
         {this.props.options.filtering &&
           <this.props.components.FilterRow
             columns={this.props.columns.filter(columnDef => { return !columnDef.hidden })}
             icons={this.props.icons}
-            emptyCell={this.props.options.selection || (this.props.actions && this.props.actions.filter(a => !a.isFreeAction && !this.props.options.selection).length > 0)}
-            hasActions={(this.props.actions && this.props.actions.filter(a => !a.isFreeAction && !this.props.options.selection).length > 0)}
+            hasActions={hasActions}
             actionsColumnIndex={this.props.options.actionsColumnIndex}
             onFilterChanged={this.props.onFilterChanged}
             selection={this.props.options.selection}

--- a/src/components/m-table-body.js
+++ b/src/components/m-table-body.js
@@ -15,9 +15,7 @@ class MTableBody extends React.Component {
       if (this.props.options.selection) {
         addColumn++;
       }
-      if (this.props.actions && this.props.options.selection
-        ? this.props.actions.filter(a => a.position === "row").length > 0
-        : this.props.actions.filter(a => !a.isFreeAction || a.position === "auto" || a.position === "row").length > 0) {
+      if (this.props.actions && this.props.actions.filter(a => a.position === "row").length > 0) {
         addColumn++;
       }
       if (this.props.hasDetailPanel) {
@@ -135,17 +133,13 @@ class MTableBody extends React.Component {
       emptyRowCount = this.props.pageSize - renderData.length;
     }
 
-    let hasActions = this.props.actions && this.props.options.selection
-      ? this.props.actions.filter(a => a.position === "row").length > 0
-      : this.props.actions.filter(a => !a.isFreeAction || a.position === "auto" || a.position === "row").length > 0;
-
     return (
       <TableBody>
         {this.props.options.filtering &&
           <this.props.components.FilterRow
             columns={this.props.columns.filter(columnDef => { return !columnDef.hidden })}
             icons={this.props.icons}
-            hasActions={hasActions}
+            hasActions={this.props.actions.filter(a => a.position === "row").length > 0}
             actionsColumnIndex={this.props.options.actionsColumnIndex}
             onFilterChanged={this.props.onFilterChanged}
             selection={this.props.options.selection}

--- a/src/components/m-table-filter-row.js
+++ b/src/components/m-table-filter-row.js
@@ -164,7 +164,7 @@ class MTableFilterRow extends React.Component {
       columns.splice(0, 0, <TableCell padding="none" key="key-selection-column"/>);
     }
     
-    if (this.props.emptyCell && this.props.hasActions) {
+    if (this.props.hasActions) {
       if (this.props.actionsColumnIndex === -1) {
         columns.push(<TableCell key="key-action-column" />);
       } else {
@@ -204,7 +204,6 @@ class MTableFilterRow extends React.Component {
 }
 
 MTableFilterRow.defaultProps = {
-  emptyCell: false,
   columns: [],
   selection: false,
   hasActions: false,
@@ -214,7 +213,6 @@ MTableFilterRow.defaultProps = {
 };
 
 MTableFilterRow.propTypes = {
-  emptyCell: PropTypes.bool,
   columns: PropTypes.array.isRequired,
   hasDetailPanel: PropTypes.bool.isRequired,
   isTreeData: PropTypes.bool.isRequired,

--- a/src/components/m-table-toolbar.js
+++ b/src/components/m-table-toolbar.js
@@ -156,7 +156,7 @@ export class MTableToolbar extends React.Component {
 
         }
         <span>
-          <this.props.components.Actions actions={this.props.actions && this.props.actions.filter(a => a.isFreeAction || a.position === "toolbar")} components={this.props.components} />
+          <this.props.components.Actions actions={this.props.actions && this.props.actions.filter(a => a.position === "toolbar")} components={this.props.components} />
         </span>
       </div>
     );
@@ -165,7 +165,7 @@ export class MTableToolbar extends React.Component {
   renderSelectedActions() {
     return (
       <React.Fragment>
-        <this.props.components.Actions actions={this.props.actions.filter(a => !a.isFreeAction || a.position === "toolbarOnSelect" || a.position === "auto")} data={this.props.selectedRows} components={this.props.components} />
+        <this.props.components.Actions actions={this.props.actions.filter(a => a.position === "toolbarOnSelect")} data={this.props.selectedRows} components={this.props.components} />
       </React.Fragment>
     );
   }

--- a/src/components/m-table-toolbar.js
+++ b/src/components/m-table-toolbar.js
@@ -156,7 +156,7 @@ export class MTableToolbar extends React.Component {
 
         }
         <span>
-          <this.props.components.Actions actions={this.props.actions && this.props.actions.filter(a => a.isFreeAction)} components={this.props.components} />
+          <this.props.components.Actions actions={this.props.actions && this.props.actions.filter(a => a.isFreeAction || a.position === "toolbar")} components={this.props.components} />
         </span>
       </div>
     );
@@ -165,7 +165,7 @@ export class MTableToolbar extends React.Component {
   renderSelectedActions() {
     return (
       <React.Fragment>
-        <this.props.components.Actions actions={this.props.actions.filter(a => !a.isFreeAction)} data={this.props.selectedRows} components={this.props.components} />
+        <this.props.components.Actions actions={this.props.actions.filter(a => !a.isFreeAction || a.position === "toolbarOnSelect" || a.position === "auto")} data={this.props.selectedRows} components={this.props.components} />
       </React.Fragment>
     );
   }

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -108,7 +108,7 @@ export default class MaterialTable extends React.Component {
     calculatedProps.actions = [...(calculatedProps.actions || [])];
 
     if (calculatedProps.options.selection)
-      calculatedProps.actions = calculatedProps.actions.map(action => {
+      calculatedProps.actions = calculatedProps.actions.filter(a => a).map(action => {
         if (
           (action.position === "auto") ||
           (action.isFreeAction === false) ||
@@ -120,7 +120,7 @@ export default class MaterialTable extends React.Component {
         else return action;
       });
     else
-      calculatedProps.actions = calculatedProps.actions.map(action => {
+      calculatedProps.actions = calculatedProps.actions.filter(a => a).map(action => {
         if (
           (action.position === "auto") ||
           (action.isFreeAction === false) ||

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -106,6 +106,32 @@ export default class MaterialTable extends React.Component {
     const localization = calculatedProps.localization.body;
 
     calculatedProps.actions = [...(calculatedProps.actions || [])];
+
+    if (props.selection)
+      calculatedProps.actions.map(action => {
+        if (
+          (action.position === "auto") ||
+          (action.isFreeAction === false) ||
+          (action.position === undefined && action.isFreeAction === undefined)
+        )
+          return { ...action, position: "toolbarOnSelect" };
+        else if (action.isFreeAction)
+          return { ...action, position: "toolbar" };
+        else return action;
+      });
+    else
+      calculatedProps.actions.map(action => {
+        if (
+          (action.position === "auto") ||
+          (action.isFreeAction === false) ||
+          (action.position === undefined && action.isFreeAction === undefined)
+        )
+          return { ...action, position: "row" };
+        else if (action.isFreeAction)
+          return { ...action, position: "toolbar" };
+        else return action;
+      });
+    
     if (calculatedProps.editable) {
       if (calculatedProps.editable.onRowAdd) {
         calculatedProps.actions.push({
@@ -529,11 +555,7 @@ export default class MaterialTable extends React.Component {
                           dataCount={props.parentChildData ? this.state.treefiedDataLength : this.state.data.length}
                           hasDetailPanel={!!props.detailPanel}
                           detailPanelColumnAlignment={props.options.detailPanelColumnAlignment}
-                          showActionsColumn={
-                            props.actions && this.props.options.selection
-                              ? props.actions.filter(a => a.position === "row").length > 0
-                              : props.actions.filter(a => !a.isFreeAction || a.position === "auto" || a.position === "row").length > 0
-                          }
+                          showActionsColumn={props.actions && props.actions.filter(a => a.position === "row").length > 0}
                           showSelectAllCheckbox={props.options.showSelectAllCheckbox}
                           orderBy={this.state.orderBy}
                           orderDirection={this.state.orderDirection}

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -107,7 +107,7 @@ export default class MaterialTable extends React.Component {
 
     calculatedProps.actions = [...(calculatedProps.actions || [])];
 
-    if (props.selection)
+    if (calculatedProps.options.selection)
       calculatedProps.actions.map(action => {
         if (
           (action.position === "auto") ||

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -114,9 +114,11 @@ export default class MaterialTable extends React.Component {
           (action.isFreeAction === false) ||
           (action.position === undefined && action.isFreeAction === undefined)
         )
-          return { ...action, position: "toolbarOnSelect" };
+          if (typeof action === "function") return { action: action, position: "toolbarOnSelect" };
+          else return { ...action, position: "toolbarOnSelect" };
         else if (action.isFreeAction)
-          return { ...action, position: "toolbar" };
+          if (typeof action === "function") return { action: action, position: "toolbar" };
+          else return { ...action, position: "toolbar" };
         else return action;
       });
     else
@@ -126,9 +128,11 @@ export default class MaterialTable extends React.Component {
           (action.isFreeAction === false) ||
           (action.position === undefined && action.isFreeAction === undefined)
         )
-          return { ...action, position: "row" };
+          if (typeof action === "function") return { action: action, position: "row" };
+          else return { ...action, position: "row" };
         else if (action.isFreeAction)
-          return { ...action, position: "toolbar" };
+          if (typeof action === "function") return { action: action, position: "toolbar" };
+          else return { ...action, position: "toolbar" };
         else return action;
       });
     

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -108,7 +108,7 @@ export default class MaterialTable extends React.Component {
     calculatedProps.actions = [...(calculatedProps.actions || [])];
 
     if (calculatedProps.options.selection)
-      calculatedProps.actions.map(action => {
+      calculatedProps.actions = calculatedProps.actions.map(action => {
         if (
           (action.position === "auto") ||
           (action.isFreeAction === false) ||
@@ -120,7 +120,7 @@ export default class MaterialTable extends React.Component {
         else return action;
       });
     else
-      calculatedProps.actions.map(action => {
+      calculatedProps.actions = calculatedProps.actions.map(action => {
         if (
           (action.position === "auto") ||
           (action.isFreeAction === false) ||

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -111,7 +111,7 @@ export default class MaterialTable extends React.Component {
         calculatedProps.actions.push({
           icon: calculatedProps.icons.Add,
           tooltip: localization.addTooltip,
-          isFreeAction: true,
+          position: "toolbar",
           onClick: () => {
             this.dataManager.changeRowEditing();
             this.setState({
@@ -529,7 +529,11 @@ export default class MaterialTable extends React.Component {
                           dataCount={props.parentChildData ? this.state.treefiedDataLength : this.state.data.length}
                           hasDetailPanel={!!props.detailPanel}
                           detailPanelColumnAlignment={props.options.detailPanelColumnAlignment}
-                          showActionsColumn={props.actions && props.actions.filter(a => !a.isFreeAction && !this.props.options.selection).length > 0}
+                          showActionsColumn={
+                            props.actions && this.props.options.selection
+                              ? props.actions.filter(a => a.position === "row").length > 0
+                              : props.actions.filter(a => !a.isFreeAction || a.position === "auto" || a.position === "row").length > 0
+                          }
                           showSelectAllCheckbox={props.options.showSelectAllCheckbox}
                           orderBy={this.state.orderBy}
                           orderDirection={this.state.orderDirection}

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -16,7 +16,9 @@ export const propTypes = {
     iconProps: PropTypes.object,
     disabled: PropTypes.bool,
     hidden: PropTypes.bool,
-  })])),
+  }),
+    PropTypes.shape({action: PropTypes.func, position: PropTypes.oneOf(['auto', 'toolbar', 'toolbarOnSelect', 'row'])})
+  ])),
   columns: PropTypes.arrayOf(PropTypes.shape({
     cellStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
     currencySetting: PropTypes.shape({

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -10,6 +10,7 @@ export const propTypes = {
   actions: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.shape({
     icon: PropTypes.oneOfType([PropTypes.element, PropTypes.func, PropTypes.string, RefComponent]).isRequired,
     isFreeAction: PropTypes.bool,
+    position: PropTypes.oneOf(['auto', 'header', 'headerOnSelect', 'row']),
     tooltip: PropTypes.string,
     onClick: PropTypes.func.isRequired,
     iconProps: PropTypes.object,

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -16,9 +16,7 @@ export const propTypes = {
     iconProps: PropTypes.object,
     disabled: PropTypes.bool,
     hidden: PropTypes.bool,
-  }),
-    PropTypes.shape({action: PropTypes.func, position: PropTypes.oneOf(['auto', 'toolbar', 'toolbarOnSelect', 'row'])})
-  ])),
+  })])),
   columns: PropTypes.arrayOf(PropTypes.shape({
     cellStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
     currencySetting: PropTypes.shape({

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -10,7 +10,7 @@ export const propTypes = {
   actions: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.shape({
     icon: PropTypes.oneOfType([PropTypes.element, PropTypes.func, PropTypes.string, RefComponent]).isRequired,
     isFreeAction: PropTypes.bool,
-    position: PropTypes.oneOf(['auto', 'header', 'headerOnSelect', 'row']),
+    position: PropTypes.oneOf(['auto', 'toolbar', 'toolbarOnSelect', 'row']),
     tooltip: PropTypes.string,
     onClick: PropTypes.func.isRequired,
     iconProps: PropTypes.object,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -69,7 +69,7 @@ export interface Action<RowData extends object> {
   disabled?: boolean;
   icon: string | (() => React.ReactElement<any>);
   isFreeAction?: boolean;
-  position?: 'auto' | 'header' | 'headerOnSelect' | 'row';
+  position?: 'auto' | 'toolbar' | 'toolbarOnSelect' | 'row';
   tooltip?: string;
   onClick: (event: any, data: RowData | RowData[]) => void;
   iconProps?: IconProps;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -3,7 +3,7 @@ import { IconProps } from '@material-ui/core/Icon';
 import { string } from 'prop-types';
 
 export interface MaterialTableProps<RowData extends object> {
-  actions?: (Action<RowData> | FunctionalAction | ((rowData: RowData) => Action<RowData>))[];
+  actions?: (Action<RowData> | ((rowData: RowData) => Action<RowData>))[];
   columns: Column<RowData>[];
   components?: Components;
   data: RowData[] | ((query: Query<RowData>) => Promise<QueryResult<RowData>>);
@@ -74,11 +74,6 @@ export interface Action<RowData extends object> {
   onClick: (event: any, data: RowData | RowData[]) => void;
   iconProps?: IconProps;
   hidden?: boolean;
-}
-
-export interface FunctionalAction<RowData extends object> {
-  action: ((rowData: RowData) => Action<RowData>)
-  position?: 'auto' | 'toolbar' | 'toolbarOnSelect' | 'row';
 }
 
 export interface EditComponentProps<RowData extends object> {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -3,7 +3,7 @@ import { IconProps } from '@material-ui/core/Icon';
 import { string } from 'prop-types';
 
 export interface MaterialTableProps<RowData extends object> {
-  actions?: (Action<RowData> | ((rowData: RowData) => Action<RowData>))[];
+  actions?: (Action<RowData> | FunctionalAction | ((rowData: RowData) => Action<RowData>))[];
   columns: Column<RowData>[];
   components?: Components;
   data: RowData[] | ((query: Query<RowData>) => Promise<QueryResult<RowData>>);
@@ -74,6 +74,11 @@ export interface Action<RowData extends object> {
   onClick: (event: any, data: RowData | RowData[]) => void;
   iconProps?: IconProps;
   hidden?: boolean;
+}
+
+export interface FunctionalAction<RowData extends object> {
+  action: ((rowData: RowData) => Action<RowData>)
+  position?: 'auto' | 'toolbar' | 'toolbarOnSelect' | 'row';
 }
 
 export interface EditComponentProps<RowData extends object> {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -69,6 +69,7 @@ export interface Action<RowData extends object> {
   disabled?: boolean;
   icon: string | (() => React.ReactElement<any>);
   isFreeAction?: boolean;
+  position?: 'auto' | 'header' | 'headerOnSelect' | 'row';
   tooltip?: string;
   onClick: (event: any, data: RowData | RowData[]) => void;
   iconProps?: IconProps;


### PR DESCRIPTION
## Related Issue
#676 

## Description

### Can now show action on row while `option.select === true`
Implements idea 2 of https://github.com/mbrn/material-table/issues/676#issuecomment-502665435
> I really appreciate your work on Material Table. I've started using it heavily and looking forward to contributing.
> 
> Could lend a hand on implementing this, I think.
> 
> As I understand it there's three types of actions currently:
> 
> 1. `isFreeAction` top bar action
> 2. Top bar action _when rows are selected_
> 3. Actions on rows
> 
> The type of 2 and 3 are currently implicitly defined based on if it's a selectable table. (Please correct me if I'm wrong or missed something)
> 
> I would propose one or these two approaches (backwards-compatible with just deprecating the old API):
> 
> 1. Move row actions to `columns[]`. Would make it very explicit what is where.
> 2. Explicit `position`-prop in the `actions[]` array with 4 options + deprecate `isFreeAction`
>    
>    1. `auto` (default) - existing behaviour (it can figure out the one of the below)
>    2. `header`
>    3. `headerOnSelect` - Show when a row is selected
>    4. `row`

Specifically 
> 2. Explicit `position`-prop in the `actions[]` array with 4 options + deprecate `isFreeAction`
>    
>    1. `auto` (default) - existing behaviour (it can figure out the one of the below)
>    2. `header`
>    3. `headerOnSelect` - Show when a row is selected
>    4. `row`

## Impacted Areas in Application
List general components of the application that this PR will affect:
Actions
Toolbar
Row
Filter
