### PR TITLE
Bugfix: marginTop in TableFilterRow

### DIFF
--- a/src/components/m-table-filter-row.js
+++ b/src/components/m-table-filter-row.js
@@ -41,6 +41,7 @@ class MTableFilterRow extends React.Component {
         input={<Input id="select-multiple-checkbox" />}
         renderValue={selecteds => selecteds.map(selected => columnDef.lookup[selected]).join(', ')}
         MenuProps={MenuProps}
+        style={{marginTop: 0}}
       >
         {
           Object.keys(columnDef.lookup).map(key => (


### PR DESCRIPTION
## Related Issue
Local bug

## Description
Wrong top margin in FilterRow property lookup

## Impacted Areas in Application
Custom style. component Select, style marginTop in MTableFilterRow