### PR TITLE
Allow `React.ReactNode` for certain localization strings

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -244,49 +244,49 @@ export interface Options {
 export interface Localization {
   body?: {
     dateTimePickerLocalization?: object; // The date-fns locale object applied to the datepickers
-    emptyDataSourceMessage?: string;
+    emptyDataSourceMessage?: React.ReactNode;
     filterRow?: {
-      filterTooltip?: string;
+      filterTooltip?: React.ReactNode;
     };
     editRow?: {
-      saveTooltip?: string;
-      cancelTooltip?: string;
-      deleteText?: string;
+      saveTooltip?: React.ReactNode;
+      cancelTooltip?: React.ReactNode;
+      deleteText?: React.ReactNode;
     },
-    addTooltip?: string;
-    deleteTooltip?: string;
-    editTooltip?: string;
+    addTooltip?: React.ReactNode;
+    deleteTooltip?: React.ReactNode;
+    editTooltip?: React.ReactNode;
   };
   header?: {
-    actions?: string;
+    actions?: React.ReactNode;
   };
   grouping?: {
-    groupedBy?: string;
-    placeholder?: string;
+    groupedBy?: React.ReactNode;
+    placeholder?: React.ReactNode;
   };
   pagination?: {
-    firstTooltip?: string;
+    firstTooltip?: React.ReactNode;
     firstAriaLabel?: string;
-    previousTooltip?: string;
+    previousTooltip?: React.ReactNode;
     previousAriaLabel?: string,
-    nextTooltip?: string;
+    nextTooltip?: React.ReactNode;
     nextAriaLabel?: string,
-    labelDisplayedRows?: string;
-    labelRowsPerPage?: string;
-    lastTooltip?: string;
+    labelDisplayedRows?: React.ReactNode;
+    labelRowsPerPage?: React.ReactNode;
+    lastTooltip?: React.ReactNode;
     lastAriaLabel?: string,
-    labelRowsSelect?: string;
+    labelRowsSelect?: React.ReactNode;
   };
   toolbar?: {
-    addRemoveColumns?: string;
-    nRowsSelected?: string;
-    showColumnsTitle?: string;
+    addRemoveColumns?: React.ReactNode;
+    nRowsSelected?: React.ReactNode;
+    showColumnsTitle?: React.ReactNode;
     showColumnsAriaLabel?: string;
-    exportTitle?: string;
+    exportTitle?: React.ReactNode;
     exportAriaLabel?: string;
-    exportName?: string;
-    searchTooltip?: string;
-    searchPlaceholder?: string;
+    exportName?: React.ReactNode;
+    searchTooltip?: React.ReactNode;
+    searchPlaceholder?: React.ReactNode;
   };
 }
 


### PR DESCRIPTION
## Description
Allow passing in React components as localization options. This allows for example changing typography, "tagging" strings with data attributes for testing, etc.
