### PR TITLE
Adding isEditHidden and isDeleteHidden to editable prop

### DIFF
--- a/src/material-table.js
+++ b/src/material-table.js
@@ -170,6 +170,7 @@ export default class MaterialTable extends React.Component {
           icon: calculatedProps.icons.Edit,
           tooltip: localization.editTooltip,
           disabled: calculatedProps.editable.isEditable && !calculatedProps.editable.isEditable(rowData),
+          hidden: calculatedProps.editable.isEditHidden && calculatedProps.editable.isEditHidden(rowData),
           onClick: (e, rowData) => {
             this.dataManager.changeRowEditing(rowData, "update");
             this.setState({
@@ -184,6 +185,7 @@ export default class MaterialTable extends React.Component {
           icon: calculatedProps.icons.Delete,
           tooltip: localization.deleteTooltip,
           disabled: calculatedProps.editable.isDeletable && !calculatedProps.editable.isDeletable(rowData),
+          hidden: calculatedProps.editable.isDeleteHidden && calculatedProps.editable.isDeleteHidden(rowData),
           onClick: (e, rowData) => {
             this.dataManager.changeRowEditing(rowData, "delete");
             this.setState({

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -70,9 +70,13 @@ export const propTypes = {
   }),
   data: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.object), PropTypes.func]).isRequired,
   editable: PropTypes.shape({
+    isEditable: PropTypes.func,
+    isDeletable: PropTypes.func,
     onRowAdd: PropTypes.func,
     onRowUpdate: PropTypes.func,
-    onRowDelete: PropTypes.func
+    onRowDelete: PropTypes.func,
+    isEditHidden: PropTypes.func,
+    isDeleteHidden: PropTypes.func
   }),
   detailPanel: PropTypes.oneOfType([
     PropTypes.func,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -14,6 +14,8 @@ export interface MaterialTableProps<RowData extends object> {
     onRowAdd?: (newData: RowData) => Promise<any>;
     onRowUpdate?: (newData: RowData, oldData?: RowData) => Promise<any>;
     onRowDelete?: (oldData: RowData) => Promise<any>;
+    isEditHidden?: (rowData: RowData) => boolean;
+    isDeleteHidden?: (rowData: RowData) => boolean;
   }
   icons?: Icons;
   isLoading?: boolean;


### PR DESCRIPTION
## Related Issue
#1719 

## Description
Adding isEditHidden and isDeleteHidden optional props to "editable" prop to allow hiding Edit and Delete buttons based on rowData

## Related PRs
N/A


## Impacted Areas in Application

Action component

## Additional Notes
I stumbled with same requirement as in #1719 . I am using material-table to display hierarchical data. However wanted to hide the Edit/Delete buttons in node rows. Without this solution I can only disable the buttons, however it looks better when icons are hidden.