### PR TITLE
Asc/desc icons are mixed up

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,13 +95,13 @@ If your environment doesn't support tree-shaking, the **recommended** way to imp
 
 ```jsx
 import AddBox from "@material-ui/icons/AddBox";
-import ArrowUpward from "@material-ui/icons/ArrowUpward";
+import ArrowDownward from "@material-ui/icons/ArrowDownward";
 ```
 
 If your environment support tree-shaking you can also import the icons this way:
 
 ```jsx
-import { AddBox, ArrowUpward } from "@material-ui/icons";
+import { AddBox, ArrowDownward } from "@material-ui/icons";
 ```
 
 Note: Importing named exports in this way will result in the code for _every icon_ being included in your project, so is not recommended unless you configure [tree-shaking](https://webpack.js.org/guides/tree-shaking/). It may also impact Hot Module Reload performance. Source: [@material-ui/icons](https://github.com/mui-org/material-ui/blob/master/packages/material-ui-icons/README.md#imports)
@@ -112,7 +112,7 @@ Example
 import { forwardRef } from 'react';
 
 import AddBox from '@material-ui/icons/AddBox';
-import ArrowUpward from '@material-ui/icons/ArrowUpward';
+import ArrowDownward from '@material-ui/icons/ArrowDownward';
 import Check from '@material-ui/icons/Check';
 import ChevronLeft from '@material-ui/icons/ChevronLeft';
 import ChevronRight from '@material-ui/icons/ChevronRight';
@@ -142,7 +142,7 @@ const tableIcons = {
     PreviousPage: forwardRef((props, ref) => <ChevronLeft {...props} ref={ref} />),
     ResetSearch: forwardRef((props, ref) => <Clear {...props} ref={ref} />),
     Search: forwardRef((props, ref) => <Search {...props} ref={ref} />),
-    SortArrow: forwardRef((props, ref) => <ArrowUpward {...props} ref={ref} />),
+    SortArrow: forwardRef((props, ref) => <ArrowDownward {...props} ref={ref} />),
     ThirdStateCheck: forwardRef((props, ref) => <Remove {...props} ref={ref} />),
     ViewColumn: forwardRef((props, ref) => <ViewColumn {...props} ref={ref} />)
   };


### PR DESCRIPTION
## Related Issue
https://github.com/mbrn/material-table/issues/1349

## Description
Up/Down arrows are mixed up.
