### PR TITLE
Returns the current data after sorting

### DIFF
--- a/src/material-table.js
+++ b/src/material-table.js
@@ -189,7 +189,7 @@ export default class MaterialTable extends React.Component {
       });
     } else {
       this.setState(this.dataManager.getRenderState(), () => {
-        this.props.onOrderChange && this.props.onOrderChange(newOrderBy, orderDirection);
+        this.props.onOrderChange && this.props.onOrderChange(newOrderBy, orderDirection, this.state.renderData);
       });
     }
   }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -25,7 +25,7 @@ export interface MaterialTableProps<RowData extends object> {
   onChangePage?: (page: number) => void;
   onChangeColumnHidden?: (column:Column<RowData>, hidden:boolean) => void;
   onColumnDragged?: (sourceIndex: number, destinationIndex: number) => void;
-  onOrderChange?: (orderBy: number, orderDirection: ("asc" | "desc")) => void;
+  onOrderChange?: (orderBy: number, orderDirection: ("asc" | "desc"), displayedData: RowData[]) => void;
   onGroupRemoved?: (column:Column<RowData>, index:boolean) => void;
   onRowClick?: (event?: React.MouseEvent, rowData?: RowData, toggleDetailPanel?: (panelIndex?: number) => void) => void;
   onRowSelected?: (rowData: RowData) => void;


### PR DESCRIPTION
## Description
It is [requested](https://stackoverflow.com/questions/58285810/is-it-possible-to-get-the-current-page-data-after-re-ordering-in-material-table) to get the currently displayed data after a sorting happend. This PR returns the current displayed data after onOrderChange.

## Impacted Areas in Application
List general components of the application that this PR will affect:

* Table
