### PR TITLE
Bugfix: Passing cellStyle to ColumnDef props

### DIFF
--- a/src/components/m-table-body-row.js
+++ b/src/components/m-table-body-row.js
@@ -21,7 +21,7 @@ export default class MTableBodyRow extends React.Component {
           <this.props.components.Cell
             size={size}
             icons={this.props.icons}
-            columnDef={columnDef}
+            columnDef={{ ...columnDef, cellStyle: this.props.options.cellStyle }}
             value={value}
             key={"cell-" + this.props.data.tableData.id + "-" + columnDef.tableData.id}
             rowData={this.props.data}
@@ -302,7 +302,7 @@ export default class MTableBodyRow extends React.Component {
                   components={this.props.components}
                   data={data}
                   icons={this.props.icons}
-                  localization={this.props.localization}          
+                  localization={this.props.localization}
                   getFieldValue={this.props.getFieldValue}
                   key={index}
                   mode={data.tableData.editing}

--- a/src/components/m-table-body-row.js
+++ b/src/components/m-table-body-row.js
@@ -20,8 +20,8 @@ export default class MTableBodyRow extends React.Component {
         return (
           <this.props.components.Cell
             size={size}
-            icons={this.props.icons}
-            columnDef={{ ...columnDef, cellStyle: this.props.options.cellStyle }}
+            icons={this.props.icons}            
+            columnDef={{ cellStyle: this.props.options.cellStyle, ...columnDef }}
             value={value}
             key={"cell-" + this.props.data.tableData.id + "-" + columnDef.tableData.id}
             rowData={this.props.data}


### PR DESCRIPTION
## Related Issue
#1213 

## Description
`options.cellStyle` props is not actually being passed down to `cell` `columnDef` props but already being used. As a result, styles don't reflect.

## Impacted Areas in Application
Custom styling of Cells as mentioned in #552 doesn't work.

## Additional Notes
If you have any suggestions or concerns i am more than happy to hear it. Thanks a lot for this tool, i am one of those who's actually using it! :D