### PR TITLE
Missing property searchText in TS def

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -227,6 +227,7 @@ export interface Options {
   search?: boolean;
   searchFieldAlignment?: 'left' | 'right';
   searchFieldStyle?: React.CSSProperties;
+  searchText?: string;
   selection?: boolean;
   selectionProps?: any | ((data: any) => any);
   sorting?: boolean;


### PR DESCRIPTION
## Related Issue
#1298 #1225 #1265

## Description
missing property searchText for typescript