### PR TITLE
Update action types to support current icon usage

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,6 +1,9 @@
 import * as React from 'react';
 import { IconProps } from '@material-ui/core/Icon';
+import SvgIcon from "@material-ui/core/SvgIcon"
 import { string } from 'prop-types';
+
+type SvgIconComponent = typeof SvgIcon;
 
 export interface MaterialTableProps<RowData extends object> {
   actions?: (Action<RowData> | ((rowData: RowData) => Action<RowData>))[];
@@ -74,7 +77,7 @@ export interface DetailPanel<RowData extends object> {
 
 export interface Action<RowData extends object> {
   disabled?: boolean;
-  icon: string | (() => React.ReactElement<any>);
+  icon: string | (() => React.ReactElement<any>) | SvgIconComponent;
   isFreeAction?: boolean;
   position?: 'auto' | 'toolbar' | 'toolbarOnSelect' | 'row';
   tooltip?: string;


### PR DESCRIPTION
## Description
The usage below works as it is supported in the code but when using TypeScript (I am on 3.7.x) it complains about the field labelled "icon" being incorrect. I have update the types based on [@material-ui/icons](https://github.com/mui-org/material-ui/blob/e168bc694a7c7a59e86990e2a3677938acf7e953/packages/material-ui-icons/scripts/create-typings.js#L24). Since this project does not include "@material-ui/icons", I just recreated the type in the same way they did it on line 24. 

`
import { Save } from "@material-ui/icons"
import { Action } from "material-table"

const saveAction: Action<{ id: number}> = {
  icon: Save,
  tooltip: "Save",
  onClick: () => { /* ... */},
}
`