### PR TITLE
Bugfix: Passing cellStyle to ColumnDef

### DIFF
--- a/src/components/m-table-body-row.js
+++ b/src/components/m-table-body-row.js
@@ -21,7 +21,7 @@ export default class MTableBodyRow extends React.Component {
           <this.props.components.Cell
             size={size}
             icons={this.props.icons}
-            columnDef={columnDef}
+            columnDef={{...columnDef, cellStyle: this.props.options.cellStyle}}
             value={value}
             key={"cell-" + this.props.data.tableData.id + "-" + columnDef.tableData.id}
             rowData={this.props.data}


### PR DESCRIPTION
## Related Issue
#1213 #1158 

## Description
`cellStyle` is being used in `getStyle` at `m-table-cell` but it is not being passed down to be useable.

## Impacted Areas in Application
Designing the Cell itself.