### PR TITLE
Fix #1049 Warning on disabled edit buttons

### DIFF
--- a/src/components/m-table-action.js
+++ b/src/components/m-table-action.js
@@ -28,22 +28,22 @@ class MTableAction extends React.Component {
     };
 
     const button = (
-      <IconButton
-        size={this.props.size}
-        color="inherit"
-        disabled={action.disabled}
-        onClick={(event) => handleOnClick(event)}
-      >
-        {typeof action.icon === "string" ? (
-          <Icon {...action.iconProps}>{action.icon}</Icon>
-        ) : (
-            <action.icon
-              {...action.iconProps}
-              disabled={action.disabled}
-            />
-          )
-        }
-      </IconButton>
+        <IconButton
+          size={this.props.size}
+          color="inherit"
+          disabled={action.disabled}
+          onClick={(event) => handleOnClick(event)}
+        >
+          {typeof action.icon === "string" ? (
+            <Icon {...action.iconProps}>{action.icon}</Icon>
+          ) : (
+              <action.icon
+                {...action.iconProps}
+                disabled={action.disabled}
+              />
+            )
+          }
+        </IconButton>
     );
 
     if (action.tooltip) {

--- a/src/components/m-table-action.js
+++ b/src/components/m-table-action.js
@@ -28,30 +28,28 @@ class MTableAction extends React.Component {
     };
 
     const button = (
-        <>
-          <IconButton
-            size={this.props.size}
-            color="inherit"
-            disabled={action.disabled}
-            onClick={(event) => handleOnClick(event)}
-          >
-            {typeof action.icon === "string" ? (
-              <Icon {...action.iconProps}>{action.icon}</Icon>
-            ) : (
-                <action.icon
-                  {...action.iconProps}
-                  disabled={action.disabled}
-                />
-              )
-            }
-          </IconButton>
-        </>
+      <IconButton
+        size={this.props.size}
+        color="inherit"
+        disabled={action.disabled}
+        onClick={(event) => handleOnClick(event)}
+      >
+        {typeof action.icon === "string" ? (
+          <Icon {...action.iconProps}>{action.icon}</Icon>
+        ) : (
+            <action.icon
+              {...action.iconProps}
+              disabled={action.disabled}
+            />
+          )
+        }
+      </IconButton>
     );
 
     if (action.tooltip) {
       return <Tooltip title={action.tooltip}>{button}</Tooltip>;
     } else {
-      return button;
+      return <span>{button}</span>;
     }
   }
 }

--- a/src/components/m-table-action.js
+++ b/src/components/m-table-action.js
@@ -28,22 +28,24 @@ class MTableAction extends React.Component {
     };
 
     const button = (
-        <IconButton
-          size={this.props.size}
-          color="inherit"
-          disabled={action.disabled}
-          onClick={(event) => handleOnClick(event)}
-        >
-          {typeof action.icon === "string" ? (
-            <Icon {...action.iconProps}>{action.icon}</Icon>
-          ) : (
-              <action.icon
-                {...action.iconProps}
-                disabled={action.disabled}
-              />
-            )
-          }
-        </IconButton>
+        <>
+          <IconButton
+            size={this.props.size}
+            color="inherit"
+            disabled={action.disabled}
+            onClick={(event) => handleOnClick(event)}
+          >
+            {typeof action.icon === "string" ? (
+              <Icon {...action.iconProps}>{action.icon}</Icon>
+            ) : (
+                <action.icon
+                  {...action.iconProps}
+                  disabled={action.disabled}
+                />
+              )
+            }
+          </IconButton>
+        </>
     );
 
     if (action.tooltip) {


### PR DESCRIPTION
## Related Issue
#1049 Warning on disabled edit buttons

## Description
The error messaged 
`Material-UI: you are providing a disabled `button` child to the Tooltip component.
A disabled element does not fire events.
Tooltip needs to listen to the child element's events to display the title.

Add a simple wrapper element, such as a `span`.`
followed from the
[PR](https://github.com/mbrn/material-table/commit/3f3413713d4b00e353fcf38b2cc4507ff0ccdb60#diff-1bebc326492d6cec01b923b38a98d992)

caused me to insert a span element around the button

## Related PRs
List related PRs against other branches:
#1049

branch | PR
------ | ------
other_pr_production | [link](rkram3r:material-table)
other_pr_master | [link](mbrn:master)

## Impacted Areas in Application
List general components of the application that this PR will affect:

m-table-action.js

## Additional Notes
Hi,
since this is my first public pr, i am not sure if the form was filled out correctly(especially the branch | PR section). 