### PR TITLE
Option to have icons display oriented according to initial column sorting

### DIFF
--- a/src/components/m-table-header.js
+++ b/src/components/m-table-header.js
@@ -41,7 +41,12 @@ export class MTableHeader extends React.Component {
             <TableSortLabel
               IconComponent={this.props.icons.SortArrow}
               active={this.props.orderBy === columnDef.tableData.id}
-              direction={this.props.orderDirection || 'asc'}
+              direction={
+                this.props.iconMatchOrientation
+                  ? this.props.orderDirection || 'asc'
+                  : this.props.orderBy === columnDef.tableData.id
+                  ? this.props.orderDirection || 'asc' : 'asc'
+              }
               onClick={() => {
                 const orderDirection =
                   columnDef.tableData.id !== this.props.orderBy
@@ -186,6 +191,7 @@ MTableHeader.defaultProps = {
   detailPanelColumnAlignment: "left",
   draggable: true,
   thirdSortClick: true,
+  iconMatchOrientation: true,
 };
 
 MTableHeader.propTypes = {
@@ -207,6 +213,7 @@ MTableHeader.propTypes = {
   showSelectAllCheckbox: PropTypes.bool,
   draggable: PropTypes.bool,
   thirdSortClick: PropTypes.bool,
+  iconMatchOrientation: PropTypes.bool,
 };
 
 

--- a/src/components/m-table-header.js
+++ b/src/components/m-table-header.js
@@ -37,19 +37,19 @@ export class MTableHeader extends React.Component {
         }
 
         if (columnDef.sorting !== false && this.props.sorting) {
+          const isActive = this.props.orderBy === columnDef.tableData.id;
           content = (
             <TableSortLabel
               IconComponent={this.props.icons.SortArrow}
-              active={this.props.orderBy === columnDef.tableData.id}
+              active={isActive}
               direction={
-                this.props.iconMatchOrientation
-                  ? this.props.orderDirection || 'asc'
-                  : this.props.orderBy === columnDef.tableData.id
-                  ? this.props.orderDirection || 'asc' : 'asc'
+                !isActive && !this.props.iconMatchOrientation
+                  ? 'asc'
+                  : this.props.orderDirection || 'asc'
               }
               onClick={() => {
                 const orderDirection =
-                  columnDef.tableData.id !== this.props.orderBy
+                  !isActive
                     ? 'asc'
                     : this.props.orderDirection === 'asc'
                     ? 'desc'

--- a/src/default-props.js
+++ b/src/default-props.js
@@ -101,6 +101,7 @@ export const defaultProps = {
     defaultExpanded: false,
     detailPanelColumnAlignment: 'left',
     thirdSortClick: true,
+    iconMatchOrientation: true,
   },
   localization: {
     grouping: {

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -609,6 +609,7 @@ export default class MaterialTable extends React.Component {
                           isTreeData={this.props.parentChildData !== undefined}
                           draggable={props.options.draggable}
                           thirdSortClick={props.options.thirdSortClick}
+                          iconMatchOrientation={props.options.iconMatchOrientation}
                         />
                       }
                       <props.components.Body

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -153,6 +153,7 @@ export const propTypes = {
     sorting: PropTypes.bool,
     toolbar: PropTypes.bool,
     thirdSortClick: PropTypes.bool,
+    iconMatchOrientation: PropTypes.bool,
   }),
   localization: PropTypes.shape({
     grouping: PropTypes.shape({

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -231,6 +231,7 @@ export interface Options {
   selectionProps?: any | ((data: any) => any);
   sorting?: boolean;
   thirdSortClick?: boolean;
+  iconMatchOrientation?: boolean;
   toolbar?: boolean;
   toolbarButtonAlignment?: 'left' | 'right';
   detailPanelColumnAlignment?: 'left' | 'right';


### PR DESCRIPTION
For certain use cases it is desirable to have the icons in a column header appear in the orientation that the column will be sorted by if selected. This PR allows that while leaving the previous behaviour on by default

Old behaviour (with Adı selected, and Soyadı hovered):
![Screenshot from 2020-01-09 18-20-43](https://user-images.githubusercontent.com/4065445/72040372-3da47180-330d-11ea-84b6-28ae24e73f8b.png)

New desired behaviour (with Adı selected, and Soyadı hovered):
![Screenshot from 2020-01-09 18-21-01](https://user-images.githubusercontent.com/4065445/72040376-4137f880-330d-11ea-97b3-648c28752a6a.png)

configuration is through a toplevel option `iconMatchOrientation` with the default value of `true`. Setting it to `false` enables the new behaviour