### PR TITLE
display length of grouped data

### DIFF
--- a/src/components/m-table-group-row.js
+++ b/src/components/m-table-group-row.js
@@ -115,7 +115,7 @@ export default class MTableGroupRow extends React.Component {
 
     let separator = this.props.options.groupRowSeparator || ": ";
 
-      return (
+    return (
       <>
         <TableRow>
           {freeCells}
@@ -134,7 +134,7 @@ export default class MTableGroupRow extends React.Component {
             >
               <this.props.icons.DetailPanel />
             </IconButton>
-            <b>{title}{separator}</b>
+            <b>{title} ({this.props.groupData.data.length}) {separator}</b>
           </this.props.components.Cell>
         </TableRow>
         {detail}


### PR DESCRIPTION
## Description
I often would like to know the number of items upon grouping data by a column. This adds that information to the grouped data's title row.
