### PR TITLE
fix: remove tableData property from column in check phase

### DIFF
--- a/src/material-table.js
+++ b/src/material-table.js
@@ -100,7 +100,9 @@ export default class MaterialTable extends React.Component {
 
     let propsChanged = !equal(fixedPrevColumns, fixedPropsColumns);
     propsChanged = propsChanged || !equal(prevProps.options, this.props.options);
-    propsChanged = propsChanged || !equal(prevProps.data, this.props.data);
+    if(!this.isRemoteData()) {
+      propsChanged = propsChanged || !equal(prevProps.data, this.props.data);
+    }
 
     if (propsChanged) {
       const props = this.getProps(this.props);

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -84,10 +84,21 @@ export default class MaterialTable extends React.Component {
     this.dataManager.changeDetailPanelType(props.options.detailPanelType);
   }
 
+  cleanColumns(columns) {
+    return columns.map(col => {
+      const colClone = {...col};
+      delete colClone.tableData;
+      return colClone;
+    });
+  }
+
   componentDidUpdate(prevProps) {
     // const propsChanged = Object.entries(this.props).reduce((didChange, prop) => didChange || prop[1] !== prevProps[prop[0]], false);
 
-    let propsChanged = !equal(prevProps.columns, this.props.columns);
+    const fixedPrevColumns = this.cleanColumns(prevProps.columns);
+    const fixedPropsColumns = this.cleanColumns(this.props.columns);
+
+    let propsChanged = !equal(fixedPrevColumns, fixedPropsColumns);
     propsChanged = propsChanged || !equal(prevProps.options, this.props.options);
     propsChanged = propsChanged || !equal(prevProps.data, this.props.data);
 


### PR DESCRIPTION
## Related Issue
#491 
but actually many more like #1272 (partially solved) #1265

## Description
This PR introduces a fair equality check between columns when using remote data.
Without this pr, while checking in component did update if the columns changed, `this.props.columns` and `prevProps.columns` assumed different forms hence the deep equal returned false for the first time causing a rerendering of the entire table losing every setting set, and true at the second time.

This happens because through the data-manager the tableData property is added only in a second time to this.props.columns.

## Impacted Areas in Application
List general components of the application that this PR will affect:

* the entire material-table.js component is affected
