### PR TITLE
Updated actions to show toolbar actions even when selection is made

### DIFF
--- a/src/components/m-table-toolbar.js
+++ b/src/components/m-table-toolbar.js
@@ -173,7 +173,7 @@ export class MTableToolbar extends React.Component {
   renderSelectedActions() {
     return (
       <React.Fragment>
-        <this.props.components.Actions actions={this.props.actions.filter(a => a.position === "toolbarOnSelect")} data={this.props.selectedRows} components={this.props.components} />
+        <this.props.components.Actions actions={this.props.actions.filter(a => { return (a.position === "toolbarOnSelect" || a.position === "toolbar"); })} data={this.props.selectedRows} components={this.props.components} />
       </React.Fragment>
     );
   }


### PR DESCRIPTION
## Related Issue
Relate the Github issue with this PR using `#`
`#980`
https://github.com/mbrn/material-table/issues/980

## Description
Actions icons which are set as toolbar position are not showing up when selection is made. Updated the code so that toolbar position actions are shown no matter what.

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
other_pr_production | [link]()
other_pr_master | [link]()

## Impacted Areas in Application
List general components of the application that this PR will affect:

*

## Additional Notes
This is optional, feel free to follow your hearth and write here :)