### PR TITLE
Fix: Action/Detail/Tree spacing with hidden columns

### DIFF
--- a/src/utils/data-manager.js
+++ b/src/utils/data-manager.js
@@ -19,7 +19,7 @@ export default class DataManager {
   treeDataMaxLevel = 0;
   groupedDataLength = 0;
   defaultExpanded = false;
-  
+
   data = [];
   columns = [];
 
@@ -57,7 +57,7 @@ export default class DataManager {
     this.filtered = false;
   }
 
-  setColumns(columns) {    
+  setColumns(columns) {
     const undefinedWidthColumns = columns.filter(c => c.width === undefined);
     let usedWidth = ["0px"];
 
@@ -66,8 +66,8 @@ export default class DataManager {
         columnOrder: index,
         filterValue: columnDef.defaultFilter,
         groupOrder: columnDef.defaultGroupOrder,
-        groupSort: columnDef.defaultGroupSort || 'asc',     
-        width: columnDef.width,   
+        groupSort: columnDef.defaultGroupSort || 'asc',
+        width: columnDef.width,
         ...columnDef.tableData,
         id: index,
       };
@@ -86,7 +86,7 @@ export default class DataManager {
 
     usedWidth = "(" + usedWidth.join(' + ') + ")";
     undefinedWidthColumns.forEach(columnDef => {
-      columnDef.tableData.width = `calc((100% - ${usedWidth}) / ${undefinedWidthColumns.length})`;
+      columnDef.tableData.width = `calc((100% - ${usedWidth}) / ${undefinedWidthColumns.filter(c => !c.hidden).length})`;
     });
   }
 

--- a/src/utils/data-manager.js
+++ b/src/utils/data-manager.js
@@ -58,7 +58,7 @@ export default class DataManager {
   }
 
   setColumns(columns) {    
-    const undefinedWidthColumns = columns.filter(c => c.width === undefined);
+    const undefinedWidthColumns = columns.filter(c => c.width === undefined && !c.hidden);
     let usedWidth = ["0px"];
 
     this.columns = columns.map((columnDef, index) => {
@@ -86,7 +86,7 @@ export default class DataManager {
 
     usedWidth = "(" + usedWidth.join(' + ') + ")";
     undefinedWidthColumns.forEach(columnDef => {
-      columnDef.tableData.width = `calc((100% - ${usedWidth}) / ${undefinedWidthColumns.filter(c => !c.hidden).length})`;
+      columnDef.tableData.width = `calc((100% - ${usedWidth}) / ${undefinedWidthColumns.length})`;
     });
   }
 

--- a/src/utils/data-manager.js
+++ b/src/utils/data-manager.js
@@ -19,7 +19,7 @@ export default class DataManager {
   treeDataMaxLevel = 0;
   groupedDataLength = 0;
   defaultExpanded = false;
-
+  
   data = [];
   columns = [];
 
@@ -57,7 +57,7 @@ export default class DataManager {
     this.filtered = false;
   }
 
-  setColumns(columns) {
+  setColumns(columns) {    
     const undefinedWidthColumns = columns.filter(c => c.width === undefined);
     let usedWidth = ["0px"];
 
@@ -66,8 +66,8 @@ export default class DataManager {
         columnOrder: index,
         filterValue: columnDef.defaultFilter,
         groupOrder: columnDef.defaultGroupOrder,
-        groupSort: columnDef.defaultGroupSort || 'asc',
-        width: columnDef.width,
+        groupSort: columnDef.defaultGroupSort || 'asc',     
+        width: columnDef.width,   
         ...columnDef.tableData,
         id: index,
       };


### PR DESCRIPTION
## Related Issue
#1121 

## Description
Fixes a bug that would cause the iconbutton (action/detail/tree etc) on the right side to take on the "extra" space "leftover" when hiding columns. See the related issue for how this looks.   
This is fixed by filtering out hidden columns when checking the length for the CSS `calc`. 

## Related PRs
None that I could find.

## Impacted Areas in Application
* data-manager.js
