### PR TITLE
Fix header scrolls with the body

### DIFF
--- a/src/material-table.js
+++ b/src/material-table.js
@@ -580,7 +580,7 @@ export default class MaterialTable extends React.Component {
             <Droppable droppableId="headers" direction="horizontal">
               {(provided, snapshot) => (
                 <div ref={provided.innerRef}>
-                  <div style={{ maxHeight: props.options.maxBodyHeight, minHeight: props.options.minBodyHeight, overflowY: 'auto' }}>
+                  <div style={{ maxHeight: props.options.maxBodyHeight, minHeight: props.options.minBodyHeight }}>
                     <Table>
                       {props.options.header &&
                         <props.components.Header


### PR DESCRIPTION
Removing the auto overflow-y prevents body scrolling with the header, making it really sticky.
With overflow-y:'auto', the header scrolls as a regular row

## Related Issue
Relate the Github issue with this PR using `#`

## Description
Simple words to describe the overall goals of the pull request's commits.

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
other_pr_production | [link]()
other_pr_master | [link]()

## Impacted Areas in Application
List general components of the application that this PR will affect:

*

## Additional Notes
This is optional, feel free to follow your hearth and write here :)