### PR TITLE
New prop option for style action inner div .

### DIFF
--- a/src/components/m-table-body-row.js
+++ b/src/components/m-table-body-row.js
@@ -37,7 +37,7 @@ export default class MTableBodyRow extends React.Component {
     const actions = this.props.actions.filter(a => a.position === "row" || typeof a === "function");
     return (
       <TableCell size={size} padding="none" key="key-actions-column" style={{ width: baseIconSize * actions.length, padding: '0px 5px', ...this.props.options.actionsCellStyle }}>
-        <div style={{  ...this.props.options.actionsCellInsideStyle }}>
+        <div style={{...this.props.options.actionsCellInsideStyle}}>
           <this.props.components.Actions data={this.props.data} actions={actions} components={this.props.components} size={size} disabled={this.props.hasAnyEditingRow} />
         </div>
       </TableCell>

--- a/src/components/m-table-body-row.js
+++ b/src/components/m-table-body-row.js
@@ -37,7 +37,7 @@ export default class MTableBodyRow extends React.Component {
     const actions = this.props.actions.filter(a => a.position === "row" || typeof a === "function");
     return (
       <TableCell size={size} padding="none" key="key-actions-column" style={{ width: baseIconSize * actions.length, padding: '0px 5px', ...this.props.options.actionsCellStyle }}>
-        <div style={{ display: 'flex' }}>
+        <div style={{  ...this.props.options.actionsCellInsideStyle }}>
           <this.props.components.Actions data={this.props.data} actions={actions} components={this.props.components} size={size} disabled={this.props.hasAnyEditingRow} />
         </div>
       </TableCell>

--- a/src/default-props.js
+++ b/src/default-props.js
@@ -66,6 +66,7 @@ export const defaultProps = {
   isLoading: false,
   title: 'Table Title',
   options: {
+    actionsCellInsideStyle :{ display: 'flex' },
     actionsColumnIndex: 0,
     addRowPosition: 'last',
     columnsButton: false,

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -111,6 +111,7 @@ export const propTypes = {
   title: PropTypes.oneOfType([PropTypes.element, PropTypes.string]),
   options: PropTypes.shape({
     actionsCellStyle: PropTypes.object,
+    actionsCellInsideStyle: PropTypes.object,
     actionsColumnIndex: PropTypes.number,
     addRowPosition: PropTypes.oneOf(['first', 'last']),
     columnsButton: PropTypes.bool,


### PR DESCRIPTION
## Related Issue
Style div action `#`1587

## Description
New prop option for style action inner div . Now you can add style to make vertical aligment of actions. Ex: { display: 'grid'} or set width to stack icon {width: }

