### PR TITLE
Add functional action

### DIFF
--- a/src/components/m-table-action.js
+++ b/src/components/m-table-action.js
@@ -16,6 +16,13 @@ class MTableAction extends React.Component {
       }
     }
 
+    if (action.action) {
+      action = action.action(this.props.data);
+      if (!action) {
+        return null;
+      }
+    }
+
     if (action.hidden) {
       return null;
     }

--- a/src/components/m-table-action.js
+++ b/src/components/m-table-action.js
@@ -16,13 +16,6 @@ class MTableAction extends React.Component {
       }
     }
 
-    if (action.action) {
-      action = action.action(this.props.data);
-      if (!action) {
-        return null;
-      }
-    }
-
     if (action.hidden) {
       return null;
     }

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -15,7 +15,9 @@ export const propTypes = {
     iconProps: PropTypes.object,
     disabled: PropTypes.bool,
     hidden: PropTypes.bool,
-  })])),
+  }),
+    PropTypes.shape({action: PropTypes.func, position: PropTypes.oneOf(['auto', 'toolbar', 'toolbarOnSelect', 'row'])})
+  ])),
   columns: PropTypes.arrayOf(PropTypes.shape({
     cellStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
     currencySetting: PropTypes.shape({

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -16,7 +16,7 @@ export const propTypes = {
     disabled: PropTypes.bool,
     hidden: PropTypes.bool,
   }),
-    PropTypes.shape({action: PropTypes.func, position: PropTypes.oneOf(['auto', 'toolbar', 'toolbarOnSelect', 'row'])})
+    PropTypes.shape({action: PropTypes.func.isRequired, position: PropTypes.oneOf(['auto', 'toolbar', 'toolbarOnSelect', 'row'])})
   ])),
   columns: PropTypes.arrayOf(PropTypes.shape({
     cellStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -3,7 +3,7 @@ import { IconProps } from '@material-ui/core/Icon';
 import { string } from 'prop-types';
 
 export interface MaterialTableProps<RowData extends object> {
-  actions?: (Action<RowData> | FunctionalAction | ((rowData: RowData) => Action<RowData>))[];
+  actions?: (Action<RowData> | FunctionalAction<RowData> | ((rowData: RowData) => Action<RowData>))[];
   columns: Column<RowData>[];
   components?: Components;
   data: RowData[] | ((query: Query<RowData>) => Promise<QueryResult<RowData>>);

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -3,7 +3,7 @@ import { IconProps } from '@material-ui/core/Icon';
 import { string } from 'prop-types';
 
 export interface MaterialTableProps<RowData extends object> {
-  actions?: (Action<RowData> | ((rowData: RowData) => Action<RowData>))[];
+  actions?: (Action<RowData> | FunctionalAction | ((rowData: RowData) => Action<RowData>))[];
   columns: Column<RowData>[];
   components?: Components;
   data: RowData[] | ((query: Query<RowData>) => Promise<QueryResult<RowData>>);
@@ -73,6 +73,11 @@ export interface Action<RowData extends object> {
   onClick: (event: any, data: RowData | RowData[]) => void;
   iconProps?: IconProps;
   hidden?: boolean;
+}
+
+export interface FunctionalAction<RowData extends object> {
+  action: ((rowData: RowData) => Action<RowData>)
+  position?: 'auto' | 'toolbar' | 'toolbarOnSelect' | 'row';
 }
 
 export interface EditComponentProps<RowData extends object> {


### PR DESCRIPTION
## Description
After #1156 , I noticed actions that are functions can't indicate their position. This PR adds a new type of action that allows actions to be functions while still indicating its position. This new type of action is of the shape:
```
{
    action: (rowData) => { icon: ..., tooltip: ..., onClick: ... },
    position: ...
}
```

## Related PRs
#1156 

## Impacted Areas in Application
Actions