### PR TITLE
added onRowModifyingCancelled prop call in onEditCancelled

### DIFF
--- a/src/material-table.js
+++ b/src/material-table.js
@@ -369,6 +369,7 @@ export default class MaterialTable extends React.Component {
       this.dataManager.changeRowEditing(rowData);
       this.setState(this.dataManager.getRenderState());
     }
+    this.props.editable.onRowModifyingCancelled && this.props.editable.onRowModifyingCancelled(rowData, mode);
   }
 
   onQueryChange = (query, callback) => {
@@ -453,9 +454,9 @@ export default class MaterialTable extends React.Component {
 
       this.onQueryChange(query);
     }
-    else {		
+    else {
       this.setState(this.dataManager.getRenderState(), () => {
-        if(this.props.onFilterChange) { 
+        if(this.props.onFilterChange) {
 		const appliedFilters = this.state.columns
 			.filter(a => a.tableData.filterValue)
 			.map(a => ({

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -72,7 +72,8 @@ export const propTypes = {
   editable: PropTypes.shape({
     onRowAdd: PropTypes.func,
     onRowUpdate: PropTypes.func,
-    onRowDelete: PropTypes.func
+    onRowDelete: PropTypes.func,
+    onRowModifyingCancelled: PropTypes.func
   }),
   detailPanel: PropTypes.oneOfType([
     PropTypes.func,


### PR DESCRIPTION
## Related Issue
#1596 1596

## Description
Added a simple 'signal' from the component to notify if row modification has been cancelled 

## Impacted Areas in Application
List general components of the application that this PR will affect:

* MaterialTable only

## Additional Notes
Not much, but will save my ass at work
Now it can be used like this: 
```
 editable={{
   onRowModifyingCancelled: (newData) => new Promise(async (resolve) => {
      console.log('x button pressed. Row editing cancelled', newData);
      resolve()
    }),
}}
```