### PR TITLE
bugfix: disable defaultSorting when sorting = false

### DIFF
--- a/src/material-table.js
+++ b/src/material-table.js
@@ -55,8 +55,8 @@ export default class MaterialTable extends React.Component {
   setDataManagerFields(props, isInit) {
     let defaultSortColumnIndex = -1;
     let defaultSortDirection = '';
-    if (props) {
-      defaultSortColumnIndex = props.columns.findIndex(a => a.defaultSort);
+    if (props.options.sorting !== false) {
+      defaultSortColumnIndex = props.columns.findIndex(a => a.defaultSort && a.sorting !== false);
       defaultSortDirection = defaultSortColumnIndex > -1 ? props.columns[defaultSortColumnIndex].defaultSort : '';
     }
 

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -55,7 +55,7 @@ export default class MaterialTable extends React.Component {
   setDataManagerFields(props, isInit) {
     let defaultSortColumnIndex = -1;
     let defaultSortDirection = '';
-    if (props.options.sorting !== false) {
+    if (props && props.options.sorting !== false) {
       defaultSortColumnIndex = props.columns.findIndex(a => a.defaultSort && a.sorting !== false);
       defaultSortDirection = defaultSortColumnIndex > -1 ? props.columns[defaultSortColumnIndex].defaultSort : '';
     }


### PR DESCRIPTION
## Related Issue
#1223 

## Description
Config for validating when applying `defaultSort` is not checking the options for `sorting: false`. Also when applying it directly at the `column`. As per the documentation, this should not be the case.

## Impacted Areas in Application
Sorting of columns.

## Additional Notes
Just let me know if you have any concerns so I can immediately coordinate.