### PR TITLE
fix(editComponent): add missing onRowDataChange type declaration

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -87,6 +87,7 @@ export interface EditComponentProps<RowData extends object> {
   rowData: RowData;
   value: any;
   onChange: (newValue: any) => void;
+  onRowDataChange: (newValue: RowData) => void;
   columnDef: EditCellColumnDef;
 }
 


### PR DESCRIPTION
## Related Issue
On my **local** project ;)

## Description
This PR is meant to allow to use the **onRowDataChange** props in **editComponent** Column object attribute.
My project is in **TS** and the type declaration for this one was **missing**


## Impacted Areas in Application
It will affect **only the TS types** !
*

## Additional Notes
**Thanks** for the incoming revue ;)