### PR TITLE
Fix rows becoming locked when edit state is lost

### DIFF
--- a/src/material-table.js
+++ b/src/material-table.js
@@ -69,6 +69,7 @@ export default class MaterialTable extends React.Component {
 
     this.dataManager.setColumns(props.columns);
     this.dataManager.setDefaultExpanded(props.options.defaultExpanded);
+    this.dataManager.changeRowEditing();
 
     if (this.isRemoteData(props)) {
       this.dataManager.changeApplySearch(false);
@@ -260,7 +261,7 @@ export default class MaterialTable extends React.Component {
     const pageSize = event.target.value;
 
     this.dataManager.changePageSize(pageSize);
-	  
+
     this.props.onChangePage && this.props.onChangePage(0);
 
     if (this.isRemoteData()) {


### PR DESCRIPTION
Part of editing mode is captured on the tableData field of the individual row's data object.
This field is overwritten when new row data is provided to the table.
Overwriting this field without dropping the lastEditingRow in
DataManager causes the entire table to become locked.

Add call to DataManager#changeRowEditing to drop all references to
editing rows. This prevents table from becoming locked when row data is
updated while editing.

https://github.com/mbrn/material-table/issues/1610

## Related Issue
#1610 
#1595
#1527
#1487 
#1446 

## Description
Prevent table from having all rows locked in edit mode when a row data change occurs by resetting the editing state captured in MaterialTable and DataManager.

## Related PRs
None

## Impacted Areas in Application
List general components of the application that this PR will affect:

* MaterialTable when editable is defined.