### PR TITLE
Add editActionProps

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -116,6 +116,17 @@ class App extends Component {
                             }, 1000);
                         })
                 }}
+                editActionProps={{
+                  add: {
+                    'data-test-id': 'add-row'
+                  },
+                  update: {
+                    'data-test-id': 'edit-row'
+                  },
+                  delete: {
+                    'data-test-id': 'delete-row'
+                  }
+                }}
                 />
               </Grid>
             </Grid>

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -147,7 +147,7 @@ export default class MaterialTable extends React.Component {
     if (calculatedProps.editable) {
       if (calculatedProps.editable.onRowAdd) {
         calculatedProps.actions.push({
-          icon: calculatedProps.icons.Add,
+          icon: () => <calculatedProps.icons.Add {...calculatedProps.editActionProps.add} />,
           tooltip: localization.addTooltip,
           position: "toolbar",
           onClick: () => {
@@ -161,7 +161,7 @@ export default class MaterialTable extends React.Component {
       }
       if (calculatedProps.editable.onRowUpdate) {
         calculatedProps.actions.push(rowData => ({
-          icon: calculatedProps.icons.Edit,
+          icon: () => <calculatedProps.icons.Edit {...calculatedProps.editActionProps.update} />,
           tooltip: localization.editTooltip,
           disabled: calculatedProps.editable.isEditable && !calculatedProps.editable.isEditable(rowData),
           onClick: (e, rowData) => {
@@ -175,7 +175,7 @@ export default class MaterialTable extends React.Component {
       }
       if (calculatedProps.editable.onRowDelete) {
         calculatedProps.actions.push(rowData => ({
-          icon: calculatedProps.icons.Delete,
+          icon: () => <calculatedProps.icons.Delete {...calculatedProps.editActionProps.delete} />,
           tooltip: localization.deleteTooltip,
           disabled: calculatedProps.editable.isDeletable && !calculatedProps.editable.isDeletable(rowData),
           onClick: (e, rowData) => {

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -73,6 +73,11 @@ export const propTypes = {
     onRowUpdate: PropTypes.func,
     onRowDelete: PropTypes.func
   }),
+  editActionProps: PropTypes.shape({
+    add: PropTypes.object,
+    update: PropTypes.object,
+    delete: PropTypes.object,
+  }),
   detailPanel: PropTypes.oneOfType([
     PropTypes.func,
     PropTypes.arrayOf(PropTypes.oneOfType([


### PR DESCRIPTION
New props "editActionProps" for passing props directly to the icons displayed for actions defined in the "editable" prop

## Description
The goal of this PR is to enable developers to add custom props to the icons that are being displayed for actions rendered when the `editable` prop is set.
Therefore a new prop has been introduced: `editActionProps`
`editActionProps` allows any valid Object to be passed, from which each entry will be rendered as a prop directly on the icon for the respective action.
For an example please refer to the updated Demo in `demo/demo.js` where each action gets passed a `data-test-id` as an arbitrary example. 

The reason for this was the need to identify these actions in a test-case. Custom actions were not sufficient to solve this usecase, since they do not allow for the use of the internal `editRow` as a means of data input.

## Impacted Areas in Application
For the user of this component only the main entry will be impacted. The newly introduced prop is a top-level _optional_ prop, which can me omitted if not needed.

## Additional Notes
It is, of course, entirely possible, that I am missing some way to fulfill the aforementioned usecase, and if so, I would be thankful for any feedback.

As another sidenode: This is my first time contributing to any kind of open-source project, so I may made some rookie-mistakes along the way and kindly ask for your understanding if this is the case.

Thanks for this amazing component which I intend to continuously use throughout various projects!