### PR TITLE
Remove color="inherit" from TextField.

### DIFF
--- a/src/components/m-table-toolbar.js
+++ b/src/components/m-table-toolbar.js
@@ -65,7 +65,6 @@ export class MTableToolbar extends React.Component {
           value={this.props.searchText}
           onChange={event => this.props.onSearchChanged(event.target.value)}
           placeholder={localization.searchPlaceholder}
-          color="inherit"
           InputProps={{
             startAdornment: (
               <InputAdornment position="start">


### PR DESCRIPTION
## Related Issue
#1293

## Description
Only primary and secondary are valid on TextField. Removes error that is thrown.