### PR TITLE
Fix issue #1321: broken isEditable and isDeletable options

### DIFF
--- a/src/components/m-table-action.js
+++ b/src/components/m-table-action.js
@@ -9,7 +9,7 @@ import Tooltip from '@material-ui/core/Tooltip';
 class MTableAction extends React.Component {
   render() {
     let action = this.props.action;
-    const disabled = action.disabled || this.props.disabled;
+    
     if (typeof action === 'function') {
       action = action(this.props.data);
       if (!action) {
@@ -27,6 +27,8 @@ class MTableAction extends React.Component {
     if (action.hidden) {
       return null;
     }
+
+    const disabled = action.disabled || this.props.disabled;
 
     const handleOnClick = event => {
       if (action.onClick) {


### PR DESCRIPTION
## Related Issue
isEditable conditional is broken in version 1.54.1 #1321

## Description
Fixes a bug that is causing the `editable` property's `isEditable` and `isDeletable` options to be ignored.
