### PR TITLE
Placeholder fix

### DIFF
--- a/src/components/m-table-edit-field.js
+++ b/src/components/m-table-edit-field.js
@@ -113,7 +113,7 @@ class MTableEditField extends React.Component {
         {...this.getProps()}
         style={this.props.columnDef.type === 'numeric' ? { float: 'right' } : {}}
         type={this.props.columnDef.type === 'numeric' ? 'number' : 'text'}
-        placeholder={(typeof this.props.columnDef.title !== 'string') ? this.props.columnDef.placeholder : this.props.columnDef.title}
+        placeholder={this.props.columnDef.title}
         value={this.props.value === undefined ? '' : this.props.value}
         onChange={event => this.props.onChange(event.target.value)}
         InputProps={{
@@ -129,7 +129,7 @@ class MTableEditField extends React.Component {
     return (
       <TextField
         {...this.getProps()}
-        placeholder={(typeof this.props.columnDef.title !== 'string') ? this.props.columnDef.placeholder : this.props.columnDef.title}
+        placeholder={this.props.columnDef.title}
         value={this.props.value === undefined ? '' : this.props.value}
         onChange={event => this.props.onChange(event.target.value)}
         inputProps={{

--- a/src/components/m-table-edit-field.js
+++ b/src/components/m-table-edit-field.js
@@ -113,7 +113,7 @@ class MTableEditField extends React.Component {
         {...this.getProps()}
         style={this.props.columnDef.type === 'numeric' ? { float: 'right' } : {}}
         type={this.props.columnDef.type === 'numeric' ? 'number' : 'text'}
-        placeholder={this.props.columnDef.title}
+        placeholder={(typeof this.props.columnDef.title !== 'string') ? this.props.columnDef.placeholder : this.props.columnDef.title}
         value={this.props.value === undefined ? '' : this.props.value}
         onChange={event => this.props.onChange(event.target.value)}
         InputProps={{
@@ -129,7 +129,7 @@ class MTableEditField extends React.Component {
     return (
       <TextField
         {...this.getProps()}
-        placeholder={this.props.columnDef.title}
+        placeholder={(typeof this.props.columnDef.title !== 'string') ? this.props.columnDef.placeholder : this.props.columnDef.title}
         value={this.props.value === undefined ? '' : this.props.value}
         onChange={event => this.props.onChange(event.target.value)}
         inputProps={{


### PR DESCRIPTION
Allows to use "placeholder" for Textfield or Currency input when the title is a complex element instead of a simple string.

Fixes #1260