### PR TITLE
Add type for new option prop thirdSortClick

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -223,6 +223,7 @@ export interface Options {
   selection?: boolean;
   selectionProps?: any | ((data: any) => any);
   sorting?: boolean;
+  thirdSortClick?: boolean;
   toolbar?: boolean;
   toolbarButtonAlignment?: 'left' | 'right';
   detailPanelColumnAlignment?: 'left' | 'right';


### PR DESCRIPTION
## Related Issue
N/A

## Description
Add type for new option property `thirdSortClick`. Resolves compile issue when using this property in TypeScript. 

## Related PRs
N/A