### PR TITLE
Add named pageSizeOption value

### DIFF
--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -136,7 +136,13 @@ export const propTypes = {
     padding: PropTypes.oneOf(['default', 'dense']),
     paging: PropTypes.bool,
     pageSize: PropTypes.number,
-    pageSizeOptions: PropTypes.arrayOf(PropTypes.number),
+    pageSizeOptions: PropTypes.arrayOf(PropTypes.oneOfType([
+      PropTypes.number,
+      PropTypes.shape({
+        value: PropTypes.number,
+        label: PropTypes.string
+      })
+    ])),
     paginationType: PropTypes.oneOf(['normal', 'stepped']),
     rowStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
     search: PropTypes.bool,


### PR DESCRIPTION
## Related Issue
I didn't create issue. I thought it will be easier, if I simply provide solution for my problem and maybe problem of other users of Material Table

## Description
Material Table documentation (https://material-ui.com/components/tables/#custom-pagination-options) specifies that pagination can use not only options of type number, but also objects with the value and label keys, which will be used respectively for the value and label of the option (useful for language strings such as 'All').

## Impacted Areas in Application
List general components of the application that this PR will affect:

* Pagination

