### PR TITLE
allow overriding of self-defined classes

### DIFF
--- a/src/components/m-table-header.js
+++ b/src/components/m-table-header.js
@@ -207,6 +207,7 @@ MTableHeader.propTypes = {
   detailPanelColumnAlignment: PropTypes.string,
   hasSelection: PropTypes.bool,
   headerStyle: PropTypes.object,
+  headerClassOverrides: PropTypes.object,
   localization: PropTypes.object,
   selectedCount: PropTypes.number,
   sorting: PropTypes.bool,

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -111,6 +111,7 @@ export default class MaterialTable extends React.Component {
     calculatedProps.components = { ...MaterialTable.defaultProps.components, ...calculatedProps.components };
     calculatedProps.icons = { ...MaterialTable.defaultProps.icons, ...calculatedProps.icons };
     calculatedProps.options = { ...MaterialTable.defaultProps.options, ...calculatedProps.options };
+    calculatedProps.classes = { ...calculatedProps.classes, ...calculatedProps.options.tableClassOverrides };
 		
     const localization =  { ...MaterialTable.defaultProps.localization.body, ...calculatedProps.localization.body };
 
@@ -518,8 +519,8 @@ export default class MaterialTable extends React.Component {
                 onChangePage={this.onChangePage}
                 onChangeRowsPerPage={this.onChangeRowsPerPage}
                 ActionsComponent={(subProps) => props.options.paginationType === 'normal' ?
-                  <MTablePagination {...subProps} icons={props.icons} localization={localization} showFirstLastPageButtons={props.options.showFirstLastPageButtons} /> :
-                  <MTableSteppedPagination {...subProps} icons={props.icons} localization={localization} showFirstLastPageButtons={props.options.showFirstLastPageButtons} />}
+                  <MTablePagination {...subProps} icons={props.icons} localization={localization} showFirstLastPageButtons={props.options.showFirstLastPageButtons} classes={props.options.paginationClassOverrides} /> :
+                  <MTableSteppedPagination {...subProps} icons={props.icons} localization={localization} showFirstLastPageButtons={props.options.showFirstLastPageButtons} classes={props.options.steppedPaginationClassOverrides} />}
                 labelDisplayedRows={(row) => localization.labelDisplayedRows.replace('{from}', row.from).replace('{to}', row.to).replace('{count}', row.count)}
                 labelRowsPerPage={localization.labelRowsPerPage}
               />
@@ -577,7 +578,7 @@ export default class MaterialTable extends React.Component {
               onGroupRemoved={this.onGroupRemoved}
             />
           }
-          <ScrollBar double={props.options.doubleHorizontalScroll}>
+          <ScrollBar double={props.options.doubleHorizontalScroll} classes={props.options.scrollbarClassOverrides}>
             <Droppable droppableId="headers" direction="horizontal">
               {(provided, snapshot) => (
                 <div ref={provided.innerRef}>
@@ -589,6 +590,7 @@ export default class MaterialTable extends React.Component {
                           columns={this.state.columns}
                           hasSelection={props.options.selection}
                           headerStyle={props.options.headerStyle}
+                          classes={props.options.headerClassOverrides}
                           icons={props.icons}
                           selectedCount={this.state.selectedCount}
                           dataCount={

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -128,6 +128,7 @@ export const propTypes = {
     filterCellStyle: PropTypes.object,
     header: PropTypes.bool,
     headerStyle: PropTypes.object,
+    headerClassOverrides: PropTypes.object,
     hideFilterIcons: PropTypes.bool,
     initialPage: PropTypes.number,
     maxBodyHeight: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -188,6 +188,12 @@ export interface Icons {
   ViewColumn?: React.ForwardRefExoticComponent<React.RefAttributes<SVGSVGElement>>;
 }
 
+export type MTableClassKeys = 'paginationRoot' | 'paginationToolbar' | 'paginationCaption' | 'paginationSelectRoot';
+export type MTableHeaderClassKeys = 'header';
+export type MTableScrollBarClassKeys = 'horizontalScrollContainer';
+export type MTablePaginationClassKeys = 'root';
+export type MTableSteppedPaginationClassKeys = 'root';
+
 export interface Options {
   actionsCellStyle?: React.CSSProperties;
   actionsColumnIndex?: number;
@@ -209,6 +215,11 @@ export interface Options {
   groupRowSeparator?: string;
   header?: boolean;
   headerStyle?: React.CSSProperties;
+  tableClassOverrides?: Partial<Record<MTableClassKeys, string>>;
+  headerClassOverrides?: Partial<Record<MTableHeaderClassKeys, string>>;
+  scrollbarClassOverrides?: Partial<Record<MTableScrollBarClassKeys, string>>;
+  paginationClassOverrides?: Partial<Record<MTablePaginationClassKeys, string>>;
+  steppedPaginationClassOverrides?: Partial<Record<MTableSteppedPaginationClassKeys, string>>;
   hideFilterIcons?: boolean;
   initialPage?: number;
   loadingType?: ('overlay' | 'linear');


### PR DESCRIPTION
## Description
MaterialTable is customizable via MaterialUI's theming.

But if you for example want the MaterialTable header to use your primary theme color, you can only use the in-line CSS style

```jsx
<MaterialTable
    {/* . . . */}
    headerStyle: {
        backgroundColor: CustomTheme.palette.primary.main,
    },
/>
```
it would be more flexible to allow custom-class overriding

```jsx
<MaterialTable
    {/* . . . */}
    headerClassOverrides: {
        header: classes.tableHeader,
    },
/>
```

## Related PRs
none

## Impacted Areas in Application
List general components of the application that this PR will affect:

* index.d.ts
* PropTypes of
  * MaterialTable
  * MTableHeader
  * Pagination
  * Scrollbar

The affected components are all components that use custom Material UI classes.

## Additional Notes
By default MaterialTables own classes will still be used. But users can choose to override them.