### PR TITLE
Update header alignment of currency header.

### DIFF
--- a/src/components/m-table-header.js
+++ b/src/components/m-table-header.js
@@ -75,7 +75,7 @@ export class MTableHeader extends React.Component {
         return (
           <TableCell
             key={columnDef.tableData.id}
-            align={['numeric'].indexOf(columnDef.type) !== -1 ? "right" : "left"}
+            align={['numeric', 'currency'].indexOf(columnDef.type) !== -1 ? "right" : "left"}
             className={this.props.classes.header}
             style={{ ...this.props.headerStyle, ...columnDef.headerStyle, boxSizing: 'border-box', width: columnDef.tableData.width }}
             size={size}


### PR DESCRIPTION
## Related Issue
#1369

## Description
Sets the default alignment of a currency column to align right rather than left. Currency cells align to the right whereas the headers align to the left which is inconsistent for the column as well as numeric cells.
