### PR TITLE
Feature/add labels to inputs

### DIFF
--- a/src/components/m-table-edit-field.js
+++ b/src/components/m-table-edit-field.js
@@ -15,20 +15,20 @@ class MTableEditField extends React.Component {
 
   renderLookupField() {
     return (
-      <Select
-        {...this.getProps()}
-        value={this.props.value === undefined ? '' : this.props.value}
-        onChange={event => this.props.onChange(event.target.value)}
-        style={{
-          fontSize: 13,
-        }}
-      >
-        {Object.keys(this.props.columnDef.lookup).map(key => (
-          <MenuItem key={key} value={key}>{this.props.columnDef.lookup[key]}</MenuItem>)
-        )}
-      </Select>
+        <Select
+          {...this.getProps()}
+          value={this.props.value === undefined ? '' : this.props.value}
+          onChange={event => this.props.onChange(event.target.value)}
+          style={{
+            fontSize: 13,
+          }}
+          SelectDisplayProps={{ 'aria-label': this.props.columnDef.title }}
+        >
+          {Object.keys(this.props.columnDef.lookup).map(key => (
+            <MenuItem key={key} value={key}>{this.props.columnDef.lookup[key]}</MenuItem>)
+          )}
+        </Select>
     );
-
   }
 
   renderBooleanField() {
@@ -43,6 +43,9 @@ class MTableEditField extends React.Component {
           paddingTop: 0,
           paddingBottom: 0
         }}
+        inputProps={{
+          'aria-label': this.props.columnDef.title
+        }}
       />
     );
   }
@@ -51,18 +54,21 @@ class MTableEditField extends React.Component {
     return (
       <MuiPickersUtilsProvider utils={DateFnsUtils}
         locale={this.props.dateTimePickerLocalization}>
-        <DatePicker
-          {...this.getProps()}
-          format="dd.MM.yyyy"
-          value={this.props.value || null}
-          onChange={this.props.onChange}
-          clearable
-          InputProps={{
-            style: {
-              fontSize: 13,
-            }
-          }}
-        />
+
+          <DatePicker
+            {...this.getProps()}
+            format="dd.MM.yyyy"
+            value={this.props.value || null}
+            onChange={this.props.onChange}
+            clearable
+            InputProps={{
+              style: {
+                fontSize: 13,
+              },
+              'aria-label': `${this.props.columnDef.title}: press space to edit`
+            }}
+          />
+
       </MuiPickersUtilsProvider>
     );
   }
@@ -71,18 +77,19 @@ class MTableEditField extends React.Component {
       <MuiPickersUtilsProvider
         utils={DateFnsUtils}
         locale={this.props.dateTimePickerLocalization}>
-        <TimePicker
-          {...this.getProps()}
-          format="HH:mm:ss"
-          value={this.props.value || null}
-          onChange={this.props.onChange}
-          clearable
-          InputProps={{
-            style: {
-              fontSize: 13,
-            }
-          }}
-        />
+          <TimePicker
+            {...this.getProps()}
+            format="HH:mm:ss"
+            value={this.props.value || null}
+            onChange={this.props.onChange}
+            clearable
+            InputProps={{
+              style: {
+                fontSize: 13,
+              },
+              'aria-label': `${this.props.columnDef.title}: press space to edit`
+            }}
+          />
       </MuiPickersUtilsProvider>
     );
   }
@@ -91,18 +98,19 @@ class MTableEditField extends React.Component {
     return (
       <MuiPickersUtilsProvider utils={DateFnsUtils}
         locale={this.props.dateTimePickerLocalization}>
-        <DateTimePicker
-          {...this.getProps()}
-          format="dd.MM.yyyy HH:mm:ss"
-          value={this.props.value || null}
-          onChange={this.props.onChange}
-          clearable
-          InputProps={{
-            style: {
-              fontSize: 13,
-            }
-          }}
-        />
+          <DateTimePicker
+            {...this.getProps()}
+            format="dd.MM.yyyy HH:mm:ss"
+            value={this.props.value || null}
+            onChange={this.props.onChange}
+            clearable
+            InputProps={{
+              style: {
+                fontSize: 13,
+              },
+              'aria-label': `${this.props.columnDef.title}: press space to edit`
+            }}
+          />
       </MuiPickersUtilsProvider>
     );
   }
@@ -119,6 +127,9 @@ class MTableEditField extends React.Component {
         InputProps={{
           style: {
             fontSize: 13,
+          },
+          inputProps: {
+            'aria-label': this.props.columnDef.title
           }
         }}
       />
@@ -135,7 +146,8 @@ class MTableEditField extends React.Component {
         inputProps={{
           style: {
             fontSize: 13,
-            textAlign: "right"
+            textAlign: 'right',
+            'aria-label': this.props.columnDef.title
           }
         }}
       />

--- a/src/components/m-table-edit-field.js
+++ b/src/components/m-table-edit-field.js
@@ -52,23 +52,25 @@ class MTableEditField extends React.Component {
 
   renderDateField() {
     return (
-      <MuiPickersUtilsProvider utils={DateFnsUtils}
-        locale={this.props.dateTimePickerLocalization}>
-
-          <DatePicker
-            {...this.getProps()}
-            format="dd.MM.yyyy"
-            value={this.props.value || null}
-            onChange={this.props.onChange}
-            clearable
-            InputProps={{
-              style: {
-                fontSize: 13,
-              },
-              'aria-label': `${this.props.columnDef.title}: press space to edit`
-            }}
-          />
-
+      <MuiPickersUtilsProvider
+        utils={DateFnsUtils}
+        locale={this.props.dateTimePickerLocalization}
+      >
+        <DatePicker
+          {...this.getProps()}
+          format='dd.MM.yyyy'
+          value={this.props.value || null}
+          onChange={this.props.onChange}
+          clearable
+          InputProps={{
+            style: {
+              fontSize: 13
+            }
+          }}
+          inputProps={{
+            'aria-label': `${this.props.columnDef.title}: press space to edit`
+          }}
+        />
       </MuiPickersUtilsProvider>
     );
   }
@@ -76,41 +78,49 @@ class MTableEditField extends React.Component {
     return (
       <MuiPickersUtilsProvider
         utils={DateFnsUtils}
-        locale={this.props.dateTimePickerLocalization}>
-          <TimePicker
-            {...this.getProps()}
-            format="HH:mm:ss"
-            value={this.props.value || null}
-            onChange={this.props.onChange}
-            clearable
-            InputProps={{
-              style: {
-                fontSize: 13,
-              },
+        locale={this.props.dateTimePickerLocalization}
+      >
+        <TimePicker
+          {...this.getProps()}
+          format='HH:mm:ss'
+          value={this.props.value || null}
+          onChange={this.props.onChange}
+          clearable
+          InputProps={{
+            style: {
+              fontSize: 13
+            },
+            inputProps: {
               'aria-label': `${this.props.columnDef.title}: press space to edit`
-            }}
-          />
+            }
+          }}
+        />
       </MuiPickersUtilsProvider>
     );
   }
 
   renderDateTimeField() {
     return (
-      <MuiPickersUtilsProvider utils={DateFnsUtils}
-        locale={this.props.dateTimePickerLocalization}>
-          <DateTimePicker
-            {...this.getProps()}
-            format="dd.MM.yyyy HH:mm:ss"
-            value={this.props.value || null}
-            onChange={this.props.onChange}
-            clearable
-            InputProps={{
-              style: {
-                fontSize: 13,
-              },
-              'aria-label': `${this.props.columnDef.title}: press space to edit`
-            }}
-          />
+      <MuiPickersUtilsProvider
+        utils={DateFnsUtils}
+        locale={this.props.dateTimePickerLocalization}
+      >
+        <DateTimePicker
+          {...this.getProps()}
+          format='dd.MM.yyyy HH:mm:ss'
+          value={this.props.value || null}
+          onChange={this.props.onChange}
+          clearable
+          InputProps={{
+            style: {
+              fontSize: 13
+            },
+            inputProps:{
+            'aria-label': `${this.props.columnDef.title}: press space to edit`
+          }
+          }}
+          
+        />
       </MuiPickersUtilsProvider>
     );
   }

--- a/src/components/m-table-filter-row.js
+++ b/src/components/m-table-filter-row.js
@@ -79,6 +79,7 @@ class MTableFilterRow extends React.Component {
         type={columnDef.type === 'numeric' ? 'number' : 'search'}
         value={columnDef.tableData.filterValue || ''}
         placeholder={columnDef.filterPlaceholder || ''}
+        inputProps={{'aria-label': `filter data by ${columnDef.title}`}}
         onChange={(event) => {
           this.props.onFilterChanged(columnDef.tableData.id, event.target.value);
         }}

--- a/src/components/m-table-toolbar.js
+++ b/src/components/m-table-toolbar.js
@@ -83,7 +83,10 @@ export class MTableToolbar extends React.Component {
                 </IconButton>
               </InputAdornment>
             ),
-            style: this.props.searchFieldStyle
+            style: this.props.searchFieldStyle,
+            inputProps: {
+              'aria-label': "Search"
+            }
           }}
         />
       );


### PR DESCRIPTION
## Related Issue
This PR addresses the issues detailed in #1498 (Missing labels on edit components)
It also addresses #1375 (Missing label on Search input)

## Description

This PR adds aria-labels to each of the table-edit-fields, and also the toolbar's search input. This has no visual impact, but means that the column currently being edited is announced to screen reader users as they fill out the form. It also advises screen reader users on how to open the date/time pickers with the keyboard.


## Impacted Areas in Application

* toolbar (search input)
* table-edit-fields (all components)

## Additional Notes
Let me know if you have any questions about the PR!