### PR TITLE
Remove hidden columns in computing the colspan of an empty tablecell …

### DIFF
--- a/src/components/m-table-body.js
+++ b/src/components/m-table-body.js
@@ -26,7 +26,7 @@ class MTableBody extends React.Component {
       }
       return (
         <TableRow style={{ height: rowHeight * (this.props.options.paging && this.props.options.emptyRowsWhenPaging ? this.props.pageSize : 1) }} key={'empty-' + 0} >
-          <TableCell style={{ paddingTop: 0, paddingBottom: 0, textAlign: 'center' }} colSpan={this.props.columns.length + addColumn} key="empty-">
+          <TableCell style={{ paddingTop: 0, paddingBottom: 0, textAlign: 'center' }} colSpan={this.props.columns.reduce((currentVal, columnDef) => columnDef.hidden ? currentVal : currentVal + 1, 0) + addColumn} key="empty-">
             {localization.emptyDataSourceMessage}
           </TableCell>
         </TableRow>

--- a/src/components/m-table-body.js
+++ b/src/components/m-table-body.js
@@ -26,7 +26,7 @@ class MTableBody extends React.Component {
       }
       return (
         <TableRow style={{ height: rowHeight * (this.props.options.paging && this.props.options.emptyRowsWhenPaging ? this.props.pageSize : 1) }} key={'empty-' + 0} >
-          <TableCell style={{ paddingTop: 0, paddingBottom: 0, textAlign: 'center' }} colSpan={this.props.columns.reduce((currentVal, columnDef) => columnDef.hidden ? currentVal : currentVal + 1, 0) + addColumn} key="empty-">
+          <TableCell style={{ paddingTop: 0, paddingBottom: 0, textAlign: 'center' }} colSpan={this.props.columns.reduce((currentVal, columnDef) => columnDef.hidden ? currentVal : currentVal + 1, addColumn)} key="empty-">
             {localization.emptyDataSourceMessage}
           </TableCell>
         </TableRow>


### PR DESCRIPTION
…so it won't have extra spaces on the right of the table.

## Related Issue
I haven't created an issue for this but when we have columns that are hidden and there is no data shown in the table, it generates empty spaces on the right of the table since the colspan is calculating the hidden columns.
![image](https://user-images.githubusercontent.com/59203763/78820840-7dc7ce80-79a6-11ea-81a9-5a1e866b04d2.png)

## Description
Do not include hidden columns in the computation of colspan of an empty `<TableCell />`

## Impacted Areas in Application
List general components of the application that this PR will affect:

* m-table-body.js