### PR TITLE
call onFilterChange

### DIFF
--- a/src/material-table.js
+++ b/src/material-table.js
@@ -413,8 +413,18 @@ export default class MaterialTable extends React.Component {
 
       this.onQueryChange(query);
     }
-    else {
-      this.setState(this.dataManager.getRenderState());
+    else {		
+      const appliedFilters = this.state.columns
+		.filter(a => a.tableData.filterValue)
+		.map(a => ({
+			column: a,
+			operator: "=",
+			value: a.tableData.filterValue
+		}));
+
+      this.setState(this.dataManager.getRenderState(), () => {
+        this.props.onFilterChange && this.props.onFilterChange(appliedFilters);
+      });
     }
   }, this.props.options.debounceInterval)
 

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -414,16 +414,17 @@ export default class MaterialTable extends React.Component {
       this.onQueryChange(query);
     }
     else {		
-      const appliedFilters = this.state.columns
-		.filter(a => a.tableData.filterValue)
-		.map(a => ({
-			column: a,
-			operator: "=",
-			value: a.tableData.filterValue
-		}));
-
       this.setState(this.dataManager.getRenderState(), () => {
-        this.props.onFilterChange && this.props.onFilterChange(appliedFilters);
+        if(this.props.onFilterChange) { 
+		const appliedFilters = this.state.columns
+			.filter(a => a.tableData.filterValue)
+			.map(a => ({
+				column: a,
+				operator: "=",
+				value: a.tableData.filterValue
+			}));
+		this.props.onFilterChange(appliedFilters);
+	}
       });
     }
   }, this.props.options.debounceInterval)

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -163,6 +163,7 @@ export const propTypes = {
   }),
   initialFormData: PropTypes.object,
   onSearchChange: PropTypes.func,
+  onFilterChange: PropTypes.func,
   onColumnDragged: PropTypes.func,
   onGroupRemoved: PropTypes.func,
   onSelectionChange: PropTypes.func,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -30,6 +30,10 @@ export interface MaterialTableProps<RowData extends object> {
   onRowClick?: (event?: React.MouseEvent, rowData?: RowData, toggleDetailPanel?: (panelIndex?: number) => void) => void;
   onRowSelected?: (rowData: RowData) => void;
   onSearchChange?: (searchText: string) => void;
+ /** An event fired when the table has finished filtering data
+  * @param {Filter<RowData>[]} filters All the filters that are applied to the table 
+  */ 
+  onFilterChange?: (filters: Filter<RowData>[]) => void;
   onSelectionChange?: (data: RowData[], rowData?: RowData) => void;
   onTreeExpandChange?: (data: any, isExpanded: boolean) => void;
   onQueryChange?: (query: Query<RowData>) => void;


### PR DESCRIPTION
## Related Issue
#367 

## Description
Expose onFilterChange as an event that fires when a table's filters are changed

## Related PRs
None that I could find

## Impacted Areas in Application
onFilterChangeDebounce in material-table.js, and associated types

## Additional Notes
Our team needs to get searched and filtered data back out of material table in order to show summary information. OnSearchChange works well as a place to hook into tableRef's data, but there was no accompanying event for filters. We have no immediate need for the filters applied to the table, so let me know if there's a more appropriate event param.