### PR TITLE
Move actionsCellStyle to div container

### DIFF
--- a/src/components/m-table-body-row.js
+++ b/src/components/m-table-body-row.js
@@ -37,8 +37,8 @@ export default class MTableBodyRow extends React.Component {
     const actions = CommonValues.rowActions(this.props);
     const width = actions.length * CommonValues.baseIconSize(this.props);
     return (
-      <TableCell size={size} padding="none" key="key-actions-column" style={{ width: width, padding: '0px 5px', boxSizing: 'border-box', ...this.props.options.actionsCellStyle }}>
-        <div style={{ display: 'flex' }}>
+      <TableCell size={size} padding="none" key="key-actions-column" style={{ width: width, padding: '0px 5px', boxSizing: 'border-box' }}>
+        <div style={{ display: 'flex', ...this.props.options.actionsCellStyle }}>
           <this.props.components.Actions data={this.props.data} actions={actions} components={this.props.components} size={size} disabled={this.props.hasAnyEditingRow} />
         </div>
       </TableCell>


### PR DESCRIPTION
The `actionCellStyle` css style object is currently applied to the `TableCell` and not the child `<div>` element. Because of this, the styles do not allow formatting of the element such as `justifyContent: 'center'`  This simple edit moves the styles to the div. Hopefully this is the intended behavior. See [Issue #888](https://github.com/mbrn/material-table/issues/888)

## Related Issue
See [Issue #888](https://github.com/mbrn/material-table/issues/888)

## Description
Enable `actionCellStyle` to affect the styling of the cell's `<div>` directly.

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
other_pr_production | [link]()
other_pr_master | [link]()

## Impacted Areas in Application
List general components of the application that this PR will affect:

* [MTableBodyRow](https://github.com/mbrn/material-table/blob/master/src/components/m-table-body-row.js)

## Additional Notes
Very new to PRs so I apologize in advance if I've screwed something up.