### PR TITLE
Allow Typography to be passed into `title` without throwing an error.

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -3,6 +3,7 @@ import { createMuiTheme } from '@material-ui/core/styles';
 import React, { Component } from 'react';
 import ReactDOM from 'react-dom';
 import MaterialTable from '../src';
+import Typography from "@material-ui/core/Typography";
 
 let direction = 'ltr';
 // direction = 'rtl';
@@ -94,7 +95,9 @@ class App extends Component {
               Select
             </button>
             <MaterialTable
-              title="Remote Data Preview"
+                title={
+                    <Typography variant='h6' color='primary'>Remote Data Preview</Typography>
+                }
               columns={[
                 {
                   title: 'Avatar',

--- a/src/components/m-table-toolbar.js
+++ b/src/components/m-table-toolbar.js
@@ -193,7 +193,7 @@ export class MTableToolbar extends React.Component {
       <div className={classes.title}>
         {toolBarTitle}
       </div>
-    )
+    );
   }
 
   render() {

--- a/src/components/m-table-toolbar.js
+++ b/src/components/m-table-toolbar.js
@@ -185,15 +185,24 @@ export class MTableToolbar extends React.Component {
     );
   }
 
+  renderToolbarTitle(title) {
+    const { classes } = this.props;
+    const toolBarTitle = (typeof title === 'string') ? <Typography variant='h6'>{title}</Typography> : title;
+
+    return (
+      <div className={classes.title}>
+        {toolBarTitle}
+      </div>
+    )
+  }
+
   render() {
     const { classes } = this.props;
     const localization = { ...MTableToolbar.defaultProps.localization, ...this.props.localization };
     const title = this.props.showTextRowsSelected && this.props.selectedRows && this.props.selectedRows.length > 0 ? localization.nRowsSelected.replace('{0}', this.props.selectedRows.length) : this.props.showTitle ? this.props.title : null;
     return (
       <Toolbar className={classNames(classes.root, { [classes.highlight]: this.props.showTextRowsSelected && this.props.selectedRows && this.props.selectedRows.length > 0 })}>
-        {title && <div className={classes.title}>
-          <Typography variant="h6">{title}</Typography>
-        </div>}
+        { title && this.renderToolbarTitle(title)}
         {this.props.searchFieldAlignment === 'left' && this.renderSearch()}
         {this.props.toolbarButtonAlignment === 'left' && this.renderActions()}
         <div className={classes.spacer} />


### PR DESCRIPTION
## Related Issue
No related issue at this time.

## Description
If passed a react component, render it without being nested inside a <Typography> element.

## Related PRs
None

## Impacted Areas in Application
Table Toolbar (`m-table-toolbar.js`)

## Additional Notes
On a project I'm working on using this component, we were passing in:
```
        title={
          <>
            <Typography variant='h6' color='primary'>{title}</Typography>
            <Divider />
          </>
        }
```
Which resulted in the following error:
`Warning: validateDOMNesting(...): <h6> cannot appear as a child of <h6>.`

This fixes that error :)