### PR TITLE
Remove UNSAFE_componentWillReceiveProps

### DIFF
--- a/src/material-table.js
+++ b/src/material-table.js
@@ -82,13 +82,16 @@ export default class MaterialTable extends React.Component {
     this.dataManager.changeDetailPanelType(props.options.detailPanelType);
   }
 
-  UNSAFE_componentWillReceiveProps(nextProps) {
-    const props = this.getProps(nextProps);
-    this.setDataManagerFields(props);
-    this.setState(this.dataManager.getRenderState());
-  }
-
   componentDidUpdate() {
+	  
+    const propsChanged = Object.entries(this.props).reduce((didChange, prop) => didChange || prop[1] !== prevProps[prop[0]], false);
+
+    if (propsChanged) {
+      const props = this.getProps(this.props);
+      this.setDataManagerFields(props);
+      this.setState(this.dataManager.getRenderState());
+    }
+	  
     const count = this.isRemoteData() ? this.state.query.totalCount : this.state.data.length;
     const currentPage = this.isRemoteData() ? this.state.query.page : this.state.currentPage;
     const pageSize = this.isRemoteData() ? this.state.query.pageSize : this.state.pageSize;

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -82,8 +82,7 @@ export default class MaterialTable extends React.Component {
     this.dataManager.changeDetailPanelType(props.options.detailPanelType);
   }
 
-  componentDidUpdate() {
-	  
+  componentDidUpdate(prevProps) {
     const propsChanged = Object.entries(this.props).reduce((didChange, prop) => didChange || prop[1] !== prevProps[prop[0]], false);
 
     if (propsChanged) {

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -90,7 +90,7 @@ export default class MaterialTable extends React.Component {
       this.setDataManagerFields(props);
       this.setState(this.dataManager.getRenderState());
     }
-	  
+
     const count = this.isRemoteData() ? this.state.query.totalCount : this.state.data.length;
     const currentPage = this.isRemoteData() ? this.state.query.page : this.state.currentPage;
     const pageSize = this.isRemoteData() ? this.state.query.pageSize : this.state.pageSize;


### PR DESCRIPTION
## Description
This will remove the deprecated componentWillReceiveProps and moves the code snippet in didUpdate. The reduce will check, if the props changed and will only trigger the setDataManagerFields update, if the props did change. This will help make the migration towards Concurrent move, since the willReceiveProps lifecycle method will not work with cocurrent mode.

## Impacted Areas in Application
List general components of the application that this PR will affect:

* Material-table
