### PR TITLE
Disable add button when in edit mode

### DIFF
--- a/src/material-table.js
+++ b/src/material-table.js
@@ -151,6 +151,7 @@ export default class MaterialTable extends React.Component {
           icon: calculatedProps.icons.Add,
           tooltip: localization.addTooltip,
           position: "toolbar",
+          disabled: !!(this.dataManager.lastEditingRow),
           onClick: () => {
             this.dataManager.changeRowEditing();
             this.setState({


### PR DESCRIPTION
## Related Issue
#1554 

## Description
Simply disable add button when a row is being edited. When a new row has been added the add button is still visible though. 
