### PR TITLE
Checking props.data type to skip remote sorting

### DIFF
--- a/src/material-table.js
+++ b/src/material-table.js
@@ -73,10 +73,12 @@ export default class MaterialTable extends React.Component {
     if (this.isRemoteData(props)) {
       this.dataManager.changeApplySearch(false);
       this.dataManager.changeApplyFilters(false);
+      this.dataManager.changeApplySort(false);
     }
     else {
       this.dataManager.changeApplySearch(true);
       this.dataManager.changeApplyFilters(true);
+      this.dataManager.changeApplySort(true);
       this.dataManager.setData(props.data);
     }
 
@@ -378,14 +380,8 @@ export default class MaterialTable extends React.Component {
     }
   }
 
-  checkFunctionType = (data) => {
-    return typeof data === 'function' ? true : false;
-  }
-
   onQueryChange = (query, callback) => {
     query = { ...this.state.query, ...query };
-    const isFunction = this.checkFunctionType(this.props.data);
-    this.dataManager.setRemoteSortingStatus(isFunction);
     this.setState({ isLoading: true }, () => {
       this.props.data(query).then((result) => {
         query.totalCount = result.totalCount;

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -378,9 +378,14 @@ export default class MaterialTable extends React.Component {
     }
   }
 
+  checkFunctionType = (data) => {
+    return typeof data === 'function' ? true : false;
+  }
+
   onQueryChange = (query, callback) => {
     query = { ...this.state.query, ...query };
-
+    const isFunction = this.checkFunctionType(this.props.data);
+    this.dataManager.setRemoteSortingStatus(isFunction);
     this.setState({ isLoading: true }, () => {
       this.props.data(query).then((result) => {
         query.totalCount = result.totalCount;

--- a/src/utils/data-manager.js
+++ b/src/utils/data-manager.js
@@ -19,6 +19,7 @@ export default class DataManager {
   treeDataMaxLevel = 0;
   groupedDataLength = 0;
   defaultExpanded = false;
+  remoteSorting = false;
   
   data = [];
   columns = [];
@@ -92,6 +93,10 @@ export default class DataManager {
 
   setDefaultExpanded(expanded) {
     this.defaultExpanded = expanded;
+  }
+
+  setRemoteSortingStatus(remoteSortStatus) {
+    this.remoteSorting = remoteSortStatus;
   }
 
   changeApplySearch(applySearch) {
@@ -839,7 +844,7 @@ export default class DataManager {
     }
     else if (this.isDataType("normal")) {
       this.sortedData = [...this.searchedData];
-      if (this.orderBy != -1) {
+      if (this.orderBy != -1 && this.remoteSorting === false) {
         this.sortedData = this.sortList(this.sortedData);
       }
     }

--- a/src/utils/data-manager.js
+++ b/src/utils/data-manager.js
@@ -4,6 +4,7 @@ import { byString } from './';
 export default class DataManager {
   applyFilters = false;
   applySearch = false;
+  applySort = false;
   currentPage = 0;
   detailPanelType = 'multiple'
   lastDetailPanelRow = undefined;
@@ -19,7 +20,6 @@ export default class DataManager {
   treeDataMaxLevel = 0;
   groupedDataLength = 0;
   defaultExpanded = false;
-  remoteSorting = false;
   
   data = [];
   columns = [];
@@ -95,10 +95,6 @@ export default class DataManager {
     this.defaultExpanded = expanded;
   }
 
-  setRemoteSortingStatus(remoteSortStatus) {
-    this.remoteSorting = remoteSortStatus;
-  }
-
   changeApplySearch(applySearch) {
     this.applySearch = applySearch;
     this.searched = false;
@@ -107,6 +103,11 @@ export default class DataManager {
   changeApplyFilters(applyFilters) {
     this.applyFilters = applyFilters;
     this.filtered = false;
+  }
+
+  changeApplySort(applySort) {
+    this.applySort = applySort;
+    this.sorted = false;
   }
 
   changePaging(paging) {
@@ -844,7 +845,7 @@ export default class DataManager {
     }
     else if (this.isDataType("normal")) {
       this.sortedData = [...this.searchedData];
-      if (this.orderBy != -1 && this.remoteSorting === false) {
+      if (this.orderBy != -1 && this.applySort) {
         this.sortedData = this.sortList(this.sortedData);
       }
     }


### PR DESCRIPTION
## Related Issue
[#1323 ](https://github.com/mbrn/material-table/issues/1323)

## Description
Skip the sorting if the data could be already sorted from backend. Checking type of `this.props.data`  and skip the sorting if it is a function.

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
other_pr_production | [link]()
other_pr_master | [link]()

## Impacted Areas in Application
List general components of the application that this PR will affect:

*  [material-table.js](https://github.com/mbrn/material-table/blob/master/src/material-table.js)
*  [data-manager.js](https://github.com/mbrn/material-table/blob/master/src/utils/data-manager.js)
