### PR TITLE
Solves the problem when options.paging changes dynamically

### DIFF
--- a/src/material-table.js
+++ b/src/material-table.js
@@ -78,7 +78,7 @@ export default class MaterialTable extends React.Component {
     isInit && this.dataManager.changeSearchText(props.options.searchText || '');
     isInit && this.dataManager.changeCurrentPage(props.options.initialPage ? props.options.initialPage : 0);
     this.dataManager.changePageSize(props.options.pageSize);
-    isInit && this.dataManager.changePaging(props.options.paging);
+    this.dataManager.changePaging(props.options.paging);
     isInit && this.dataManager.changeParentFunc(props.parentChildData);
     this.dataManager.changeDetailPanelType(props.options.detailPanelType);
   }


### PR DESCRIPTION
## Related Issue 
I openned an issue today #1336, and this fixes that.

## Description
When props change, `componentDidUpdate` calls `setDataManagerFields` with the new props. 
But it calls `setDataManagerFields(props)`, and `setDataManagerFields` receives two parameters (`props` and `isInit`). 
I don't have the time to check if passing `setDataManagerFields(props, true)` breaks anything, so I removed the validation `isInit && this.dataManager.changePaging(props.options.paging);` to just `this.dataManager.changePaging(props.options.paging);`. In that way, the `DataManager` knows that **now** the table has paging, and the `renderData` isn't the whole `data` prop.
