### PR TITLE
Remove duplicate Options.searchText typing

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -231,7 +231,6 @@ export interface Options {
   searchText?: string;
   searchFieldAlignment?: 'left' | 'right';
   searchFieldStyle?: React.CSSProperties;
-  searchText?: string;
   selection?: boolean;
   selectionProps?: any | ((data: any) => any);
   sorting?: boolean;


### PR DESCRIPTION
Fixes duplicate identifier typescript error:
```
$ tsc
./node_modules/material-table/types/index.d.ts:231:3 - error TS2300: Duplicate identifier 'searchText'.

231   searchText?: string;
      ~~~~~~~~~~

./node_modules/material-table/types/index.d.ts:234:3 - error TS2300: Duplicate identifier 'searchText'.

234   searchText?: string;
      ~~~~~~~~~~


Found 2 errors.

```