### PR TITLE
Add option to pass props to action IconButton 🎉

### DIFF
--- a/src/components/m-table-action.js
+++ b/src/components/m-table-action.js
@@ -49,6 +49,7 @@ class MTableAction extends React.Component {
           color="inherit"
           disabled={disabled}
           onClick={(event) => handleOnClick(event)}
+          {...action.iconButtonProps}
         >
           {icon}
         </IconButton>

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -13,6 +13,7 @@ export const propTypes = {
     position: PropTypes.oneOf(['auto', 'toolbar', 'toolbarOnSelect', 'row']),
     tooltip: PropTypes.string,
     onClick: PropTypes.func.isRequired,
+    iconButtonProps: PropTypes.object,
     iconProps: PropTypes.object,
     disabled: PropTypes.bool,
     hidden: PropTypes.bool,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { IconButtonProps } from '@material-ui/core/IconButton';
 import { IconProps } from '@material-ui/core/Icon';
 import { string } from 'prop-types';
 
@@ -79,6 +80,7 @@ export interface Action<RowData extends object> {
   position?: 'auto' | 'toolbar' | 'toolbarOnSelect' | 'row';
   tooltip?: string;
   onClick: (event: any, data: RowData | RowData[]) => void;
+  iconButtonProps?: IconButtonProps
   iconProps?: IconProps;
   hidden?: boolean;
 }


### PR DESCRIPTION
## Related Issue
Fixes #1540

## Description
This change allows to pass `props` to the `<IconButton/>` so we can tweak it (e.g: pass a `className` prop so we can modify the styles without need to modify material theme as currently you need to do if you want to do this)

## Impacted Areas in Application
List general components of the application that this PR will affect:

* MTableAction
* Types

## Additional Notes

LGTM ;-)