### PR TITLE
added onEditingStatusChange callback.

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -131,6 +131,49 @@ class App extends Component {
               })}
             />
 
+              <MaterialTable
+                  title="Edit table state notify"
+                  columns={[
+                      {
+                          title: 'Avatar',
+                          field: 'avatar',
+                          render: rowData => (
+                              <img
+                                  style={{ height: 36, borderRadius: '50%' }}
+                                  src={rowData.avatar}
+                              />
+                          ),
+                      },
+                      { title: 'Id', field: 'id', filterPlaceholder: 'placeholder' },
+                      { title: 'First Name', field: 'first_name' },
+                      { title: 'Last Name', field: 'last_name' },
+                  ]}
+                  editable={{
+                      onRowUpdate: async (d) => d,
+                      onRowAdd: async (d) => d,
+                      onRowDelete: async (d) => d,
+                  }}
+                  onEditingStatusChange={(isEditing) => console.log(`Edit mode? ${isEditing}`)}
+                  options={{
+                      grouping: true,
+                      filtering: true,
+                  }}
+                  data={query => new Promise((resolve, reject) => {
+                      let url = 'https://reqres.in/api/users?'
+                      url += 'per_page=' + query.pageSize
+                      url += '&page=' + (query.page + 1)
+                      console.log(query);
+                      fetch(url)
+                          .then(response => response.json())
+                          .then(result => {
+                              resolve({
+                                  data: result.data,
+                                  page: result.page - 1,
+                                  totalCount: result.total,
+                              })
+                          })
+                  })}
+              />
           </div>
         </MuiThemeProvider>
       </>

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -480,6 +480,8 @@ export default class MaterialTable extends React.Component {
 
   render() {
     const props = this.getProps();
+    const hasAnyEditingRow= !!(this.state.lastEditingRow || this.state.showAddRow);
+    !!props.onEditingStatusChange && props.onEditingStatusChange(hasAnyEditingRow);
 
     return (
       <DragDropContext onDragEnd={this.onDragEnd}>
@@ -579,7 +581,7 @@ export default class MaterialTable extends React.Component {
                         localization={{ ...MaterialTable.defaultProps.localization.body, ...this.props.localization.body }}
                         onRowClick={this.props.onRowClick}
                         showAddRow={this.state.showAddRow}
-                        hasAnyEditingRow={!!(this.state.lastEditingRow || this.state.showAddRow)}
+                        hasAnyEditingRow={hasAnyEditingRow}
                         hasDetailPanel={!!props.detailPanel}
                         treeDataMaxLevel={this.state.treeDataMaxLevel}
                       />

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -15,6 +15,7 @@ export interface MaterialTableProps<RowData extends object> {
     onRowUpdate?: (newData: RowData, oldData?: RowData) => Promise<void>;
     onRowDelete?: (oldData: RowData) => Promise<void>;
   }
+  onEditingStatusChange?: (isEditing: boolean) => void;
   icons?: Icons;
   isLoading?: boolean;
   title?: string | React.ReactElement<any>;


### PR DESCRIPTION
## Related Issue
#786 Allows to setup a callback for listening the state of the table. True if it's in "dirty" mode (adding, updating, or deleting) and false if it's just displaying data.

## Description
Adds a new prop `onEditingStatusChange` that expects a function with one boolean argument describing if the table is in "edit" mode or not.

## Additional Notes
I want this functionality simply to show a message if the table is in edit mode and the user wants to quit the page.