### PR TITLE
fix(types): change void to any for promises return on editable callbacks

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -11,9 +11,9 @@ export interface MaterialTableProps<RowData extends object> {
   editable?: {
     isEditable?: (rowData: RowData) => boolean;
     isDeletable?: (rowData: RowData) => boolean;
-    onRowAdd?: (newData: RowData) => Promise<void>;
-    onRowUpdate?: (newData: RowData, oldData?: RowData) => Promise<void>;
-    onRowDelete?: (oldData: RowData) => Promise<void>;
+    onRowAdd?: (newData: RowData) => Promise<any>;
+    onRowUpdate?: (newData: RowData, oldData?: RowData) => Promise<any>;
+    onRowDelete?: (oldData: RowData) => Promise<any>;
   }
   icons?: Icons;
   isLoading?: boolean;


### PR DESCRIPTION
## Related Issue
I haven't opened an issue for this, but current types do not work with react apollo hooks generated with graphql-codegen

See 
![errors_types](https://user-images.githubusercontent.com/15718919/73211512-4f2aad80-4144-11ea-93dd-5047e61617a0.png)

Because the functions available through the hook have a stronger Promise return Type 


## Description
This PR is meant to enhance compatibility of this library with apollo react and graphql-codegen


## Impacted Areas in Application
List general components of the application that this PR will affect:

* none

This will only affect types and **is not** a breaking change since it's more permissive, but imo the original type was restrictive and worked well by directly returning a Promise object, which does not cover use cases with third party librairies 

## Additional Notes
For now the workaround for using react apollo and graphql-codegen is to edit the types files directly in the node_modules folder