### PR TITLE
Update m-table-edit-row.js

### DIFF
--- a/src/components/m-table-edit-row.js
+++ b/src/components/m-table-edit-row.js
@@ -163,7 +163,7 @@ export default class MTableEditRow extends React.Component {
       columns = [
         <TableCell
           padding={this.props.options.actionsColumnIndex === 0 ? "none" : undefined}
-          key="key-selection-cell"
+          key="key-edit-cell"
           colSpan={colSpan}>
           <Typography variant="h6">
             {localization.deleteText}


### PR DESCRIPTION
Duplicate keys 'key-selection-cell' when having selection and editable enabled.

## Related Issue
Relate the Github issue with this PR using `#1582`