### PR TITLE
Fixes Cells aligned

### DIFF
--- a/src/material-table.js
+++ b/src/material-table.js
@@ -538,7 +538,7 @@ export default class MaterialTable extends React.Component {
   }
 
   renderTable = (props) => (
-    <Table style={{ tableLayout: (props.options.fixedColumns && (props.options.fixedColumns.left || props.options.fixedColumns.right)) ? 'fixed' : props.options.tableLayout }}>
+    <Table style={{ tableLayout: (props.options.fixedColumns && (props.options.fixedColumns.left || props.options.fixedColumns.right)) || (props.options.selection && props.options.columnsButton) ? 'fixed' : props.options.tableLayout }}>
       {props.options.header &&
         <props.components.Header
           actions={props.actions}


### PR DESCRIPTION
This fixes #1678 for if selection and columnsButton are enabled and columns are removed that the cells align to the right of the table.

## Related Issue
 #1678

## Description
This makes the layout fixed so that the cells are correctly aligned for removed columns.
The selection column does not span unnecessary. 

## Impacted Areas in Application
List general components of the application that this PR will affect:

* Material-Table
