### PR TITLE
Removed color="inherit" from search InputAdornment

### DIFF
--- a/src/components/m-table-toolbar.js
+++ b/src/components/m-table-toolbar.js
@@ -69,7 +69,7 @@ export class MTableToolbar extends React.Component {
             startAdornment: (
               <InputAdornment position="start">
                 <Tooltip title={localization.searchTooltip}>
-                  <this.props.icons.Search color="inherit" fontSize="small" />
+                  <this.props.icons.Search fontSize="small" />
                 </Tooltip>
               </InputAdornment>
             ),
@@ -79,7 +79,7 @@ export class MTableToolbar extends React.Component {
                   disabled={!this.props.searchText}
                   onClick={() => this.props.onSearchChanged("")}
                 >
-                  <this.props.icons.ResetSearch color="inherit" fontSize="small" />
+                  <this.props.icons.ResetSearch fontSize="small" />
                 </IconButton>
               </InputAdornment>
             ),


### PR DESCRIPTION
## Related Issue
Relate the Github issue with this PR using #1293 and #1348

## Description
Previous [commit](https://github.com/mbrn/material-table/commit/8cda5e7b208799ecc440fa15de92ef852c11a88d) removed one of these invalid props, but two remained which are not implemented in latest Material UI