### PR TITLE
Add the ability to chose the variant of the search text field

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -114,6 +114,12 @@ class App extends Component {
               options={{
                 grouping: true,
                 filtering: true,
+                searchFieldVariant: 'outlined',
+              }}
+              localization={{
+                toolbar: {
+                  searchPlaceholder: "Outlined Search Field",
+                }
               }}
               data={query => new Promise((resolve, reject) => {
                 let url = 'https://reqres.in/api/users?'

--- a/src/components/m-table-toolbar.js
+++ b/src/components/m-table-toolbar.js
@@ -63,6 +63,7 @@ export class MTableToolbar extends React.Component {
         <TextField
           className={this.props.searchFieldAlignment === 'left' && this.props.showTitle === false ? null : this.props.classes.searchField}
           value={this.props.searchText}
+          variant={this.props.searchFieldVariant}
           onChange={event => this.props.onSearchChanged(event.target.value)}
           placeholder={localization.searchPlaceholder}          
           InputProps={{
@@ -242,6 +243,7 @@ MTableToolbar.defaultProps = {
   toolbarButtonAlignment: 'right',
   searchFieldAlignment: 'right',
   searchText: '',
+  searchFieldVariant: 'standard',
   selectedRows: [],
   title: 'No Title!'
 };
@@ -258,6 +260,7 @@ MTableToolbar.propTypes = {
   search: PropTypes.bool.isRequired,
   searchFieldStyle: PropTypes.object,
   searchText: PropTypes.string.isRequired,
+  searchFieldVariant: PropTypes.string,
   selectedRows: PropTypes.array,
   title: PropTypes.oneOfType([PropTypes.element, PropTypes.string]),
   showTitle: PropTypes.bool.isRequired,

--- a/src/default-props.js
+++ b/src/default-props.js
@@ -94,6 +94,7 @@ export const defaultProps = {
     toolbarButtonAlignment: 'right',
     searchFieldAlignment: 'right',
     searchFieldStyle: {},
+    searchFieldVariant: 'standard',
     selection: false,
     selectionProps: {},
     sorting: true,

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -558,6 +558,7 @@ export default class MaterialTable extends React.Component {
               searchFieldAlignment={props.options.searchFieldAlignment}
               searchText={this.state.searchText}
               searchFieldStyle={props.options.searchFieldStyle}
+              searchFieldVariant={props.options.searchFieldVariant}
               title={props.title}
               onSearchChanged={this.onSearchChange}
               onColumnsChanged={this.onChangeColumnHidden}

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -143,6 +143,7 @@ export const propTypes = {
     toolbarButtonAlignment: PropTypes.oneOf(['left', 'right']),
     searchFieldAlignment: PropTypes.oneOf(['left', 'right']),
     searchFieldStyle: PropTypes.object,
+    searchFieldVariant: PropTypes.oneOf( ['standard', 'filled', 'outlined']),
     selection: PropTypes.bool,
     selectionProps: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
     showEmptyDataSourceMessage: PropTypes.bool,


### PR DESCRIPTION
## Related Issue
#1291 (Partially)

## Description
Added the ability to chose the variant of the search field by providing **searchFieldVariant** under the **options** props.
The possible values are _standard_, _filled_ , _outlined_.
If not provided the default value is standard

## Example usage
`
<MaterialTable>
...
  options={{
    searchFieldVariant: 'outlined',
   }}
</MaterialTable>
`
![search_field_variant](https://user-images.githubusercontent.com/23128418/71519863-f0161680-28c1-11ea-9564-dee6bcc117e4.png)

## Impacted Areas in Application

* MTableToolbar component
* Demo application which was updated to showcase the change

## Additional Notes
There was also an attempt to provide the ability to chose variant for the filter fields. The problem was with the lookup filter which did not render the correct variant but kept using the standard one as shown in the picture below. 
![problem_lookup](https://user-images.githubusercontent.com/23128418/71519908-2784c300-28c2-11ea-8716-2b4c5c34bb44.png)
This might be related to #1061. Due to this inability to change the variant of the lookup filter, no change was made to the other filters to ensure consistency

