### PR TITLE
Feature localize date picker

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -86,56 +86,30 @@ class App extends Component {
                       left: 2,
                       right: 0
                     },
-                    tableLayout: 'fixed'
+                    tableLayout: 'fixed',
+                    filtering: true,
+                  }}
+                  localization={{
+                    body: {
+                      muiDatePickerProps: {
+                        okLabel: 'oke',
+                        cancelLabel: 'no',
+                        clearLabel: 'delet this',
+                      },
+                    }
+                  }}
+                  editable={{
+                    onRowAdd: newData =>
+                      new Promise((resolve, reject) => resolve()),
+                    onRowUpdate: (newData, oldData) =>
+                      new Promise((resolve, reject) => resolve()),
+                    onRowDelete: oldData =>
+                      new Promise((resolve, reject) => resolve()),
                   }}
                 />
               </Grid>
             </Grid>
             {this.state.text}
-            <button onClick={() => this.tableRef.current.onAllSelected(true)} style={{ margin: 10 }}>
-              Select
-            </button>
-            <MaterialTable
-              title={
-                <Typography variant='h6' color='primary'>Remote Data Preview</Typography>
-              }
-              columns={[
-                {
-                  title: 'Avatar',
-                  field: 'avatar',
-                  render: rowData => (
-                    <img
-                      style={{ height: 36, borderRadius: '50%' }}
-                      src={rowData.avatar}
-                    />
-                  ),
-                },
-                { title: 'Id', field: 'id', filterPlaceholder: 'placeholder' },
-                { title: 'First Name', field: 'first_name' },
-                { title: 'Last Name', field: 'last_name' },
-              ]}
-              options={{
-                filtering: true,
-                grouping: true,
-                groupTitle: group => group.data.length,
-              }}
-              data={query => new Promise((resolve, reject) => {
-                let url = 'https://reqres.in/api/users?'
-                url += 'per_page=' + query.pageSize
-                url += '&page=' + (query.page + 1)
-                console.log(query);
-                fetch(url)
-                  .then(response => response.json())
-                  .then(result => {
-                    resolve({
-                      data: result.data,
-                      page: result.page - 1,
-                      totalCount: result.total,
-                    })
-                  })
-              })}
-            />
-
           </div>
         </MuiThemeProvider>
       </>

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -86,30 +86,56 @@ class App extends Component {
                       left: 2,
                       right: 0
                     },
-                    tableLayout: 'fixed',
-                    filtering: true,
-                  }}
-                  localization={{
-                    body: {
-                      muiDatePickerProps: {
-                        okLabel: 'oke',
-                        cancelLabel: 'no',
-                        clearLabel: 'delet this',
-                      },
-                    }
-                  }}
-                  editable={{
-                    onRowAdd: newData =>
-                      new Promise((resolve, reject) => resolve()),
-                    onRowUpdate: (newData, oldData) =>
-                      new Promise((resolve, reject) => resolve()),
-                    onRowDelete: oldData =>
-                      new Promise((resolve, reject) => resolve()),
+                    tableLayout: 'fixed'
                   }}
                 />
               </Grid>
             </Grid>
             {this.state.text}
+            <button onClick={() => this.tableRef.current.onAllSelected(true)} style={{ margin: 10 }}>
+              Select
+            </button>
+            <MaterialTable
+              title={
+                <Typography variant='h6' color='primary'>Remote Data Preview</Typography>
+              }
+              columns={[
+                {
+                  title: 'Avatar',
+                  field: 'avatar',
+                  render: rowData => (
+                    <img
+                      style={{ height: 36, borderRadius: '50%' }}
+                      src={rowData.avatar}
+                    />
+                  ),
+                },
+                { title: 'Id', field: 'id', filterPlaceholder: 'placeholder' },
+                { title: 'First Name', field: 'first_name' },
+                { title: 'Last Name', field: 'last_name' },
+              ]}
+              options={{
+                filtering: true,
+                grouping: true,
+                groupTitle: group => group.data.length,
+              }}
+              data={query => new Promise((resolve, reject) => {
+                let url = 'https://reqres.in/api/users?'
+                url += 'per_page=' + query.pageSize
+                url += '&page=' + (query.page + 1)
+                console.log(query);
+                fetch(url)
+                  .then(response => response.json())
+                  .then(result => {
+                    resolve({
+                      data: result.data,
+                      page: result.page - 1,
+                      totalCount: result.total,
+                    })
+                  })
+              })}
+            />
+
           </div>
         </MuiThemeProvider>
       </>

--- a/src/components/m-table-body.js
+++ b/src/components/m-table-body.js
@@ -50,7 +50,7 @@ class MTableBody extends React.Component {
             components={this.props.components}
             data={data}
             icons={this.props.icons}
-            localization={{ ...MTableBody.defaultProps.localization.editRow, ...this.props.localization.editRow, dateTimePickerLocalization: this.props.localization.dateTimePickerLocalization.locale }}
+            localization={{ ...MTableBody.defaultProps.localization.editRow, ...this.props.localization.editRow, dateTimePickerLocalization: this.props.localization.dateTimePickerLocalization, muiDatePickerProps: this.props.localization.muiDatePickerProps }}
             key={index}
             mode={data.tableData.editing}
             options={this.props.options}
@@ -117,7 +117,7 @@ class MTableBody extends React.Component {
         options={this.props.options}
         isTreeData={this.props.isTreeData}
         hasAnyEditingRow={this.props.hasAnyEditingRow}
-        localization={{ ...MTableBody.defaultProps.localization.editRow, ...this.props.localization.editRow }}
+        localization={{ ...MTableBody.defaultProps.localization.editRow, ...this.props.localization.editRow, muiDatePickerProps: this.props.localization.muiDatePickerProps }}
       />
     ));
   }
@@ -143,12 +143,11 @@ class MTableBody extends React.Component {
             actionsColumnIndex={this.props.options.actionsColumnIndex}
             onFilterChanged={this.props.onFilterChanged}
             selection={this.props.options.selection}
-            localization={{ ...MTableBody.defaultProps.localization.filterRow, ...this.props.localization.filterRow, dateTimePickerLocalization: this.props.localization.dateTimePickerLocalization.locale }}
+            localization={{ ...MTableBody.defaultProps.localization.filterRow, ...this.props.localization.filterRow, dateTimePickerLocalization: this.props.localization.dateTimePickerLocalization, muiDatePickerProps: this.props.localization.muiDatePickerProps }}
             hasDetailPanel={!!this.props.detailPanel}
             isTreeData={this.props.isTreeData}
             filterCellStyle={this.props.options.filterCellStyle}
             hideFilterIcons={this.props.options.hideFilterIcons}
-            muiPickerProps={this.props.localization.dateTimePickerLocalization.muiPickerProps}
           />
         }
 
@@ -160,7 +159,7 @@ class MTableBody extends React.Component {
             icons={this.props.icons}
             key="key-add-row"
             mode="add"
-            localization={{ ...MTableBody.defaultProps.localization.editRow, ...this.props.localization.editRow }}
+            localization={{ ...MTableBody.defaultProps.localization.editRow, ...this.props.localization.editRow, muiDatePickerProps: this.props.localization.muiDatePickerProps }}
             options={this.props.options}
             isTreeData={this.props.isTreeData}
             detailPanel={this.props.detailPanel}
@@ -183,7 +182,7 @@ class MTableBody extends React.Component {
             icons={this.props.icons}
             key="key-add-row"
             mode="add"
-            localization={{ ...MTableBody.defaultProps.localization.editRow, ...this.props.localization.editRow }}
+            localization={{ ...MTableBody.defaultProps.localization.editRow, ...this.props.localization.editRow, muiDatePickerProps: this.props.localization.muiDatePickerProps }}
             options={this.props.options}
             isTreeData={this.props.isTreeData}
             detailPanel={this.props.detailPanel}

--- a/src/components/m-table-body.js
+++ b/src/components/m-table-body.js
@@ -50,7 +50,7 @@ class MTableBody extends React.Component {
             components={this.props.components}
             data={data}
             icons={this.props.icons}
-            localization={{ ...MTableBody.defaultProps.localization.editRow, ...this.props.localization.editRow, dateTimePickerLocalization: this.props.localization.dateTimePickerLocalization }}
+            localization={{ ...MTableBody.defaultProps.localization.editRow, ...this.props.localization.editRow, dateTimePickerLocalization: this.props.localization.dateTimePickerLocalization.locale }}
             key={index}
             mode={data.tableData.editing}
             options={this.props.options}
@@ -143,11 +143,12 @@ class MTableBody extends React.Component {
             actionsColumnIndex={this.props.options.actionsColumnIndex}
             onFilterChanged={this.props.onFilterChanged}
             selection={this.props.options.selection}
-            localization={{ ...MTableBody.defaultProps.localization.filterRow, ...this.props.localization.filterRow, dateTimePickerLocalization: this.props.localization.dateTimePickerLocalization }}
+            localization={{ ...MTableBody.defaultProps.localization.filterRow, ...this.props.localization.filterRow, dateTimePickerLocalization: this.props.localization.dateTimePickerLocalization.locale }}
             hasDetailPanel={!!this.props.detailPanel}
             isTreeData={this.props.isTreeData}
             filterCellStyle={this.props.options.filterCellStyle}
             hideFilterIcons={this.props.options.hideFilterIcons}
+            muiPickerProps={this.props.localization.dateTimePickerLocalization.muiPickerProps}
           />
         }
 

--- a/src/components/m-table-edit-field.js
+++ b/src/components/m-table-edit-field.js
@@ -62,6 +62,7 @@ class MTableEditField extends React.Component {
               fontSize: 13,
             }
           }}
+          {...this.props.muiDatePickerProps}
         />
       </MuiPickersUtilsProvider>
     );
@@ -82,6 +83,7 @@ class MTableEditField extends React.Component {
               fontSize: 13,
             }
           }}
+          {...this.props.muiDatePickerProps}
         />
       </MuiPickersUtilsProvider>
     );
@@ -102,6 +104,7 @@ class MTableEditField extends React.Component {
               fontSize: 13,
             }
           }}
+          {...this.props.muiDatePickerProps}
         />
       </MuiPickersUtilsProvider>
     );

--- a/src/components/m-table-edit-row.js
+++ b/src/components/m-table-edit-row.js
@@ -94,7 +94,7 @@ export default class MTableEditRow extends React.Component {
                 key={columnDef.tableData.id}
                 columnDef={cellProps}
                 value={value}
-                locale={this.props.localization.dateTimePickerLocalization}
+                dateTimePickerLocalization={this.props.localization.dateTimePickerLocalization}
                 muiDatePickerProps={{...MTableEditRow.defaultProps.localization.muiDatePickerProps, ...this.props.localization.muiDatePickerProps}}
                 rowData={this.state.data}
                 onChange={value => {

--- a/src/components/m-table-edit-row.js
+++ b/src/components/m-table-edit-row.js
@@ -84,7 +84,6 @@ export default class MTableEditRow extends React.Component {
         else {
           const { editComponent, ...cellProps } = columnDef;
           const EditComponent = editComponent || this.props.components.EditField;
-          
           return (
             <TableCell
               key={columnDef.tableData.id}
@@ -96,6 +95,7 @@ export default class MTableEditRow extends React.Component {
                 columnDef={cellProps}
                 value={value}
                 locale={this.props.localization.dateTimePickerLocalization}
+                muiDatePickerProps={this.props.localization.muiDatePickerProps || {}}
                 rowData={this.state.data}
                 onChange={value => {
                   const data = { ...this.state.data };

--- a/src/components/m-table-edit-row.js
+++ b/src/components/m-table-edit-row.js
@@ -95,7 +95,7 @@ export default class MTableEditRow extends React.Component {
                 columnDef={cellProps}
                 value={value}
                 locale={this.props.localization.dateTimePickerLocalization}
-                muiDatePickerProps={this.props.localization.muiDatePickerProps || {}}
+                muiDatePickerProps={{...MTableEditRow.defaultProps.localization.muiDatePickerProps, ...this.props.localization.muiDatePickerProps}}
                 rowData={this.state.data}
                 onChange={value => {
                   const data = { ...this.state.data };
@@ -250,6 +250,11 @@ MTableEditRow.defaultProps = {
     saveTooltip: 'Save',
     cancelTooltip: 'Cancel',
     deleteText: 'Are you sure you want to delete this row?',
+    muiDatePickerProps: {
+      okLabel: 'OK',
+      cancelLabel: 'Cancel',
+      clearLabel: 'Clear',
+    }
   }
 };
 

--- a/src/components/m-table-filter-row.js
+++ b/src/components/m-table-filter-row.js
@@ -109,6 +109,7 @@ class MTableFilterRow extends React.Component {
           value={columnDef.tableData.filterValue || null}
           onChange={onDateInputChange}
           clearable
+          {...this.props.muiPickerProps}
         />
       );
     } else if (columnDef.type === 'datetime') {

--- a/src/components/m-table-filter-row.js
+++ b/src/components/m-table-filter-row.js
@@ -109,7 +109,7 @@ class MTableFilterRow extends React.Component {
           value={columnDef.tableData.filterValue || null}
           onChange={onDateInputChange}
           clearable
-          {...this.props.muiPickerProps}
+          {...this.props.localization.muiDatePickerProps}
         />
       );
     } else if (columnDef.type === 'datetime') {
@@ -118,6 +118,7 @@ class MTableFilterRow extends React.Component {
           value={columnDef.tableData.filterValue || null}
           onChange={onDateInputChange}
           clearable
+          {...this.props.localization.muiDatePickerProps}
         />
       );
     } else if (columnDef.type === 'time') {
@@ -126,6 +127,7 @@ class MTableFilterRow extends React.Component {
           value={columnDef.tableData.filterValue || null}
           onChange={onDateInputChange}
           clearable
+          {...this.props.localization.muiDatePickerProps}
         />
       );
     }

--- a/src/components/m-table-filter-row.js
+++ b/src/components/m-table-filter-row.js
@@ -109,6 +109,7 @@ class MTableFilterRow extends React.Component {
           value={columnDef.tableData.filterValue || null}
           onChange={onDateInputChange}
           clearable
+          {...MTableFilterRow.defaultProps.localization.muiDatePickerProps}
           {...this.props.localization.muiDatePickerProps}
         />
       );
@@ -118,6 +119,7 @@ class MTableFilterRow extends React.Component {
           value={columnDef.tableData.filterValue || null}
           onChange={onDateInputChange}
           clearable
+          {...MTableFilterRow.defaultProps.localization.muiDatePickerProps}
           {...this.props.localization.muiDatePickerProps}
         />
       );
@@ -127,6 +129,7 @@ class MTableFilterRow extends React.Component {
           value={columnDef.tableData.filterValue || null}
           onChange={onDateInputChange}
           clearable
+          {...MTableFilterRow.defaultProps.localization.muiDatePickerProps}
           {...this.props.localization.muiDatePickerProps}
         />
       );
@@ -218,7 +221,12 @@ MTableFilterRow.defaultProps = {
   selection: false,
   hasActions: false,
   localization: {
-    filterTooltip: 'Filter'
+    filterTooltip: 'Filter',
+    muiDatePickerProps: {
+      okLabel: 'OK',
+      cancelLabel: 'Cancel',
+      clearLabel: 'Clear',
+    }
   },
   hideFilterIcons: false,
 };


### PR DESCRIPTION
## Related Issue
#531

## Description
Expose @material-ui/pickers props to material table.

## Impacted Areas in Application
List general components of the application that this PR will affect:
* FilterRow, EditRow

## Additional Notes
Example:
```
localization={{
          body: {
            emptyDataSourceMessage: getMessage('label.no.records.to.display'),
            dateTimePickerLocalization: resolvedLocaleMap,
            muiDatePickerProps: {
              okLabel: getMessage('label.ok'),
              cancelLabel: getMessage('label.cancel'),
              clearLabel: getMessage('label.clear'),
            },
          },
        }}
```