### PR TITLE
Strips internal props to prevent ending up in the dom

### DIFF
--- a/src/components/m-table-body-row.js
+++ b/src/components/m-table-body-row.js
@@ -260,6 +260,8 @@ export default class MTableBodyRow extends React.Component {
       options,
       hasAnyEditingRow,
       treeDataMaxLevel,
+      localization,
+      actions,
       ...rowProps } = this.props;
 
     return (

--- a/src/components/m-table-edit-row.js
+++ b/src/components/m-table-edit-row.js
@@ -200,6 +200,12 @@ export default class MTableEditRow extends React.Component {
       onEditingApproved,
       onEditingCanceled,
       getFieldValue,
+      components,
+      icons,
+      columns: columnsProp, // renamed to not conflict with definition above
+      localization: localizationProp, // renamed to not conflict with definition above
+      options,
+      actions,
       ...rowProps
     } = this.props;
 


### PR DESCRIPTION
## Related Issue
#1075 & #1020

## Description
Prevents internal props from ending up in the dom

## Impacted Areas in Application
* Table Rows

## Additional Notes
There are probably better ways of handling this overall, but that would require a more substantial rewrite of the components.