### PR TITLE
Bug/fix removing data mutation provoques instable state

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -5,6 +5,7 @@ import ReactDOM from 'react-dom';
 import MaterialTable from '../src';
 import Typography from "@material-ui/core/Typography";
 
+
 let direction = 'ltr';
 // direction = 'rtl';
 const theme = createMuiTheme({
@@ -36,11 +37,13 @@ class App extends Component {
 
   colRenderCount = 0;
 
+
   state = {
     text: 'text',
     selecteds: 0,
+    selection : null,
     data: [
-      { id: 1, name: 'A1', surname: 'B', isMarried: true, birthDate: new Date(1987, 1, 1), birthCity: 0, sex: 'Male', type: 'adult', insertDateTime: new Date(2018, 1, 1, 12, 23, 44), time: new Date(1900, 1, 1, 14, 23, 35) },
+      { id: 1, name: 'A11', surname: 'B', isMarried: true, birthDate: new Date(1987, 1, 1), birthCity: 0, sex: 'Male', type: 'adult', insertDateTime: new Date(2018, 1, 1, 12, 23, 44), time: new Date(1900, 1, 1, 14, 23, 35) },
       { id: 2, name: 'A2', surname: 'B', isMarried: false, birthDate: new Date(1987, 1, 1), birthCity: 34, sex: 'Female', type: 'adult', insertDateTime: new Date(2018, 1, 1, 12, 23, 44), time: new Date(1900, 1, 1, 14, 23, 35), parentId: 1 },
       { id: 3, name: 'A3', surname: 'B', isMarried: true, birthDate: new Date(1987, 1, 1), birthCity: 34, sex: 'Female', type: 'child', insertDateTime: new Date(2018, 1, 1, 12, 23, 44), time: new Date(1900, 1, 1, 14, 23, 35), parentId: 1 },
       { id: 4, name: 'A4', surname: 'Dede', isMarried: true, birthDate: new Date(1987, 1, 1), birthCity: 34, sex: 'Female', type: 'child', insertDateTime: new Date(2018, 1, 1, 12, 23, 44), time: new Date(1900, 1, 1, 14, 23, 35), parentId: 3 },
@@ -67,6 +70,9 @@ class App extends Component {
   }
 
   render() {
+var me = this;
+   // const [selected, setSelected] = React.useState(null);
+
     return (
       <>
         <MuiThemeProvider theme={theme}>
@@ -77,9 +83,18 @@ class App extends Component {
                   tableRef={this.tableRef}
                   columns={this.state.columns}
                   data={this.state.data}
+                  dataFieldId={"id"}
                   title="Demo Title"
+                  onSelectionChange={ (data )=> {
+                     me.setState((oldData, props) => { return { ...oldData, select : data}});
+                     console.log('After set',me.state.select);
+                  }}
                   options={{
-                    selection: true,
+                    selection : true,
+                    selectionOpts: {
+                      recursive : false,
+                      multiple : false
+                    },
                     columnsButton: true,
                     filtering: true,
                     defaultExpanded: row => row.surname === 'C'

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -18,6 +18,7 @@ export default class MaterialTable extends React.Component {
     super(props);
 
     const calculatedProps = this.getProps(props);
+
     this.setDataManagerFields(calculatedProps, true);
     const renderState = this.dataManager.getRenderState();
 
@@ -62,6 +63,7 @@ export default class MaterialTable extends React.Component {
 
     this.dataManager.setColumns(props.columns);
     this.dataManager.setDefaultExpanded(props.options.defaultExpanded);
+    this.dataManager.setDataFieldId(props.dataFieldId);
 
     if (this.isRemoteData(props)) {
       this.dataManager.changeApplySearch(false);
@@ -150,6 +152,7 @@ export default class MaterialTable extends React.Component {
         }));
       }
     }
+
 
     return calculatedProps;
   }

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -66,6 +66,7 @@ export const propTypes = {
     Toolbar: PropTypes.oneOfType([PropTypes.element, PropTypes.func, StyledComponent])
   }),
   data: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.object), PropTypes.func]).isRequired,
+  dataFieldId : PropTypes.string,
   editable: PropTypes.shape({
     onRowAdd: PropTypes.func,
     onRowUpdate: PropTypes.func,

--- a/src/utils/data-manager.js
+++ b/src/utils/data-manager.js
@@ -20,6 +20,7 @@ export default class DataManager {
   defaultExpanded = false;
 
   data = [];
+  dataFieldId = null;
   columns = [];
 
   filteredData = [];
@@ -29,6 +30,7 @@ export default class DataManager {
   sortedData = [];
   pagedData = [];
   renderData = [];
+  tableData = {};
 
   filtered = false;
   searched = false;
@@ -45,18 +47,50 @@ export default class DataManager {
   setData(data) {
     this.selectedCount = 0;
 
+    const me = this;
+    const keys = Object.keys(this.tableData);
+    const exists = {}
+    keys.forEach(k => {
+      exists[k] = false;
+    });
+
     this.data = data.map((row, index) => {
+      if (!me.dataFieldId) {
+           // Keep mutable for legacy.
+            row.tableData = { ...row.tableData, id: index };
+            if (row.tableData.checked) {
+                this.selectedCount++;
+            }
+            return row;
+      }
+
+      me.tableData[row[me.dataFieldId]] = {...me.tableData[row[me.dataFieldId]] || {}, id : index};
+
+      exists[row[me.dataFieldId]] = true;
+
       const localRow = {
         ...row,
-        tableData: { ...row.tableData, id: index }
+        tableData:  me.tableData[row[me.dataFieldId]]
       };
       if (localRow.tableData.checked) {
         this.selectedCount++;
       }
       return localRow;
+     
+
+    });
+
+    keys.forEach(k => {
+      if (!exists[k]){
+        delete me.tableData[k];
+      }
     });
 
     this.filtered = false;
+  }
+
+  setDataFieldId(dataFieldId){
+    this.dataFieldId = dataFieldId;
   }
 
   setColumns(columns) {

--- a/src/utils/data-manager.js
+++ b/src/utils/data-manager.js
@@ -49,7 +49,7 @@ export default class DataManager {
 
     const me = this;
     const keys = Object.keys(this.tableData);
-    const exists = {}
+    const exists = {};
     keys.forEach(k => {
       exists[k] = false;
     });
@@ -64,7 +64,7 @@ export default class DataManager {
             return row;
       }
 
-      me.tableData[row[me.dataFieldId]] = {...me.tableData[row[me.dataFieldId]] || {}, id : index};
+      me.tableData[row[me.dataFieldId]] = {...me.tableData[row[me.dataFieldId]]||{}, id : index};
 
       exists[row[me.dataFieldId]] = true;
 


### PR DESCRIPTION
## Related Issue

Remove data mutation #1174

## Description

The PR #1174 decoupled intern data from extern data source by removing data mutation.

The consequence was that tableData was not persistent anymore.

I proposed to create a Map in data-manager and use a new dataFieldId attribute to bind the row in the tableData.

This correction implies a new props attribute, so for legacy, i restore old mutation version when the attribute is not supplied.

For now, for having non data mutation and tableData persistent, you just have to supply a dataFieldId in MaterialTable props.


## Related PRs
Remove data mutation #1174

branch | PR
------ | ------
other_pr_production | [link]()
other_pr_master | [link]()

## Impacted Areas in Application
List general components of the application that this PR will affect:

*

## Additional Notes
This is optional, feel free to follow your hearth and write here :)