### PR TITLE
#1235: prevent actions icons re-render

### DIFF
--- a/src/components/m-table-action.js
+++ b/src/components/m-table-action.js
@@ -37,10 +37,10 @@ class MTableAction extends React.Component {
           {typeof action.icon === "string" ? (
             <Icon {...action.iconProps}>{action.icon}</Icon>
           ) : (
-              <action.icon
-                {...action.iconProps}
-                disabled={action.disabled}
-              />
+              action.icon({
+                ...action.iconProps,
+                disabled: action.disabled
+              })
             )
           }
         </IconButton>

--- a/src/components/m-table-action.js
+++ b/src/components/m-table-action.js
@@ -27,6 +27,14 @@ class MTableAction extends React.Component {
       }
     };
 
+    const icon = typeof action.icon === "string" ? (
+        <Icon {...action.iconProps}>{action.icon}</Icon>
+    ) : typeof action.icon === "function" ? (
+        action.icon({ ...action.iconProps, disabled: action.disabled })
+    ) : (
+        <action.icon />
+    );
+
     const button = (
         <IconButton
           size={this.props.size}
@@ -34,15 +42,7 @@ class MTableAction extends React.Component {
           disabled={action.disabled}
           onClick={(event) => handleOnClick(event)}
         >
-          {typeof action.icon === "string" ? (
-            <Icon {...action.iconProps}>{action.icon}</Icon>
-          ) : (
-              action.icon({
-                ...action.iconProps,
-                disabled: action.disabled
-              })
-            )
-          }
+          {icon}
         </IconButton>
     );
 


### PR DESCRIPTION
## Related Issue
#1235

## Description
Prevent action icons to re-render unconditionally.

## Impacted Areas in Application
* MTableAction
