### PR TITLE
Fix the error when lookup value is null.

### DIFF
--- a/src/utils/data-manager.js
+++ b/src/utils/data-manager.js
@@ -521,7 +521,7 @@ export default class DataManager {
               const value = this.getFieldValue(row, columnDef, false);
               return !tableData.filterValue ||
                 tableData.filterValue.length === 0 ||
-                tableData.filterValue.indexOf(value !== undefined && value.toString()) > -1;
+                tableData.filterValue.indexOf(value !== undefined && value !== null && value.toString()) > -1;
             });
           } else if (type === 'numeric') {
             this.filteredData = this.filteredData.filter(row => {


### PR DESCRIPTION
## Description
An error occurred if using null value.
```
data-manager.js:180 Uncaught TypeError: Cannot read property 'toString' of null
    at data-manager.js:180
    at Array.filter (<anonymous>)
    at data-manager.js:177
    at Array.forEach (<anonymous>)
    at DataManager.filterData (data-manager.js:166)
    at DataManager.getRenderState (data-manager.js:119)
    at MaterialTable.<anonymous> (material-table.js:355)
```

## Additional Notes
Thanks for your great library :)