### PR TITLE
After retrieving the value out of the Select component when editing a…

### DIFF
--- a/src/components/m-table-edit-field.js
+++ b/src/components/m-table-edit-field.js
@@ -13,12 +13,36 @@ class MTableEditField extends React.Component {
     return props;
   }
 
+  coerceLookupType(type, value) {
+    if (type === 'numeric') {
+        if (value.toString().indexOf('.') > -1) {
+            return parseFloat(value);
+        } else {
+            return parseInt(value);
+        }
+    } else if (type === 'boolean') {
+        return value === 'true';
+    } else if (type === 'datetime') {
+        return new Date(value);
+    } else if (type === 'time') {
+        return value;
+    } else {
+        return value;
+    }
+  }
+
   renderLookupField() {
     return (
       <Select
         {...this.getProps()}
         value={this.props.value === undefined ? '' : this.props.value}
-        onChange={event => this.props.onChange(event.target.value)}
+        onChange={event => {
+            let value = event.target.value;
+            if (this.props.columnDef.type !== undefined) {
+              value = this.coerceLookupType(this.props.columnDef.type, event.target.value);
+            }
+            return this.props.onChange(value);
+        }}
         style={{
           fontSize: 13,
         }}


### PR DESCRIPTION
… field with the lookup property, attempt to coerce it to the right typeif type is also set on the column.

## Related Issue
#1402 

## Description
Enforce types of data values based on the column's type when a column uses the lookup feature.

## Related PRs
None

## Impacted Areas in Application
List general components of the application that this PR will affect:

* Columns that use the lookup and type attributes in tandem.

## Additional Notes
I don't know enough about the project to know if this change will have unintended side effects. I tested it with my local project and it works for the issue I've identified.