### PR TITLE
Fix off-by-one error for fixed table layouts

### DIFF
--- a/src/material-table.js
+++ b/src/material-table.js
@@ -620,7 +620,7 @@ export default class MaterialTable extends React.Component {
     }
 
     for (let i = 0; i < Math.abs(count) && i < props.columns.length; i++) {
-      const colDef = props.columns[i > 0 ? i : props.columns.length - 1 - i];
+      const colDef = props.columns[i >= 0 ? i : props.columns.length - 1 - i];
       if(colDef.tableData) {
         if (typeof colDef.tableData.width === "number") {
           result.push(colDef.tableData.width + "px");


### PR DESCRIPTION
## Related Issue
None

## Description
This pull request fixes an off-by-one error which causes the incorrect column width to be used for the vertical line delineating the fixed from unfixed columns.

## Related PRs
None

## Impacted Areas in Application
List general components of the application that this PR will affect:

* [Fixed Columns](https://material-table.com/#/docs/features/fixed-columns)

## Additional Notes
None