### PR TITLE
Set row equal to a new object, with new ref, to prevent Material-Tabl…

### DIFF
--- a/src/utils/data-manager.js
+++ b/src/utils/data-manager.js
@@ -47,7 +47,7 @@ export default class DataManager {
     this.selectedCount = 0;
 
     this.data = data.map((row, index) => {
-      row.tableData = { ...row.tableData, id: index };
+      row = {...row, tableData: { ...row.tableData, id: index }};
       if (row.tableData.checked) {
         this.selectedCount++;
       }


### PR DESCRIPTION
…e from mutating variable passed through the data prop;

## Related Issue
Relate the Github issue with this PR using #1371

## Description
We are passing an array of objects from our app's Redux state to the data prop. Material Table mutates that Redux state by adding a tableData property to each object in the array. This unexpected mutation of our apps Redux state caused some of our data to be corrupted when we saved the state back to our database (now with the inclusion of the tableData property.

This pull request prevents the mutation of data described above.
