### PR TITLE
add multiline textfield support

### DIFF
--- a/src/components/m-table-edit-field.js
+++ b/src/components/m-table-edit-field.js
@@ -110,6 +110,7 @@ class MTableEditField extends React.Component {
         {...this.getProps()}
         style={this.props.columnDef.type === 'numeric' ? { float: 'right' } : {}}
         type={this.props.columnDef.type === 'numeric' ? 'number' : 'text'}
+        multiline={this.props.columnDef.type === 'textarea'}
         placeholder={this.props.columnDef.title}
         value={this.props.value === undefined ? '' : this.props.value}
         onChange={event => this.props.onChange(event.target.value)}

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -46,7 +46,7 @@ export const propTypes = {
     searchable: PropTypes.bool,
     sorting: PropTypes.bool,
     title: PropTypes.oneOfType([PropTypes.element, PropTypes.string]),
-    type: PropTypes.oneOf(['string', 'boolean', 'numeric', 'date', 'datetime', 'time', 'currency'])
+    type: PropTypes.oneOf(['string', 'boolean', 'numeric', 'date', 'datetime', 'time', 'currency', 'textarea'])
   })).isRequired,
   components: PropTypes.shape({
     Action: PropTypes.oneOfType([PropTypes.element, PropTypes.func, StyledComponent]),

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -124,7 +124,7 @@ export interface Column<RowData extends object> {
   searchable?: boolean;
   sorting?: boolean;
   title?: string | React.ReactElement<any>;
-  type?: ('string' | 'boolean' | 'numeric' | 'date' | 'datetime' | 'time' | 'currency');
+  type?: ('string' | 'boolean' | 'numeric' | 'date' | 'datetime' | 'time' | 'currency' | 'textarea');
 }
 
 export interface Components {


### PR DESCRIPTION
Using textfields with anything more than a small amount of data is unworkable in edit mode. This allows  user to specify using a textarea field