### PR TITLE
Ensure 'disabled' property is applied to icon if return by function

### DIFF
--- a/src/components/m-table-action.js
+++ b/src/components/m-table-action.js
@@ -9,7 +9,6 @@ import Tooltip from '@material-ui/core/Tooltip';
 class MTableAction extends React.Component {
   render() {
     let action = this.props.action;
-    const disabled = action.disabled || this.props.disabled;
     if (typeof action === 'function') {
       action = action(this.props.data);
       if (!action) {
@@ -27,6 +26,7 @@ class MTableAction extends React.Component {
     if (action.hidden) {
       return null;
     }
+    const disabled = action.disabled || this.props.disabled;
 
     const handleOnClick = event => {
       if (action.onClick) {


### PR DESCRIPTION
If action is a function which returns 'disabled' property it was not taken into account. 