### PR TITLE
Call onChangePage on changePageSize

### DIFF
--- a/src/material-table.js
+++ b/src/material-table.js
@@ -254,6 +254,8 @@ export default class MaterialTable extends React.Component {
     const pageSize = event.target.value;
 
     this.dataManager.changePageSize(pageSize);
+	  
+    this.props.onChangePage && this.props.onChangePage(0);
 
     if (this.isRemoteData()) {
       const query = { ...this.state.query };


### PR DESCRIPTION
## Related Issue
#1376

## Description
This adds the missing onChangePage call on onChangeRowsPerPage and the page is set to 0.


## Impacted Areas in Application
* material-table
