### PR TITLE
Fix remote data search flicker

### DIFF
--- a/src/material-table.js
+++ b/src/material-table.js
@@ -375,11 +375,12 @@ export default class MaterialTable extends React.Component {
     }
   }
 
-  onSearchChange = searchText => this.setState({ searchText }, this.onSearchChangeDebounce)
+  onSearchChange = searchText => {
+    this.dataManager.changeSearchText(searchText);
+    this.setState(({ searchText }), this.onSearchChangeDebounce());
+  }
 
   onSearchChangeDebounce = debounce(() => {
-    this.dataManager.changeSearchText(this.state.searchText);
-
     if (this.isRemoteData()) {
       const query = { ...this.state.query };
       query.page = 0;


### PR DESCRIPTION
## Description

Fix async search where the debouncing rolls back the search input while typing

### Video Before

ℹ️ Notice `f` disappearing whilst typing)

https://www.dropbox.com/s/9gpjagettvujeg0/1-before.mov?dl=0 

### Video After

https://www.dropbox.com/s/d6bfoimuaf45dv9/2-after.mov?dl=0

## Additional Notes

Can't say I fully grasp the double state management of `dataManger` vs `setState`, but hammered it enough to  get what  I needed working