### PR TITLE
Make MTableEditRow's cells use cellStyle (related to #1136)

### DIFF
--- a/src/components/m-table-edit-row.js
+++ b/src/components/m-table-edit-row.js
@@ -18,18 +18,34 @@ export default class MTableEditRow extends React.Component {
     };
   }
 
-  createRowData(){
+  createRowData() {
     return this.props.columns.filter(column => (column.initialEditValue || column.initialEditValue === 0) && column.field).reduce((prev,column)=>{
       prev[column.field]=column.initialEditValue;
       return prev;
     },{});
   }
-
+  
   renderColumns() {
     const mapArr = this.props.columns.filter(columnDef => !columnDef.hidden && !(columnDef.tableData.groupOrder > -1))
       .sort((a, b) => a.tableData.columnOrder - b.tableData.columnOrder)
       .map((columnDef, index) => {
         const value = (typeof this.state.data[columnDef.field] !== 'undefined' ? this.state.data[columnDef.field] : byString(this.state.data, columnDef.field));
+        const getCellStyle = (columnDef, value) => {
+          let cellStyle = {
+            color: 'inherit'
+          };
+          if (typeof columnDef.cellStyle === 'function') {
+            cellStyle = { ...cellStyle, ...columnDef.cellStyle(value, this.props.data) };
+          } else {
+            cellStyle = { ...cellStyle, ...columnDef.cellStyle };
+          }
+          if (columnDef.disableClick) {
+            cellStyle.cursor = 'default';
+          }
+
+          return { ...cellStyle };
+        };
+
         const style = {};
         if (index === 0) {
           style.paddingLeft = 24 + this.props.level * 20;
@@ -61,16 +77,19 @@ export default class MTableEditRow extends React.Component {
               value={readonlyValue}
               key={columnDef.tableData.id}
               rowData={this.props.data}
+              style={getCellStyle(columnDef, value)}
             />
           );
         }
         else {
           const { editComponent, ...cellProps } = columnDef;
           const EditComponent = editComponent || this.props.components.EditField;
+          
           return (
             <TableCell
               key={columnDef.tableData.id}
               align={['numeric'].indexOf(columnDef.type) !== -1 ? "right" : "left"}
+              style={getCellStyle(columnDef, value)}
             >
               <EditComponent
                 key={columnDef.tableData.id}


### PR DESCRIPTION
## Related Issue
#1136

## Description
The change makes MTableEditRow's cells use the cellStyle defined.

## Impacted Areas in Application
List general components of the application that this PR will affect:

* MTableEditRow
