### PR TITLE
Expose a cspNonce option and pass it to react-beautiful-dnd's DragDro…

### DIFF
--- a/src/material-table.js
+++ b/src/material-table.js
@@ -533,7 +533,7 @@ export default class MaterialTable extends React.Component {
     const props = this.getProps();
 
     return (
-      <DragDropContext onDragEnd={this.onDragEnd}>
+      <DragDropContext onDragEnd={this.onDragEnd} nonce={props.options.cspNonce}>
         <props.components.Container style={{ position: 'relative', ...props.style }}>
           {props.options.toolbar &&
             <props.components.Toolbar

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -234,6 +234,7 @@ export interface Options {
   toolbar?: boolean;
   toolbarButtonAlignment?: 'left' | 'right';
   detailPanelColumnAlignment?: 'left' | 'right';
+  cspNonce?: string;
 }
 
 export interface Localization {


### PR DESCRIPTION
…pContext component.

## Related Issue
#1436

## Description
Allow consumers of material-table to supply a nonce that will be passed to react-beautiful-dnd's DragDropContext for CSP purposes.

## Related PRs
N/A

## Impacted Areas in Application
The DragDropContext component from react-beautiful-dnd will be impacted because it will optionally have a nonce specified for it.

## Additional Notes
N/A