### PR TITLE
Table Cell sytyle inherits color by  default

### DIFF
--- a/src/components/m-table-cell.js
+++ b/src/components/m-table-cell.js
@@ -78,7 +78,9 @@ export default class MTableCell extends React.Component {
   }
 
   getStyle = () => {
-    let cellStyle = {};
+    let cellStyle = {
+      color: 'inherit'
+    };
 
     if (typeof this.props.columnDef.cellStyle === 'function') {
       cellStyle = { ...cellStyle, ...this.props.columnDef.cellStyle(this.props.value, this.props.rowData) };


### PR DESCRIPTION
## Related Issue
https://github.com/mbrn/material-table/issues/1158

## Description
Table Cell will have default style: `color: inherit` so color styles set on row are inherited by default from but has an override available.

## Related PRs
None

## Impacted Areas in Application
* Table Cell Styles
