### PR TITLE
Fixes the unnecessary PropType warning in #1387

### DIFF
--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -80,8 +80,8 @@ export const propTypes = {
       PropTypes.func,
       PropTypes.shape({
         disabled: PropTypes.bool,
-        icon: PropTypes.oneOfType([PropTypes.element, PropTypes.func, PropTypes.string]),
-        openIcon: PropTypes.oneOfType([PropTypes.element, PropTypes.func, PropTypes.string]),
+        icon: PropTypes.oneOfType([PropTypes.element, PropTypes.func, PropTypes.string, RefComponent]),
+        openIcon: PropTypes.oneOfType([PropTypes.element, PropTypes.func, PropTypes.string, RefComponent]),
         tooltip: PropTypes.string,
         render: PropTypes.func.isRequired
       })


### PR DESCRIPTION
## Related Issue
#1387 

## Description
Fix the warning that arises when passing a ForwardRef as an icon to `detailPanel`. If you install the material icons as listed [here in the readme](Warning: Failed prop type: Invalid prop `detailPanel`), you may run into this warning when passing an icon ForwardRef as a prop, as showed in #1387 .

## Impacted Areas in Application
List general components of the application that this PR will affect:

* `detailPanel` prop in `MaterialTable`

## Additional Notes
A current workaround to silence the warning:
```
import AccountCircle from '@material-ui/icons/AccountCircle';

      ...
      <MaterialTable
        ...
        detailPanel={[
          {
            icon: () => <AccountCircle />,  // <------------- here
            tooltip: 'Show Account',
            render: rowData => <Redirect to={`/profile/${rowData.id}`} />,
          },
        ]}
      />
```
It makes more sense though to allow `RefComponent` prop type since the other `icon` prop accepts that prop type.