### PR TITLE
Management of Selections through Properties

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -37,6 +37,7 @@ class App extends Component {
   colRenderCount = 0;
 
   state = {
+    selectedRows: [],
     text: 'text',
     selecteds: 0,
     data: [
@@ -83,14 +84,34 @@ class App extends Component {
                   options={{
                     rowStyle: rowData => ({
                       backgroundColor: (this.state.selectedRow && this.state.selectedRow.tableData.id === rowData.tableData.id) ? '#EEE' : '#FFF'
-                    })
+                    }),
+                    selection: true
                   }}
+                  onSelectionChange={(data, rowData) => {
+                    this.setState({selectedRows: data});
+                  }}
+                  // onRowSelected = {(data, selected) => {
+                  //   if (selected){
+                  //     let selectedRows = this.state.selectedRows.slice();
+                  //     selectedRows.push(data);
+                  //     this.setState({selectedRows: selectedRows});
+                  //   }
+                  //   else{
+                  //     let selectedRows = this.state.selectedRows.slice().filter((sdata) => sdata['id'] !== data['id']);
+                  //     this.setState({selectedRows: selectedRows});
+                  //   }
+                  // }}
+                  primaryField='id'
+                  selectedRows={this.state.selectedRows}
                 />
               </Grid>
             </Grid>
             {this.state.text}
             <button onClick={() => this.tableRef.current.onAllSelected(true)} style={{ margin: 10 }}>
               Select
+            </button>
+            <button onClick = {() => this.setState({selectedRows: []})}>
+              Deselect
             </button>
             <MaterialTable
               title={
@@ -115,7 +136,10 @@ class App extends Component {
                 filtering: true,
                 grouping: true,
                 groupTitle: group => group.data.length,
+                selection: true
               }}
+              selectedRows={this.state.selectedRows}
+              primaryField='id'
               data={query => new Promise((resolve, reject) => {
                 let url = 'https://reqres.in/api/users?'
                 url += 'per_page=' + query.pageSize

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -140,6 +140,7 @@ class App extends Component {
               }}
               selectedRows={this.state.selectedRows}
               primaryField='id'
+              externalSelection
               data={query => new Promise((resolve, reject) => {
                 let url = 'https://reqres.in/api/users?'
                 url += 'per_page=' + query.pageSize

--- a/src/default-props.js
+++ b/src/default-props.js
@@ -131,5 +131,6 @@ export const defaultProps = {
   style: {
   },
   selectedRows: undefined,
-  primaryField: undefined
+  primaryField: undefined,
+  externalSelection: false
 };

--- a/src/default-props.js
+++ b/src/default-props.js
@@ -129,5 +129,7 @@ export const defaultProps = {
     }
   },
   style: {
-  }
+  },
+  selectedRows: undefined,
+  primaryField: undefined
 };

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -402,9 +402,9 @@ export default class MaterialTable extends React.Component {
     if (this.props.selectedRows !== undefined && this.props.externalSelection === true) return;
     let data = this.dataManager.changeRowSelected(event.target.checked, path);
     if (this.props.onRowSelected){
-      this.props.onRowSelected(data, event.target.checked);
+      this.props.onRowSelected(dataClicked, event.target.checked);
     }
-    this.setState(this.dataManager.getRenderState(), () => this.onSelectionChange(dataClicked));
+    this.setState(this.dataManager.getRenderState(), () => this.onSelectionChange(dataClicked, event.target.checked));
   }
 
   onSelectionChange = (dataClicked, rowChecked) => {

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -399,7 +399,7 @@ export default class MaterialTable extends React.Component {
   }
 
   onRowSelected = (event, path, dataClicked) => {
-    if (this.props.selectedRows !== undefined && (this.props.onRowSelected === undefined && this.props.onSelectionChange === undefined)) return;
+    if (this.props.selectedRows !== undefined && this.props.externalSelection === true) return;
     let data = this.dataManager.changeRowSelected(event.target.checked, path);
     if (this.props.onRowSelected){
       this.props.onRowSelected(data, event.target.checked);

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -399,6 +399,7 @@ export default class MaterialTable extends React.Component {
   }
 
   onRowSelected = (event, path, dataClicked) => {
+    if (this.props.selectedRows !== undefined && (this.props.onRowSelected === undefined && this.props.onSelectionChange === undefined)) return;
     let data = this.dataManager.changeRowSelected(event.target.checked, path);
     if (this.props.onRowSelected){
       this.props.onRowSelected(data, event.target.checked);

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -400,11 +400,13 @@ export default class MaterialTable extends React.Component {
 
   onRowSelected = (event, path, dataClicked) => {
     if (this.props.selectedRows !== undefined && this.props.externalSelection === true) return;
-    let data = this.dataManager.changeRowSelected(event.target.checked, path);
+    let checked = event.target.checked;
+    this.dataManager.changeRowSelected(checked, path);
     if (this.props.onRowSelected){
-      this.props.onRowSelected(dataClicked, event.target.checked);
+      this.props.onRowSelected(dataClicked, checked);
     }
-    this.setState(this.dataManager.getRenderState(), () => this.onSelectionChange(dataClicked, event.target.checked));
+    
+    this.setState(this.dataManager.getRenderState(), () => this.onSelectionChange(dataClicked, checked));
   }
 
   onSelectionChange = (dataClicked, rowChecked) => {

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -184,5 +184,6 @@ export const propTypes = {
   page: PropTypes.number,
   totalCount: PropTypes.number,
   selectedRows: PropTypes.arrayOf(PropTypes.object),
-  primaryField: PropTypes.string
+  primaryField: PropTypes.string,
+  externalSelection: PropTypes.bool
 };

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -182,5 +182,7 @@ export const propTypes = {
   tableRef: PropTypes.any,
   style: PropTypes.object,
   page: PropTypes.number,
-  totalCount: PropTypes.number
+  totalCount: PropTypes.number,
+  selectedRows: PropTypes.arrayOf(PropTypes.object),
+  primaryField: PropTypes.string
 };

--- a/src/utils/data-manager.js
+++ b/src/utils/data-manager.js
@@ -19,6 +19,7 @@ export default class DataManager {
   treeDataMaxLevel = 0;
   groupedDataLength = 0;
   defaultExpanded = false;
+  suppressSelectionChange = false;
   
   data = [];
   columns = [];
@@ -38,6 +39,8 @@ export default class DataManager {
   sorted = false;
   paged = false;
 
+  primaryField = undefined;
+
   rootGroupsIndex = {};
 
   constructor() {
@@ -55,6 +58,26 @@ export default class DataManager {
     });
 
     this.filtered = false;
+  }
+
+  setPrimaryField(field){
+    this.primaryField = field;
+  }
+
+  setSelected(selectedRows){
+    if (selectedRows === undefined) return;
+    this.suppressSelectionChange = true;
+    this.selectedCount = 0;
+    this.data.forEach((row, index) => {
+      if (selectedRows.some((sRow, sIndex) => this.getPrimaryFieldValue(sRow) === this.getPrimaryFieldValue(row))){
+        row.tableData.checked = true;
+        this.selectedCount++;
+      }
+      else{
+        row.tableData.checked = false;
+      }
+    });
+    this.suppressSelectionChange = false;
   }
 
   setColumns(columns) {
@@ -129,6 +152,7 @@ export default class DataManager {
     checkChildRows(rowData);
 
     this.filtered = false;
+    return rowData;
   }
 
   changeDetailPanelVisibility(path, render) {
@@ -398,6 +422,14 @@ export default class DataManager {
       // return group;
     }, data);
     return node;
+  }
+
+  getPrimaryFieldValue = (rowData) => {
+    if (this.primaryField !== undefined){
+      let value = (typeof rowData[this.primaryField] !== 'undefined' ? rowData[this.primaryField] : byString(rowData, this.primaryField));
+      return value;
+    }
+    return undefined;
   }
 
   getFieldValue = (rowData, columnDef, lookup = true) => {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -43,6 +43,7 @@ export interface MaterialTableProps<RowData extends object> {
   totalCount?: number;
   selectedRows?: RowData[];
   primaryField?: string;
+  externalSelection?: boolean;
 }
 
 export interface Filter<RowData extends object> {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -28,19 +28,21 @@ export interface MaterialTableProps<RowData extends object> {
   onOrderChange?: (orderBy: number, orderDirection: ("asc" | "desc")) => void;
   onGroupRemoved?: (column:Column<RowData>, index:boolean) => void;
   onRowClick?: (event?: React.MouseEvent, rowData?: RowData, toggleDetailPanel?: (panelIndex?: number) => void) => void;
-  onRowSelected?: (rowData: RowData) => void;
+  onRowSelected?: (rowData: RowData, checked: boolean) => void;
   onSearchChange?: (searchText: string) => void;
  /** An event fired when the table has finished filtering data
   * @param {Filter<RowData>[]} filters All the filters that are applied to the table 
   */ 
   onFilterChange?: (filters: Filter<RowData>[]) => void;
-  onSelectionChange?: (data: RowData[], rowData?: RowData) => void;
+  onSelectionChange?: (data: RowData[], rowData?: RowData, rowChecked?: boolean) => void;
   onTreeExpandChange?: (data: any, isExpanded: boolean) => void;
   onQueryChange?: (query: Query<RowData>) => void;
   style?: React.CSSProperties;
   tableRef?: any;
   page?: number;
   totalCount?: number;
+  selectedRows?: RowData[];
+  primaryField?: string;
 }
 
 export interface Filter<RowData extends object> {


### PR DESCRIPTION
## Related Issue
#1603 

## Description
Allows for row selection to be managed from outside of the table itself.
Also properly fires `onRowSelected`, and will include whether or not the row selection has been changed to a true state, to allow for more granular operations.

Added parameter `checked` to `onRowSelected`, and `rowChecked` to `onSelectionChanged`.

## Impacted Areas in Application
List general components of the application that this PR will affect:

* Row selection
* `onRowSelected`
* `onSelectionChanged`

## Additional Notes
If a property for `selectedRows` is supplied, and neither the `onRowSelected` nor the `onSelectionChanged` property function alters the state value, the table will reflect the change, but the state won't change. If the property `externalSelection` is provided, it will not be able to change the selection whatsoever.