### PR TITLE
Add row action option

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -81,8 +81,23 @@ class App extends Component {
                     selection: true,
                     columnsButton: true,
                     filtering: true,
+                    actionsColumnIndex: -1,
                     defaultExpanded: row => row.surname === 'C'
                   }}
+                  actions={[
+                    {
+                      icon: 'edit',
+                      tooltip: 'Edit',
+                      onClick: (event, rowData) => console.log(rowData),
+                      isRowAction: true,
+                    },
+                    {
+                      icon: 'add',
+                      tooltip: 'Add',
+                      onClick: (event, rowData) => console.log(rowData),
+                      isFreeAction: true,
+                    },
+                  ]}
                   onSearchChange={(e) => console.log("search changed: " + e)}
                   onColumnDragged={(oldPos, newPos) => console.log("Dropped column from " + oldPos + " to position " + newPos)}
                   parentChildData={(row, rows) => rows.find(a => a.id === row.parentId)}
@@ -95,6 +110,7 @@ class App extends Component {
             </button>
             <MaterialTable
               title="Remote Data Preview"
+
               columns={[
                 {
                   title: 'Avatar',

--- a/src/components/m-table-body-row.js
+++ b/src/components/m-table-body-row.js
@@ -34,7 +34,7 @@ export default class MTableBodyRow extends React.Component {
   renderActions() {
     const size = this.getElementSize();
     const baseIconSize = size === 'medium' ? 42 : 26;
-    const actions = this.props.actions.filter(a => !a.isFreeAction && !this.props.options.selection);
+    const actions = this.props.actions.filter(a => (!a.isFreeAction && !this.props.options.selection) || a.isRowAction);
     return (
       <TableCell size={size} padding="none" key="key-actions-column" style={{ width: baseIconSize * actions.length, padding: '0px 5px', ...this.props.options.actionsCellStyle }}>
         <div style={{ display: 'flex' }}>
@@ -190,7 +190,7 @@ export default class MTableBodyRow extends React.Component {
     if (this.props.options.selection) {
       renderColumns.splice(0, 0, this.renderSelectionColumn());
     }
-    if (this.props.actions && this.props.actions.filter(a => !a.isFreeAction && !this.props.options.selection).length > 0) {
+    if (this.props.actions && this.props.actions.filter(a => (!a.isFreeAction && !this.props.options.selection) || a.isRowAction).length > 0) {
       if (this.props.options.actionsColumnIndex === -1) {
         renderColumns.push(this.renderActions());
       } else if (this.props.options.actionsColumnIndex >= 0) {
@@ -296,7 +296,7 @@ export default class MTableBodyRow extends React.Component {
                   components={this.props.components}
                   data={data}
                   icons={this.props.icons}
-                  localization={this.props.localization}          
+                  localization={this.props.localization}
                   getFieldValue={this.props.getFieldValue}
                   key={index}
                   mode={data.tableData.editing}

--- a/src/components/m-table-body.js
+++ b/src/components/m-table-body.js
@@ -12,7 +12,7 @@ class MTableBody extends React.Component {
     const localization = { ...MTableBody.defaultProps.localization, ...this.props.localization };
     if (this.props.options.showEmptyDataSourceMessage && renderData.length === 0) {
       let addColumn = 0;
-      if (this.props.options.selection || (this.props.actions && this.props.actions.filter(a => !a.isFreeAction && !this.props.options.selection).length > 0)) {
+      if (this.props.options.selection || (this.props.actions && this.props.actions.filter(a => (!a.isFreeAction && !this.props.options.selection) || a.isRowAction).length > 0)) {
         addColumn++;
       }
       if (this.props.hasDetailPanel) {
@@ -135,8 +135,8 @@ class MTableBody extends React.Component {
           <this.props.components.FilterRow
             columns={this.props.columns.filter(columnDef => { return !columnDef.hidden })}
             icons={this.props.icons}
-            emptyCell={this.props.options.selection || (this.props.actions && this.props.actions.filter(a => !a.isFreeAction && !this.props.options.selection).length > 0)}
-            hasActions={(this.props.actions && this.props.actions.filter(a => !a.isFreeAction && !this.props.options.selection).length > 0)}
+            emptyCell={this.props.options.selection || (this.props.actions && this.props.actions.filter(a => (!a.isFreeAction && !this.props.options.selection) || a.isRowAction).length > 0)}
+            hasActions={(this.props.actions && this.props.actions.filter(a => (!a.isFreeAction && !this.props.options.selection) || a.isRowAction).length > 0)}
             actionsColumnIndex={this.props.options.actionsColumnIndex}
             onFilterChanged={this.props.onFilterChanged}
             selection={this.props.options.selection}

--- a/src/components/m-table-filter-row.js
+++ b/src/components/m-table-filter-row.js
@@ -161,9 +161,9 @@ class MTableFilterRow extends React.Component {
       ));
 
     if (this.props.selection) {
-      columns.splice(0, 0, <TableCell padding="none" key="key-selection-column"/>);
+      columns.splice(0, 0, <TableCell padding="none" key="key-selection-column" />);
     }
-    
+
     if (this.props.emptyCell && this.props.hasActions) {
       if (this.props.actionsColumnIndex === -1) {
         columns.push(<TableCell key="key-action-column" />);

--- a/src/components/m-table-toolbar.js
+++ b/src/components/m-table-toolbar.js
@@ -156,7 +156,7 @@ export class MTableToolbar extends React.Component {
 
         }
         <span>
-          <this.props.components.Actions actions={this.props.actions && this.props.actions.filter(a => a.isFreeAction)} components={this.props.components} />
+          <this.props.components.Actions actions={this.props.actions && this.props.actions.filter(a => a.isFreeAction && !a.isRowAction)} components={this.props.components} />
         </span>
       </div>
     );
@@ -165,7 +165,7 @@ export class MTableToolbar extends React.Component {
   renderSelectedActions() {
     return (
       <React.Fragment>
-        <this.props.components.Actions actions={this.props.actions.filter(a => !a.isFreeAction)} data={this.props.selectedRows} components={this.props.components} />
+        <this.props.components.Actions actions={this.props.actions.filter(a => !a.isFreeAction && !a.isRowAction)} data={this.props.selectedRows} components={this.props.components} />
       </React.Fragment>
     );
   }

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -542,7 +542,7 @@ export default class MaterialTable extends React.Component {
                           dataCount={props.parentChildData ? this.state.treefiedDataLength : this.state.data.length}
                           hasDetailPanel={!!props.detailPanel}
                           detailPanelColumnAlignment={props.options.detailPanelColumnAlignment}
-                          showActionsColumn={props.actions && props.actions.filter(a => !a.isFreeAction && !this.props.options.selection).length > 0}
+                          showActionsColumn={props.actions && props.actions.filter(a => !a.isFreeAction && !this.props.options.selection || a.isRowAction).length > 0}
                           showSelectAllCheckbox={props.options.showSelectAllCheckbox}
                           orderBy={this.state.orderBy}
                           orderDirection={this.state.orderDirection}

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -10,6 +10,7 @@ export const propTypes = {
   actions: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.shape({
     icon: PropTypes.oneOfType([PropTypes.element, PropTypes.func, PropTypes.string, RefComponent]).isRequired,
     isFreeAction: PropTypes.bool,
+    isRowAction: PropTypes.bool,
     tooltip: PropTypes.string,
     onClick: PropTypes.func.isRequired,
     iconProps: PropTypes.object,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -23,10 +23,10 @@ export interface MaterialTableProps<RowData extends object> {
   localization?: Localization;
   onChangeRowsPerPage?: (pageSize: number) => void;
   onChangePage?: (page: number) => void;
-  onChangeColumnHidden?: (column:Column<RowData>, hidden:boolean) => void;
+  onChangeColumnHidden?: (column: Column<RowData>, hidden: boolean) => void;
   onColumnDragged?: (sourceIndex: number, destinationIndex: number) => void;
   onOrderChange?: (orderBy: number, orderDirection: ("asc" | "desc")) => void;
-  onGroupRemoved?: (column:Column<RowData>, index:boolean) => void;
+  onGroupRemoved?: (column: Column<RowData>, index: boolean) => void;
   onRowClick?: (event?: React.MouseEvent, rowData?: RowData, toggleDetailPanel?: (panelIndex?: number) => void) => void;
   onRowSelected?: (rowData: RowData) => void;
   onSearchChange?: (searchText: string) => void;
@@ -72,6 +72,7 @@ export interface Action<RowData extends object> {
   disabled?: boolean;
   icon: string | (() => React.ReactElement<any>);
   isFreeAction?: boolean;
+  isRowAction?: boolean;
   tooltip?: string;
   onClick: (event: any, data: RowData | RowData[]) => void;
   iconProps?: IconProps;
@@ -274,4 +275,4 @@ export interface Localization {
   };
 }
 
-export default class MaterialTable<RowData extends object> extends React.Component<MaterialTableProps<RowData>> {}
+export default class MaterialTable<RowData extends object> extends React.Component<MaterialTableProps<RowData>> { }


### PR DESCRIPTION
## Related Issue
#676 

## Description
Add the option isRowAction to allow showing actions on a row level. If an action has the property isRowAction set to true, the action won't be shown in the toolbar.

## Impacted Areas in Application
List general components of the application that this PR will affect:

* MTableToolbar
* MTableBodyRow
* MTableBody

## Additional Notes
For some cases, sometimes is better to have individual actions on every row instead of having to select them. For example, an edit action is OK to show per row, but a remove could be selectable. Maybe sometimes is also ok to have both options as well