### PR TITLE
Bug/accessibility1747

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -118,6 +118,7 @@ class App extends Component {
                 filtering: true,
                 grouping: true,
                 groupTitle: group => group.data.length,
+                selection: true,
               }}
               data={query => new Promise((resolve, reject) => {
                 let url = 'https://reqres.in/api/users?'

--- a/src/components/m-table-body-row.js
+++ b/src/components/m-table-body-row.js
@@ -64,7 +64,7 @@ export default class MTableBodyRow extends React.Component {
       <TableCell size={size} padding="none" key="key-selection-column" style={{ width: selectionWidth }}>
         <Checkbox
           inputProps={{
-            'aria-label': 'Select all rows'
+            'aria-label': MTableBodyRow.defaultProps.localization.selectThisRow
           }}
           size={size}
           checked={this.props.data.tableData.checked === true}
@@ -351,7 +351,11 @@ MTableBodyRow.defaultProps = {
   index: 0,
   data: {},
   options: {},
-  path: []
+  path: [],
+  localization: {
+    selectThisRow: 'Select this row'
+  }
+
 };
 
 MTableBodyRow.propTypes = {

--- a/src/components/m-table-body-row.js
+++ b/src/components/m-table-body-row.js
@@ -8,6 +8,8 @@ import Tooltip from '@material-ui/core/Tooltip';
 import PropTypes from 'prop-types';
 import * as React from 'react';
 import * as CommonValues from '../utils/common-values';
+import MEditTableRow from './m-table-edit-row';
+
 /* eslint-enable no-unused-vars */
 
 
@@ -49,7 +51,7 @@ export default class MTableBodyRow extends React.Component {
     if (typeof checkboxProps === 'function') {
       checkboxProps = checkboxProps(this.props.data);
     }
-    const localization = { ...this.props.localization };
+    const localization = { ...MEditTableRow.defaultProps.localization, ...this.props.localization };
     const size = CommonValues.elementSize(this.props);
     const selectionWidth = CommonValues.selectionMaxWidth(this.props, this.props.treeDataMaxLevel);
 

--- a/src/components/m-table-body-row.js
+++ b/src/components/m-table-body-row.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-unused-vars */
 import Checkbox from '@material-ui/core/Checkbox';
 import TableCell from '@material-ui/core/TableCell';
+import FormLabel from '@material-ui/core/FormLabel'
 import TableRow from '@material-ui/core/TableRow';
 import IconButton from '@material-ui/core/IconButton';
 import Icon from '@material-ui/core/Icon';
@@ -63,6 +64,10 @@ export default class MTableBodyRow extends React.Component {
     return (
       <TableCell size={size} padding="none" key="key-selection-column" style={{ width: selectionWidth }}>
         <Checkbox
+          aria-label={'select all rows'}
+          inputProps={{
+            title: 'select this row'
+          }}
           size={size}
           checked={this.props.data.tableData.checked === true}
           onClick={(e) => e.stopPropagation()}

--- a/src/components/m-table-body-row.js
+++ b/src/components/m-table-body-row.js
@@ -49,7 +49,7 @@ export default class MTableBodyRow extends React.Component {
     if (typeof checkboxProps === 'function') {
       checkboxProps = checkboxProps(this.props.data);
     }
-
+    const localization = { ...this.props.localization };
     const size = CommonValues.elementSize(this.props);
     const selectionWidth = CommonValues.selectionMaxWidth(this.props, this.props.treeDataMaxLevel);
 
@@ -64,7 +64,7 @@ export default class MTableBodyRow extends React.Component {
       <TableCell size={size} padding="none" key="key-selection-column" style={{ width: selectionWidth }}>
         <Checkbox
           inputProps={{
-            'aria-label': MTableBodyRow.defaultProps.localization.selectThisRow
+            'aria-label': localization.selectThisRowAriaLabel
           }}
           size={size}
           checked={this.props.data.tableData.checked === true}
@@ -351,11 +351,7 @@ MTableBodyRow.defaultProps = {
   index: 0,
   data: {},
   options: {},
-  path: [],
-  localization: {
-    selectThisRow: 'Select this row'
-  }
-
+  path: []
 };
 
 MTableBodyRow.propTypes = {

--- a/src/components/m-table-body-row.js
+++ b/src/components/m-table-body-row.js
@@ -1,7 +1,6 @@
 /* eslint-disable no-unused-vars */
 import Checkbox from '@material-ui/core/Checkbox';
 import TableCell from '@material-ui/core/TableCell';
-import FormLabel from '@material-ui/core/FormLabel'
 import TableRow from '@material-ui/core/TableRow';
 import IconButton from '@material-ui/core/IconButton';
 import Icon from '@material-ui/core/Icon';

--- a/src/components/m-table-body-row.js
+++ b/src/components/m-table-body-row.js
@@ -63,9 +63,8 @@ export default class MTableBodyRow extends React.Component {
     return (
       <TableCell size={size} padding="none" key="key-selection-column" style={{ width: selectionWidth }}>
         <Checkbox
-          aria-label={'select all rows'}
           inputProps={{
-            title: 'select this row'
+            'aria-label': 'Select all rows'
           }}
           size={size}
           checked={this.props.data.tableData.checked === true}

--- a/src/components/m-table-body.js
+++ b/src/components/m-table-body.js
@@ -206,7 +206,7 @@ MTableBody.defaultProps = {
   localization: {
     emptyDataSourceMessage: 'No records to display',
     filterRow: {},
-    editRow: {},
+    editRow: {}
   }
 };
 

--- a/src/components/m-table-body.js
+++ b/src/components/m-table-body.js
@@ -206,7 +206,7 @@ MTableBody.defaultProps = {
   localization: {
     emptyDataSourceMessage: 'No records to display',
     filterRow: {},
-    editRow: {}
+    editRow: {},
   }
 };
 

--- a/src/components/m-table-edit-field.js
+++ b/src/components/m-table-edit-field.js
@@ -15,20 +15,20 @@ class MTableEditField extends React.Component {
 
   renderLookupField() {
     return (
-      <Select
-        {...this.getProps()}
-        value={this.props.value === undefined ? '' : this.props.value}
-        onChange={event => this.props.onChange(event.target.value)}
-        style={{
-          fontSize: 13,
-        }}
-      >
-        {Object.keys(this.props.columnDef.lookup).map(key => (
-          <MenuItem key={key} value={key}>{this.props.columnDef.lookup[key]}</MenuItem>)
-        )}
-      </Select>
+        <Select
+          {...this.getProps()}
+          value={this.props.value === undefined ? '' : this.props.value}
+          onChange={event => this.props.onChange(event.target.value)}
+          style={{
+            fontSize: 13,
+          }}
+          SelectDisplayProps={{ 'aria-label': this.props.columnDef.title }}
+        >
+          {Object.keys(this.props.columnDef.lookup).map(key => (
+            <MenuItem key={key} value={key}>{this.props.columnDef.lookup[key]}</MenuItem>)
+          )}
+        </Select>
     );
-
   }
 
   renderBooleanField() {
@@ -43,6 +43,9 @@ class MTableEditField extends React.Component {
           paddingTop: 0,
           paddingBottom: 0
         }}
+        inputProps={{
+          'aria-label': this.props.columnDef.title
+        }}
       />
     );
   }
@@ -51,18 +54,21 @@ class MTableEditField extends React.Component {
     return (
       <MuiPickersUtilsProvider utils={DateFnsUtils}
         locale={this.props.dateTimePickerLocalization}>
-        <DatePicker
-          {...this.getProps()}
-          format="dd.MM.yyyy"
-          value={this.props.value || null}
-          onChange={this.props.onChange}
-          clearable
-          InputProps={{
-            style: {
-              fontSize: 13,
-            }
-          }}
-        />
+
+          <DatePicker
+            {...this.getProps()}
+            format="dd.MM.yyyy"
+            value={this.props.value || null}
+            onChange={this.props.onChange}
+            clearable
+            InputProps={{
+              style: {
+                fontSize: 13,
+              },
+              'aria-label': `${this.props.columnDef.title}: press space to edit`
+            }}
+          />
+
       </MuiPickersUtilsProvider>
     );
   }
@@ -71,18 +77,19 @@ class MTableEditField extends React.Component {
       <MuiPickersUtilsProvider
         utils={DateFnsUtils}
         locale={this.props.dateTimePickerLocalization}>
-        <TimePicker
-          {...this.getProps()}
-          format="HH:mm:ss"
-          value={this.props.value || null}
-          onChange={this.props.onChange}
-          clearable
-          InputProps={{
-            style: {
-              fontSize: 13,
-            }
-          }}
-        />
+          <TimePicker
+            {...this.getProps()}
+            format="HH:mm:ss"
+            value={this.props.value || null}
+            onChange={this.props.onChange}
+            clearable
+            InputProps={{
+              style: {
+                fontSize: 13,
+              },
+              'aria-label': `${this.props.columnDef.title}: press space to edit`
+            }}
+          />
       </MuiPickersUtilsProvider>
     );
   }
@@ -91,18 +98,19 @@ class MTableEditField extends React.Component {
     return (
       <MuiPickersUtilsProvider utils={DateFnsUtils}
         locale={this.props.dateTimePickerLocalization}>
-        <DateTimePicker
-          {...this.getProps()}
-          format="dd.MM.yyyy HH:mm:ss"
-          value={this.props.value || null}
-          onChange={this.props.onChange}
-          clearable
-          InputProps={{
-            style: {
-              fontSize: 13,
-            }
-          }}
-        />
+          <DateTimePicker
+            {...this.getProps()}
+            format="dd.MM.yyyy HH:mm:ss"
+            value={this.props.value || null}
+            onChange={this.props.onChange}
+            clearable
+            InputProps={{
+              style: {
+                fontSize: 13,
+              },
+              'aria-label': `${this.props.columnDef.title}: press space to edit`
+            }}
+          />
       </MuiPickersUtilsProvider>
     );
   }
@@ -119,6 +127,9 @@ class MTableEditField extends React.Component {
         InputProps={{
           style: {
             fontSize: 13,
+          },
+          inputProps: {
+            'aria-label': this.props.columnDef.title
           }
         }}
       />
@@ -135,7 +146,8 @@ class MTableEditField extends React.Component {
         inputProps={{
           style: {
             fontSize: 13,
-            textAlign: "right"
+            textAlign: 'right',
+            'aria-label': this.props.columnDef.title
           }
         }}
       />

--- a/src/components/m-table-edit-field.js
+++ b/src/components/m-table-edit-field.js
@@ -52,23 +52,25 @@ class MTableEditField extends React.Component {
 
   renderDateField() {
     return (
-      <MuiPickersUtilsProvider utils={DateFnsUtils}
-        locale={this.props.dateTimePickerLocalization}>
-
-          <DatePicker
-            {...this.getProps()}
-            format="dd.MM.yyyy"
-            value={this.props.value || null}
-            onChange={this.props.onChange}
-            clearable
-            InputProps={{
-              style: {
-                fontSize: 13,
-              },
-              'aria-label': `${this.props.columnDef.title}: press space to edit`
-            }}
-          />
-
+      <MuiPickersUtilsProvider
+        utils={DateFnsUtils}
+        locale={this.props.dateTimePickerLocalization}
+      >
+        <DatePicker
+          {...this.getProps()}
+          format='dd.MM.yyyy'
+          value={this.props.value || null}
+          onChange={this.props.onChange}
+          clearable
+          InputProps={{
+            style: {
+              fontSize: 13
+            }
+          }}
+          inputProps={{
+            'aria-label': `${this.props.columnDef.title}: press space to edit`
+          }}
+        />
       </MuiPickersUtilsProvider>
     );
   }
@@ -76,41 +78,49 @@ class MTableEditField extends React.Component {
     return (
       <MuiPickersUtilsProvider
         utils={DateFnsUtils}
-        locale={this.props.dateTimePickerLocalization}>
-          <TimePicker
-            {...this.getProps()}
-            format="HH:mm:ss"
-            value={this.props.value || null}
-            onChange={this.props.onChange}
-            clearable
-            InputProps={{
-              style: {
-                fontSize: 13,
-              },
+        locale={this.props.dateTimePickerLocalization}
+      >
+        <TimePicker
+          {...this.getProps()}
+          format='HH:mm:ss'
+          value={this.props.value || null}
+          onChange={this.props.onChange}
+          clearable
+          InputProps={{
+            style: {
+              fontSize: 13
+            },
+            inputProps: {
               'aria-label': `${this.props.columnDef.title}: press space to edit`
-            }}
-          />
+            }
+          }}
+        />
       </MuiPickersUtilsProvider>
     );
   }
 
   renderDateTimeField() {
     return (
-      <MuiPickersUtilsProvider utils={DateFnsUtils}
-        locale={this.props.dateTimePickerLocalization}>
-          <DateTimePicker
-            {...this.getProps()}
-            format="dd.MM.yyyy HH:mm:ss"
-            value={this.props.value || null}
-            onChange={this.props.onChange}
-            clearable
-            InputProps={{
-              style: {
-                fontSize: 13,
-              },
-              'aria-label': `${this.props.columnDef.title}: press space to edit`
-            }}
-          />
+      <MuiPickersUtilsProvider
+        utils={DateFnsUtils}
+        locale={this.props.dateTimePickerLocalization}
+      >
+        <DateTimePicker
+          {...this.getProps()}
+          format='dd.MM.yyyy HH:mm:ss'
+          value={this.props.value || null}
+          onChange={this.props.onChange}
+          clearable
+          InputProps={{
+            style: {
+              fontSize: 13
+            },
+            inputProps:{
+            'aria-label': `${this.props.columnDef.title}: press space to edit`
+          }
+          }}
+          
+        />
       </MuiPickersUtilsProvider>
     );
   }

--- a/src/components/m-table-edit-field.js
+++ b/src/components/m-table-edit-field.js
@@ -68,7 +68,7 @@ class MTableEditField extends React.Component {
             }
           }}
           inputProps={{
-            'aria-label': `${this.props.columnDef.title}: press space to edit`
+            'aria-label': `${this.props.columnDef.title}`
           }}
         />
       </MuiPickersUtilsProvider>
@@ -91,7 +91,7 @@ class MTableEditField extends React.Component {
               fontSize: 13
             },
             inputProps: {
-              'aria-label': `${this.props.columnDef.title}: press space to edit`
+              'aria-label': `${this.props.columnDef.title}`
             }
           }}
         />
@@ -116,7 +116,7 @@ class MTableEditField extends React.Component {
               fontSize: 13
             },
             inputProps:{
-            'aria-label': `${this.props.columnDef.title}: press space to edit`
+            'aria-label': `${this.props.columnDef.title}`
           }
           }}
           

--- a/src/components/m-table-edit-row.js
+++ b/src/components/m-table-edit-row.js
@@ -250,7 +250,7 @@ MTableEditRow.defaultProps = {
     saveTooltip: 'Save',
     cancelTooltip: 'Cancel',
     deleteText: 'Are you sure you want to delete this row?',
-    selectThisRowAriaLabel: 'select this row'
+    selectThisRowAriaLabel: 'Select this row'
   }
 };
 

--- a/src/components/m-table-edit-row.js
+++ b/src/components/m-table-edit-row.js
@@ -250,6 +250,7 @@ MTableEditRow.defaultProps = {
     saveTooltip: 'Save',
     cancelTooltip: 'Cancel',
     deleteText: 'Are you sure you want to delete this row?',
+    selectThisRowAriaLabel: 'select this row'
   }
 };
 

--- a/src/components/m-table-filter-row.js
+++ b/src/components/m-table-filter-row.js
@@ -79,6 +79,7 @@ class MTableFilterRow extends React.Component {
         type={columnDef.type === 'numeric' ? 'number' : 'search'}
         value={columnDef.tableData.filterValue || ''}
         placeholder={columnDef.filterPlaceholder || ''}
+        inputProps={{'aria-label': `filter data by ${columnDef.title}`}}
         onChange={(event) => {
           this.props.onFilterChanged(columnDef.tableData.id, event.target.value);
         }}

--- a/src/components/m-table-filter-row.js
+++ b/src/components/m-table-filter-row.js
@@ -84,7 +84,7 @@ class MTableFilterRow extends React.Component {
         type={columnDef.type === 'numeric' ? 'number' : 'search'}
         value={columnDef.tableData.filterValue || ''}
         placeholder={columnDef.filterPlaceholder || ''}
-        inputProps={{'aria-label': `filter data by ${columnDef.title}`}}
+        inputProps={{'aria-label': `${localization.filterAriaLabel} ${columnDef.title}`}}
         onChange={(event) => {
           this.props.onFilterChanged(columnDef.tableData.id, event.target.value);
         }}
@@ -216,7 +216,8 @@ MTableFilterRow.defaultProps = {
   selection: false,
   hasActions: false,
   localization: {
-    filterTooltip: 'Filter'
+    filterTooltip: 'Filter',
+    filterAriaLabel: 'Filter data by'
   },
   hideFilterIcons: false,
 };

--- a/src/components/m-table-header.js
+++ b/src/components/m-table-header.js
@@ -8,8 +8,7 @@ import TableSortLabel from '@material-ui/core/TableSortLabel';
 import Checkbox from '@material-ui/core/Checkbox';
 import withStyles from '@material-ui/core/styles/withStyles';
 import { Droppable, Draggable } from 'react-beautiful-dnd';
-import {Tooltip} from '@material-ui/core';
-import FormLabel from "@material-ui/core/FormLabel";
+import { Tooltip } from '@material-ui/core';
 import * as CommonValues from '../utils/common-values';
 /* eslint-enable no-unused-vars */
 
@@ -117,7 +116,7 @@ export class MTableHeader extends React.Component {
         {this.props.showSelectAllCheckbox &&
           <Checkbox
             inputProps={{
-              'aria-label': 'Select all rows'
+              'aria-label': MTableHeader.defaultProps.localization.selectAllRowsAriaLabel
             }}
 
             indeterminate={this.props.selectedCount > 0 && this.props.selectedCount < this.props.dataCount}
@@ -198,7 +197,8 @@ MTableHeader.defaultProps = {
   selectedCount: 0,
   sorting: true,
   localization: {
-    actions: 'Actions'
+    actions: 'Actions',
+    selectAllRowsAriaLabel: 'Select all rows'
   },
   orderBy: undefined,
   orderDirection: 'asc',

--- a/src/components/m-table-header.js
+++ b/src/components/m-table-header.js
@@ -105,6 +105,7 @@ export class MTableHeader extends React.Component {
   }
   renderSelectionHeader() {
     const selectionWidth = CommonValues.selectionMaxWidth(this.props, this.props.treeDataMaxLevel);
+    const localization = {...MTableHeader.defaultProps.localization, ...this.props.localization};
 
     return (
       <TableCell
@@ -116,7 +117,7 @@ export class MTableHeader extends React.Component {
         {this.props.showSelectAllCheckbox &&
           <Checkbox
             inputProps={{
-              'aria-label': MTableHeader.defaultProps.localization.selectAllRowsAriaLabel
+              'aria-label': localization.selectAllRowsAriaLabel
             }}
 
             indeterminate={this.props.selectedCount > 0 && this.props.selectedCount < this.props.dataCount}

--- a/src/components/m-table-header.js
+++ b/src/components/m-table-header.js
@@ -8,7 +8,8 @@ import TableSortLabel from '@material-ui/core/TableSortLabel';
 import Checkbox from '@material-ui/core/Checkbox';
 import withStyles from '@material-ui/core/styles/withStyles';
 import { Droppable, Draggable } from 'react-beautiful-dnd';
-import { Tooltip } from '@material-ui/core';
+import {Tooltip} from '@material-ui/core';
+import FormLabel from "@material-ui/core/FormLabel";
 import * as CommonValues from '../utils/common-values';
 /* eslint-enable no-unused-vars */
 
@@ -115,6 +116,10 @@ export class MTableHeader extends React.Component {
       >
         {this.props.showSelectAllCheckbox &&
           <Checkbox
+            inputProps={{
+              'aria-label': 'Select all rows'
+            }}
+
             indeterminate={this.props.selectedCount > 0 && this.props.selectedCount < this.props.dataCount}
             checked={this.props.dataCount > 0 && this.props.selectedCount === this.props.dataCount}
             onChange={(event, checked) => this.props.onAllSelected && this.props.onAllSelected(checked)}

--- a/src/components/m-table-header.js
+++ b/src/components/m-table-header.js
@@ -113,6 +113,7 @@ export class MTableHeader extends React.Component {
         key="key-selection-column"
         className={this.props.classes.header}
         style={{ ...this.props.headerStyle, width: selectionWidth }}
+        component={'td'} // accessibility: <th> without text violates accessibility, fixed by using <td> with no text
       >
         {this.props.showSelectAllCheckbox &&
           <Checkbox

--- a/src/components/m-table-toolbar.js
+++ b/src/components/m-table-toolbar.js
@@ -83,7 +83,10 @@ export class MTableToolbar extends React.Component {
                 </IconButton>
               </InputAdornment>
             ),
-            style: this.props.searchFieldStyle
+            style: this.props.searchFieldStyle,
+            inputProps: {
+              'aria-label': "Search"
+            }
           }}
         />
       );

--- a/src/components/m-table-toolbar.js
+++ b/src/components/m-table-toolbar.js
@@ -85,7 +85,7 @@ export class MTableToolbar extends React.Component {
             ),
             style: this.props.searchFieldStyle,
             inputProps: {
-              'aria-label': "Search"
+              'aria-label': localization.searchAriaLabel
             }
           }}
         />
@@ -241,7 +241,8 @@ MTableToolbar.defaultProps = {
     exportAriaLabel: 'Export',
     exportName: 'Export as CSV',
     searchTooltip: 'Search',
-    searchPlaceholder: 'Search'
+    searchPlaceholder: 'Search',
+    searchAriaLabel: 'Search'
   },
   search: true,
   showTitle: true,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -247,6 +247,7 @@ export interface Localization {
     emptyDataSourceMessage?: string;
     filterRow?: {
       filterTooltip?: string;
+      filterAriaLabel?: string;
     };
     editRow?: {
       saveTooltip?: string;
@@ -289,6 +290,7 @@ export interface Localization {
     exportName?: string;
     searchTooltip?: string;
     searchPlaceholder?: string;
+    searchAriaLabel?: string;
   };
 }
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -259,6 +259,7 @@ export interface Localization {
   };
   header?: {
     actions?: string;
+    selectAllRows?: string;
   };
   grouping?: {
     groupedBy?: string;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -252,6 +252,7 @@ export interface Localization {
       saveTooltip?: string;
       cancelTooltip?: string;
       deleteText?: string;
+      selectThisRowAriaLabel?: string;
     },
     addTooltip?: string;
     deleteTooltip?: string;
@@ -259,7 +260,7 @@ export interface Localization {
   };
   header?: {
     actions?: string;
-    selectAllRows?: string;
+    selectAllRowsAriaLabel?: string;
   };
   grouping?: {
     groupedBy?: string;


### PR DESCRIPTION
## Related Issue
Related to issue #1747 and issues #1375 and #1499, pulled from master and merged with and slightly modifying aitchiss's PR for #1499

## Description
Address a number of accessibility bugs preventing my organization and probably many others, from using material-table.
- addresses select checkbox aria labels, with overridable defaults (in English), including changes to TypeScript Localization interface
- addresses empty table header error for select all checkbox (accessibility docs suggest converting th to td using component={'td'})
- modifies a subset of the merged PR provided by @aitchiss in 1499, trying to maintain a closer consistency with existing localization and overrides
  - removes hardcoded English aria-label, while leaving the provided data column name (editing instructions could be different depending on picker implementation)
  - replaces hardcoded English search and filter aria-labels with new overridable [search|filter]AriaLabel, also added to TypeScript Localization
- Footer error with Broken Aria Reference - is actually a Material-UI error, see by running WAVE on https://material-ui.com/components/tables/
  - beyond the scope of this PR


## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
other_pr_production | [link]()
other_pr_master | [link]()

Feature/add labels to inputs #1499 | https://github.com/mbrn/material-table/pull/1499

## Impacted Areas in Application
List general components of the application that this PR will affect:

*non-displayed HTML
*TypeScript interface Localization

## Additional Notes
This is optional, feel free to follow your hearth and write here :)
Large organizations with substantial financial assets may not use material-table out of concern for lawsuits with large cash penalties for bad accessibility.  Plus its the right thing to do.  This PR fixes many/most of those issues.