### PR TITLE
add onclick event to detailPanel

### DIFF
--- a/src/components/m-table-body-row.js
+++ b/src/components/m-table-body-row.js
@@ -137,6 +137,7 @@ export default class MTableBodyRow extends React.Component {
                   style={{ transition: 'all ease 200ms', ...this.rotateIconStyle(animation && isOpen) }}
                   disabled={panel.disabled}
                   onClick={(event) => {
+                    panel.onClick && panel.onClick(this.props.data);
                     this.props.onToggleDetailPanel(this.props.path, panel.render);
                     event.stopPropagation();
                   }}

--- a/src/components/m-table-body-row.js
+++ b/src/components/m-table-body-row.js
@@ -137,7 +137,9 @@ export default class MTableBodyRow extends React.Component {
                   style={{ transition: 'all ease 200ms', ...this.rotateIconStyle(animation && isOpen) }}
                   disabled={panel.disabled}
                   onClick={(event) => {
-                    panel.onClick && panel.onClick(this.props.data);
+                    if (!isOpen) {
+                      panel.onClick && panel.onClick(this.props.data);
+                    }
                     this.props.onToggleDetailPanel(this.props.path, panel.render);
                     event.stopPropagation();
                   }}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -69,6 +69,7 @@ export interface DetailPanel<RowData extends object> {
   icon?: string | React.ComponentType<any>;
   openIcon?: string | React.ComponentType<any>;
   tooltip?: string;
+  onClick: (rowData: RowData) => void;
   render: (rowData: RowData) => string | React.ReactNode;
 }
 


### PR DESCRIPTION
## Related Issue
[`#1274`](https://github.com/mbrn/material-table/issues/1274)

## Description
Added onClick handler to detailPanel array. Great to make API calls when clicking on a detailPanel icon

## Impacted Areas in Application
List general components of the application that this PR will affect:

* renderDetailPanelColumn
* detailPanel props
