### PR TITLE
Feature/expose export button

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -1,32 +1,32 @@
-import { Grid, MuiThemeProvider, Button } from '@material-ui/core';
-import { createMuiTheme } from '@material-ui/core/styles';
-import React, { Component } from 'react';
-import ReactDOM from 'react-dom';
-import MaterialTable from '../src';
+import { Grid, MuiThemeProvider, Button } from "@material-ui/core";
+import { createMuiTheme } from "@material-ui/core/styles";
+import React, { Component } from "react";
+import ReactDOM from "react-dom";
+import MaterialTable from "../src";
 import Typography from "@material-ui/core/Typography";
 
-let direction = 'ltr';
+let direction = "ltr";
 // direction = 'rtl';
 const theme = createMuiTheme({
   direction: direction,
   palette: {
-    type: 'light'
-  }
+    type: "light",
+  },
 });
 
 const bigData = [];
 for (let i = 0; i < 1; i++) {
   const d = {
     id: i + 1,
-    name: 'Name' + i,
-    surname: 'Surname' + Math.round(i / 10),
+    name: "Name" + i,
+    surname: "Surname" + Math.round(i / 10),
     isMarried: i % 2 ? true : false,
     birthDate: new Date(1987, 1, 1),
     birthCity: 0,
-    sex: i % 2 ? 'Male' : 'Female',
-    type: 'adult',
+    sex: i % 2 ? "Male" : "Female",
+    type: "adult",
     insertDateTime: new Date(2018, 1, 1, 12, 23, 44),
-    time: new Date(1900, 1, 1, 14, 23, 35)
+    time: new Date(1900, 1, 1, 14, 23, 35),
   };
   bigData.push(d);
 }
@@ -37,41 +37,146 @@ class App extends Component {
   colRenderCount = 0;
 
   state = {
-    text: 'text',
+    text: "text",
     selecteds: 0,
     data: [
-      { id: 1, name: 'A1', surname: 'B', isMarried: true, birthDate: new Date(1987, 1, 1), birthCity: 0, sex: 'Male', type: 'adult', insertDateTime: '1994-11-23T08:15:30-05:00', time: new Date(1900, 1, 1, 14, 23, 35) },
-      { id: 2, name: 'A2', surname: 'B', isMarried: false, birthDate: new Date(1987, 1, 1), birthCity: 34, sex: 'Female', type: 'adult', insertDateTime: '1994-11-05T13:15:30Z', time: new Date(1900, 1, 1, 14, 23, 35), parentId: 1 },
-      { id: 3, name: 'A3', surname: 'B', isMarried: true, birthDate: new Date(1987, 1, 1), birthCity: 34, sex: 'Female', type: 'child', insertDateTime: new Date(2018, 1, 1, 12, 23, 44), time: new Date(1900, 1, 1, 14, 23, 35), parentId: 1 },
-      { id: 4, name: 'A4', surname: 'Dede Dede Dede Dede Dede Dede Dede Dede', isMarried: true, birthDate: new Date(1987, 1, 1), birthCity: 34, sex: 'Female', type: 'child', insertDateTime: new Date(2018, 1, 1, 12, 23, 44), time: new Date(1900, 1, 1, 14, 23, 35), parentId: 3 },
-      { id: 5, name: 'A5', surname: 'C', isMarried: false, birthDate: new Date(1987, 1, 1), birthCity: 34, sex: 'Female', type: 'child', insertDateTime: new Date(2018, 1, 1, 12, 23, 44), time: new Date(1900, 1, 1, 14, 23, 35) },
-      { id: 6, name: 'A6', surname: 'C', isMarried: true, birthDate: new Date(1989, 1, 1), birthCity: 34, sex: 'Female', type: 'child', insertDateTime: new Date(2018, 1, 1, 12, 23, 44), time: new Date(1900, 1, 1, 14, 23, 35), parentId: 5 },
+      {
+        id: 1,
+        name: "A1",
+        surname: "B",
+        isMarried: true,
+        birthDate: new Date(1987, 1, 1),
+        birthCity: 0,
+        sex: "Male",
+        type: "adult",
+        insertDateTime: "1994-11-23T08:15:30-05:00",
+        time: new Date(1900, 1, 1, 14, 23, 35),
+      },
+      {
+        id: 2,
+        name: "A2",
+        surname: "B",
+        isMarried: false,
+        birthDate: new Date(1987, 1, 1),
+        birthCity: 34,
+        sex: "Female",
+        type: "adult",
+        insertDateTime: "1994-11-05T13:15:30Z",
+        time: new Date(1900, 1, 1, 14, 23, 35),
+        parentId: 1,
+      },
+      {
+        id: 3,
+        name: "A3",
+        surname: "B",
+        isMarried: true,
+        birthDate: new Date(1987, 1, 1),
+        birthCity: 34,
+        sex: "Female",
+        type: "child",
+        insertDateTime: new Date(2018, 1, 1, 12, 23, 44),
+        time: new Date(1900, 1, 1, 14, 23, 35),
+        parentId: 1,
+      },
+      {
+        id: 4,
+        name: "A4",
+        surname: "Dede Dede Dede Dede Dede Dede Dede Dede",
+        isMarried: true,
+        birthDate: new Date(1987, 1, 1),
+        birthCity: 34,
+        sex: "Female",
+        type: "child",
+        insertDateTime: new Date(2018, 1, 1, 12, 23, 44),
+        time: new Date(1900, 1, 1, 14, 23, 35),
+        parentId: 3,
+      },
+      {
+        id: 5,
+        name: "A5",
+        surname: "C",
+        isMarried: false,
+        birthDate: new Date(1987, 1, 1),
+        birthCity: 34,
+        sex: "Female",
+        type: "child",
+        insertDateTime: new Date(2018, 1, 1, 12, 23, 44),
+        time: new Date(1900, 1, 1, 14, 23, 35),
+      },
+      {
+        id: 6,
+        name: "A6",
+        surname: "C",
+        isMarried: true,
+        birthDate: new Date(1989, 1, 1),
+        birthCity: 34,
+        sex: "Female",
+        type: "child",
+        insertDateTime: new Date(2018, 1, 1, 12, 23, 44),
+        time: new Date(1900, 1, 1, 14, 23, 35),
+        parentId: 5,
+      },
     ],
     columns: [
-      { title: 'Adı', field: 'name', filterPlaceholder: 'Adı filter', tooltip: 'This is tooltip text' },
-      { width: 200, title: 'Soyadı', field: 'surname', initialEditValue: 'test', tooltip: 'This is tooltip text' },
-      { title: 'Evli', field: 'isMarried' },
-      { title: 'Cinsiyet', field: 'sex', disableClick: true, editable: 'onAdd' },
-      { title: 'Tipi', field: 'type', removable: false, editable: 'never' },
-      { title: 'Doğum Yılı', field: 'birthDate', type: 'date' },
-      { title: 'Doğum Yeri', field: 'birthCity', lookup: { 34: 'İstanbul', 0: 'Şanlıurfa' } },
-      { title: 'Kayıt Tarihi', field: 'insertDateTime', type: 'datetime' },
-      { title: 'Zaman', field: 'time', type: 'time' },
-      { title: 'Adı', field: 'name', filterPlaceholder: 'Adı filter', tooltip: 'This is tooltip text' },
+      {
+        title: "Adı",
+        field: "name",
+        filterPlaceholder: "Adı filter",
+        tooltip: "This is tooltip text",
+      },
+      {
+        width: 200,
+        title: "Soyadı",
+        field: "surname",
+        initialEditValue: "test",
+        tooltip: "This is tooltip text",
+      },
+      { title: "Evli", field: "isMarried" },
+      {
+        title: "Cinsiyet",
+        field: "sex",
+        disableClick: true,
+        editable: "onAdd",
+      },
+      { title: "Tipi", field: "type", removable: false, editable: "never" },
+      { title: "Doğum Yılı", field: "birthDate", type: "date" },
+      {
+        title: "Doğum Yeri",
+        field: "birthCity",
+        lookup: { 34: "İstanbul", 0: "Şanlıurfa" },
+      },
+      { title: "Kayıt Tarihi", field: "insertDateTime", type: "datetime" },
+      { title: "Zaman", field: "time", type: "time" },
+      {
+        title: "Adı",
+        field: "name",
+        filterPlaceholder: "Adı filter",
+        tooltip: "This is tooltip text",
+      },
     ],
     remoteColumns: [
-      { title: 'Avatar', field: 'avatar', render: rowData => <img style={{ height: 36, borderRadius: '50%' }} src={rowData.avatar} />, tooltip: 'delakjdslkjdaskljklsdaj' },
-      { title: 'Id', field: 'id' },
-      { title: 'First Name', field: 'first_name', defaultFilter: 'De' },
-      { title: 'Last Name', field: 'last_name' },
-    ]
-  }
+      {
+        title: "Avatar",
+        field: "avatar",
+        render: (rowData) => (
+          <img
+            style={{ height: 36, borderRadius: "50%" }}
+            src={rowData.avatar}
+          />
+        ),
+        tooltip: "delakjdslkjdaskljklsdaj",
+      },
+      { title: "Id", field: "id" },
+      { title: "First Name", field: "first_name", defaultFilter: "De" },
+      { title: "Last Name", field: "last_name" },
+    ],
+  };
 
   render() {
     return (
       <>
         <MuiThemeProvider theme={theme}>
-          <div style={{ maxWidth: '100%', direction }}>
+          <div style={{ maxWidth: "100%", direction }}>
             <Grid container>
               <Grid item xs={12}>
                 {this.state.selectedRows && this.state.selectedRows.length}
@@ -80,62 +185,72 @@ class App extends Component {
                   columns={this.state.columns}
                   data={this.state.data}
                   title="Demo Title"
-                  onRowClick={((evt, selectedRow) => this.setState({ selectedRow }))}
+                  onRowClick={(evt, selectedRow) =>
+                    this.setState({ selectedRow })
+                  }
                   options={{
                     fixedColumns: {
                       left: 2,
-                      right: 0
+                      right: 0,
                     },
-                    tableLayout: 'fixed'
+
+                    tableLayout: "fixed",
+                    exportButton: true,
                   }}
                 />
               </Grid>
             </Grid>
             {this.state.text}
-            <button onClick={() => this.tableRef.current.onAllSelected(true)} style={{ margin: 10 }}>
+            <button
+              onClick={() => this.tableRef.current.onAllSelected(true)}
+              style={{ margin: 10 }}
+            >
               Select
             </button>
             <MaterialTable
               title={
-                <Typography variant='h6' color='primary'>Remote Data Preview</Typography>
+                <Typography variant="h6" color="primary">
+                  Remote Data Preview
+                </Typography>
               }
               columns={[
                 {
-                  title: 'Avatar',
-                  field: 'avatar',
-                  render: rowData => (
+                  title: "Avatar",
+                  field: "avatar",
+                  render: (rowData) => (
                     <img
-                      style={{ height: 36, borderRadius: '50%' }}
+                      style={{ height: 36, borderRadius: "50%" }}
                       src={rowData.avatar}
                     />
                   ),
                 },
-                { title: 'Id', field: 'id', filterPlaceholder: 'placeholder' },
-                { title: 'First Name', field: 'first_name' },
-                { title: 'Last Name', field: 'last_name' },
+                { title: "Id", field: "id", filterPlaceholder: "placeholder" },
+                { title: "First Name", field: "first_name" },
+                { title: "Last Name", field: "last_name" },
               ]}
               options={{
-                filtering: true,
+                filtering: false,
                 grouping: true,
-                groupTitle: group => group.data.length,
+                groupTitle: (group) => group.data.length,
               }}
-              data={query => new Promise((resolve, reject) => {
-                let url = 'https://reqres.in/api/users?'
-                url += 'per_page=' + query.pageSize
-                url += '&page=' + (query.page + 1)
-                console.log(query);
-                fetch(url)
-                  .then(response => response.json())
-                  .then(result => {
-                    resolve({
-                      data: result.data,
-                      page: result.page - 1,
-                      totalCount: result.total,
-                    })
-                  })
-              })}
+              data={(query) =>
+                new Promise((resolve, reject) => {
+                  let url = "https://reqres.in/api/users?";
+                  url += "per_page=" + query.pageSize;
+                  url += "&page=" + (query.page + 1);
+                  console.log(query);
+                  fetch(url)
+                    .then((response) => response.json())
+                    .then((result) => {
+                      resolve({
+                        data: result.data,
+                        page: result.page - 1,
+                        totalCount: result.total,
+                      });
+                    });
+                })
+              }
             />
-
           </div>
         </MuiThemeProvider>
       </>
@@ -143,9 +258,6 @@ class App extends Component {
   }
 }
 
-ReactDOM.render(
-  <App />,
-  document.getElementById('app')
-);
+ReactDOM.render(<App />, document.getElementById("app"));
 
 module.hot.accept();

--- a/src/components/m-table-body.js
+++ b/src/components/m-table-body.js
@@ -1,21 +1,32 @@
 /* eslint-disable no-unused-vars */
-import TableBody from '@material-ui/core/TableBody';
-import TableCell from '@material-ui/core/TableCell';
-import TableRow from '@material-ui/core/TableRow';
-import PropTypes from 'prop-types';
-import * as React from 'react';
+import TableBody from "@material-ui/core/TableBody";
+import TableCell from "@material-ui/core/TableCell";
+import TableRow from "@material-ui/core/TableRow";
+import PropTypes from "prop-types";
+import * as React from "react";
 /* eslint-enable no-unused-vars */
 
 class MTableBody extends React.Component {
   renderEmpty(emptyRowCount, renderData) {
-    const rowHeight = this.props.options.padding === 'default' ? 49 : 36;
-    const localization = { ...MTableBody.defaultProps.localization, ...this.props.localization };
-    if (this.props.options.showEmptyDataSourceMessage && renderData.length === 0) {
+    const rowHeight = this.props.options.padding === "default" ? 49 : 36;
+    const localization = {
+      ...MTableBody.defaultProps.localization,
+      ...this.props.localization,
+    };
+    if (
+      this.props.options.showEmptyDataSourceMessage &&
+      renderData.length === 0
+    ) {
       let addColumn = 0;
       if (this.props.options.selection) {
         addColumn++;
       }
-      if (this.props.actions && this.props.actions.filter(a => a.position === "row" || typeof a === "function").length > 0) {
+      if (
+        this.props.actions &&
+        this.props.actions.filter(
+          (a) => a.position === "row" || typeof a === "function"
+        ).length > 0
+      ) {
         addColumn++;
       }
       if (this.props.hasDetailPanel) {
@@ -25,8 +36,22 @@ class MTableBody extends React.Component {
         addColumn++;
       }
       return (
-        <TableRow style={{ height: rowHeight * (this.props.options.paging && this.props.options.emptyRowsWhenPaging ? this.props.pageSize : 1) }} key={'empty-' + 0} >
-          <TableCell style={{ paddingTop: 0, paddingBottom: 0, textAlign: 'center' }} colSpan={this.props.columns.length + addColumn} key="empty-">
+        <TableRow
+          style={{
+            height:
+              rowHeight *
+              (this.props.options.paging &&
+              this.props.options.emptyRowsWhenPaging
+                ? this.props.pageSize
+                : 1),
+          }}
+          key={"empty-" + 0}
+        >
+          <TableCell
+            style={{ paddingTop: 0, paddingBottom: 0, textAlign: "center" }}
+            colSpan={this.props.columns.length + addColumn}
+            key="empty-"
+          >
             {localization.emptyDataSourceMessage}
           </TableCell>
         </TableRow>
@@ -34,8 +59,12 @@ class MTableBody extends React.Component {
     } else if (this.props.options.emptyRowsWhenPaging) {
       return (
         <React.Fragment>
-          {[...Array(emptyRowCount)].map((r, index) => <TableRow style={{ height: rowHeight }} key={'empty-' + index} />)}
-          {emptyRowCount > 0 && <TableRow style={{ height: 1 }} key={'empty-last1'} />}
+          {[...Array(emptyRowCount)].map((r, index) => (
+            <TableRow style={{ height: rowHeight }} key={"empty-" + index} />
+          ))}
+          {emptyRowCount > 0 && (
+            <TableRow style={{ height: 1 }} key={"empty-last1"} />
+          )}
         </React.Fragment>
       );
     }
@@ -46,11 +75,18 @@ class MTableBody extends React.Component {
       if (data.tableData.editing) {
         return (
           <this.props.components.EditRow
-            columns={this.props.columns.filter(columnDef => { return !columnDef.hidden })}
+            columns={this.props.columns.filter((columnDef) => {
+              return !columnDef.hidden;
+            })}
             components={this.props.components}
             data={data}
             icons={this.props.icons}
-            localization={{ ...MTableBody.defaultProps.localization.editRow, ...this.props.localization.editRow, dateTimePickerLocalization: this.props.localization.dateTimePickerLocalization }}
+            localization={{
+              ...MTableBody.defaultProps.localization.editRow,
+              ...this.props.localization.editRow,
+              dateTimePickerLocalization: this.props.localization
+                .dateTimePickerLocalization,
+            }}
             key={index}
             mode={data.tableData.editing}
             options={this.props.options}
@@ -61,8 +97,7 @@ class MTableBody extends React.Component {
             getFieldValue={this.props.getFieldValue}
           />
         );
-      }
-      else {
+      } else {
         return (
           <this.props.components.Row
             components={this.props.components}
@@ -72,7 +107,10 @@ class MTableBody extends React.Component {
             key={"row-" + data.tableData.id}
             level={0}
             options={this.props.options}
-            localization={{ ...MTableBody.defaultProps.localization.editRow, ...this.props.localization.editRow }}
+            localization={{
+              ...MTableBody.defaultProps.localization.editRow,
+              ...this.props.localization.editRow,
+            }}
             onRowSelected={this.props.onRowSelected}
             actions={this.props.actions}
             columns={this.props.columns}
@@ -97,7 +135,7 @@ class MTableBody extends React.Component {
     return renderData.map((groupData, index) => (
       <this.props.components.GroupRow
         actions={this.props.actions}
-        key={groupData.value == null ? ('' + index) : groupData.value}
+        key={groupData.value == null ? "" + index : groupData.value}
         columns={this.props.columns}
         components={this.props.components}
         detailPanel={this.props.detailPanel}
@@ -117,7 +155,10 @@ class MTableBody extends React.Component {
         options={this.props.options}
         isTreeData={this.props.isTreeData}
         hasAnyEditingRow={this.props.hasAnyEditingRow}
-        localization={{ ...MTableBody.defaultProps.localization.editRow, ...this.props.localization.editRow }}
+        localization={{
+          ...MTableBody.defaultProps.localization.editRow,
+          ...this.props.localization.editRow,
+        }}
       />
     ));
   }
@@ -125,8 +166,10 @@ class MTableBody extends React.Component {
   render() {
     let renderData = this.props.renderData;
     const groups = this.props.columns
-      .filter(col => col.tableData.groupOrder > -1)
-      .sort((col1, col2) => col1.tableData.groupOrder - col2.tableData.groupOrder);
+      .filter((col) => col.tableData.groupOrder > -1)
+      .sort(
+        (col1, col2) => col1.tableData.groupOrder - col2.tableData.groupOrder
+      );
 
     let emptyRowCount = 0;
     if (this.props.options.paging) {
@@ -135,31 +178,75 @@ class MTableBody extends React.Component {
 
     return (
       <TableBody>
-        {this.props.options.filtering &&
+        {this.props.options.filtering && (
           <this.props.components.FilterRow
-            columns={this.props.columns.filter(columnDef => !columnDef.hidden)}
+            columns={this.props.columns.filter(
+              (columnDef) => !columnDef.hidden
+            )}
             icons={this.props.icons}
-            hasActions={this.props.actions.filter(a => a.position === "row" || typeof a === "function").length > 0}
+            hasActions={
+              this.props.actions.filter(
+                (a) => a.position === "row" || typeof a === "function"
+              ).length > 0
+            }
             actionsColumnIndex={this.props.options.actionsColumnIndex}
             onFilterChanged={this.props.onFilterChanged}
             selection={this.props.options.selection}
-            localization={{ ...MTableBody.defaultProps.localization.filterRow, ...this.props.localization.filterRow, dateTimePickerLocalization: this.props.localization.dateTimePickerLocalization }}
+            localization={{
+              ...MTableBody.defaultProps.localization.filterRow,
+              ...this.props.localization.filterRow,
+              dateTimePickerLocalization: this.props.localization
+                .dateTimePickerLocalization,
+            }}
             hasDetailPanel={!!this.props.detailPanel}
             isTreeData={this.props.isTreeData}
             filterCellStyle={this.props.options.filterCellStyle}
             hideFilterIcons={this.props.options.hideFilterIcons}
           />
-        }
+        )}
 
-        {this.props.showAddRow && this.props.options.addRowPosition === "first" &&
+        {this.props.showAddRow &&
+          this.props.options.addRowPosition === "first" && (
+            <this.props.components.EditRow
+              columns={this.props.columns.filter((columnDef) => {
+                return !columnDef.hidden;
+              })}
+              data={this.props.initialFormData}
+              components={this.props.components}
+              icons={this.props.icons}
+              key="key-add-row"
+              mode="add"
+              localization={{
+                ...MTableBody.defaultProps.localization.editRow,
+                ...this.props.localization.editRow,
+              }}
+              options={this.props.options}
+              isTreeData={this.props.isTreeData}
+              detailPanel={this.props.detailPanel}
+              onEditingCanceled={this.props.onEditingCanceled}
+              onEditingApproved={this.props.onEditingApproved}
+              getFieldValue={this.props.getFieldValue}
+            />
+          )}
+
+        {groups.length > 0
+          ? this.renderGroupedRows(groups, renderData)
+          : this.renderUngroupedRows(renderData)}
+
+        {this.props.showAddRow && this.props.options.addRowPosition === "last" && (
           <this.props.components.EditRow
-            columns={this.props.columns.filter(columnDef => { return !columnDef.hidden })}
+            columns={this.props.columns.filter((columnDef) => {
+              return !columnDef.hidden;
+            })}
             data={this.props.initialFormData}
             components={this.props.components}
             icons={this.props.icons}
             key="key-add-row"
             mode="add"
-            localization={{ ...MTableBody.defaultProps.localization.editRow, ...this.props.localization.editRow }}
+            localization={{
+              ...MTableBody.defaultProps.localization.editRow,
+              ...this.props.localization.editRow,
+            }}
             options={this.props.options}
             isTreeData={this.props.isTreeData}
             detailPanel={this.props.detailPanel}
@@ -167,30 +254,7 @@ class MTableBody extends React.Component {
             onEditingApproved={this.props.onEditingApproved}
             getFieldValue={this.props.getFieldValue}
           />
-        }
-
-        {groups.length > 0 ?
-          this.renderGroupedRows(groups, renderData) :
-          this.renderUngroupedRows(renderData)
-        }
-
-        {this.props.showAddRow && this.props.options.addRowPosition === "last" &&
-          <this.props.components.EditRow
-            columns={this.props.columns.filter(columnDef => { return !columnDef.hidden })}
-            data={this.props.initialFormData}
-            components={this.props.components}
-            icons={this.props.icons}
-            key="key-add-row"
-            mode="add"
-            localization={{ ...MTableBody.defaultProps.localization.editRow, ...this.props.localization.editRow }}
-            options={this.props.options}
-            isTreeData={this.props.isTreeData}
-            detailPanel={this.props.detailPanel}
-            onEditingCanceled={this.props.onEditingCanceled}
-            onEditingApproved={this.props.onEditingApproved}
-            getFieldValue={this.props.getFieldValue}
-          />
-        }
+        )}
         {this.renderEmpty(emptyRowCount, renderData)}
       </TableBody>
     );
@@ -204,10 +268,10 @@ MTableBody.defaultProps = {
   renderData: [],
   selection: false,
   localization: {
-    emptyDataSourceMessage: 'No records to display',
+    emptyDataSourceMessage: "No records to display",
     filterRow: {},
-    editRow: {}
-  }
+    editRow: {},
+  },
 };
 
 MTableBody.propTypes = {
@@ -215,7 +279,10 @@ MTableBody.propTypes = {
   components: PropTypes.object.isRequired,
   columns: PropTypes.array.isRequired,
   currentPage: PropTypes.number,
-  detailPanel: PropTypes.oneOfType([PropTypes.func, PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.object, PropTypes.func]))]),
+  detailPanel: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.object, PropTypes.func])),
+  ]),
   getFieldValue: PropTypes.func.isRequired,
   hasAnyEditingRow: PropTypes.bool,
   hasDetailPanel: PropTypes.bool.isRequired,

--- a/src/components/m-table-toolbar.js
+++ b/src/components/m-table-toolbar.js
@@ -312,6 +312,7 @@ MTableToolbar.propTypes = {
   exportButton: PropTypes.bool,
   exportDelimiter: PropTypes.string,
   exportFileName: PropTypes.string,
+  defaultExportCsv: PropTypes.func,
   exportCsv: PropTypes.func,
   classes: PropTypes.object,
 };

--- a/src/components/m-table-toolbar.js
+++ b/src/components/m-table-toolbar.js
@@ -1,20 +1,20 @@
 /* eslint-disable no-unused-vars */
-import Checkbox from '@material-ui/core/Checkbox';
-import FormControlLabel from '@material-ui/core/FormControlLabel';
-import IconButton from '@material-ui/core/IconButton';
-import InputAdornment from '@material-ui/core/InputAdornment';
-import Menu from '@material-ui/core/Menu';
-import MenuItem from '@material-ui/core/MenuItem';
-import TextField from '@material-ui/core/TextField';
-import Toolbar from '@material-ui/core/Toolbar';
-import Tooltip from '@material-ui/core/Tooltip';
-import Typography from '@material-ui/core/Typography';
-import withStyles from '@material-ui/core/styles/withStyles';
-import { lighten } from '@material-ui/core/styles/colorManipulator';
-import classNames from 'classnames';
-import { CsvBuilder } from 'filefy';
-import PropTypes, { oneOf } from 'prop-types';
-import * as React from 'react';
+import Checkbox from "@material-ui/core/Checkbox";
+import FormControlLabel from "@material-ui/core/FormControlLabel";
+import IconButton from "@material-ui/core/IconButton";
+import InputAdornment from "@material-ui/core/InputAdornment";
+import Menu from "@material-ui/core/Menu";
+import MenuItem from "@material-ui/core/MenuItem";
+import TextField from "@material-ui/core/TextField";
+import Toolbar from "@material-ui/core/Toolbar";
+import Tooltip from "@material-ui/core/Tooltip";
+import Typography from "@material-ui/core/Typography";
+import withStyles from "@material-ui/core/styles/withStyles";
+import { lighten } from "@material-ui/core/styles/colorManipulator";
+import classNames from "classnames";
+import { CsvBuilder } from "filefy";
+import PropTypes, { oneOf } from "prop-types";
+import * as React from "react";
 /* eslint-enable no-unused-vars */
 
 export class MTableToolbar extends React.Component {
@@ -22,49 +22,36 @@ export class MTableToolbar extends React.Component {
     super(props);
     this.state = {
       columnsButtonAnchorEl: null,
-      exportButtonAnchorEl: null
+      exportButtonAnchorEl: null,
     };
-  }
-
-  defaultExportCsv = () => {
-    const columns = this.props.columns
-      .filter(columnDef => {
-        return !columnDef.hidden && columnDef.field && columnDef.export !== false;
-      })
-      .sort((a, b) => (a.tableData.columnOrder > b.tableData.columnOrder) ? 1 : -1);
-    const dataToExport = this.props.exportAllData ? this.props.data : this.props.renderData;
-    const data = dataToExport.map(rowData =>
-      columns.map(columnDef => {
-        return this.props.getFieldValue(rowData, columnDef);
-      })
-    );
-
-    const builder = new CsvBuilder((this.props.exportFileName || this.props.title || 'data') + '.csv');
-    builder
-      .setDelimeter(this.props.exportDelimiter)
-      .setColumns(columns.map(columnDef => columnDef.title))
-      .addRows(data)
-      .exportFile();
   }
 
   exportCsv = () => {
     if (this.props.exportCsv) {
       this.props.exportCsv(this.props.columns, this.props.data);
     } else {
-      this.defaultExportCsv();
+      this.props.defaultExportCsv();
     }
     this.setState({ exportButtonAnchorEl: null });
-  }
+  };
 
   renderSearch() {
-    const localization = { ...MTableToolbar.defaultProps.localization, ...this.props.localization };
+    const localization = {
+      ...MTableToolbar.defaultProps.localization,
+      ...this.props.localization,
+    };
     if (this.props.search) {
       return (
         <TextField
-          className={this.props.searchFieldAlignment === 'left' && this.props.showTitle === false ? null : this.props.classes.searchField}
+          className={
+            this.props.searchFieldAlignment === "left" &&
+            this.props.showTitle === false
+              ? null
+              : this.props.classes.searchField
+          }
           value={this.props.searchText}
-          onChange={event => this.props.onSearchChanged(event.target.value)}
-          placeholder={localization.searchPlaceholder}          
+          onChange={(event) => this.props.onSearchChanged(event.target.value)}
+          placeholder={localization.searchPlaceholder}
           InputProps={{
             startAdornment: (
               <InputAdornment position="start">
@@ -79,75 +66,90 @@ export class MTableToolbar extends React.Component {
                   disabled={!this.props.searchText}
                   onClick={() => this.props.onSearchChanged("")}
                 >
-                  <this.props.icons.ResetSearch color="inherit" fontSize="small" />
+                  <this.props.icons.ResetSearch
+                    color="inherit"
+                    fontSize="small"
+                  />
                 </IconButton>
               </InputAdornment>
             ),
-            style: this.props.searchFieldStyle
+            style: this.props.searchFieldStyle,
           }}
         />
       );
-    }
-    else {
+    } else {
       return null;
     }
   }
 
   renderDefaultActions() {
-    const localization = { ...MTableToolbar.defaultProps.localization, ...this.props.localization };
-    const {classes} = this.props;
+    const localization = {
+      ...MTableToolbar.defaultProps.localization,
+      ...this.props.localization,
+    };
+    const { classes } = this.props;
 
     return (
       <div>
-        {this.props.columnsButton &&
+        {this.props.columnsButton && (
           <span>
             <Tooltip title={localization.showColumnsTitle}>
               <IconButton
                 color="inherit"
-                onClick={event => this.setState({ columnsButtonAnchorEl: event.currentTarget })}
-                aria-label={localization.showColumnsAriaLabel}>
-
+                onClick={(event) =>
+                  this.setState({ columnsButtonAnchorEl: event.currentTarget })
+                }
+                aria-label={localization.showColumnsAriaLabel}
+              >
                 <this.props.icons.ViewColumn />
               </IconButton>
             </Tooltip>
             <Menu
               anchorEl={this.state.columnsButtonAnchorEl}
               open={Boolean(this.state.columnsButtonAnchorEl)}
-              onClose={() => this.setState({ columnsButtonAnchorEl: null })}>
-              <MenuItem key={"text"} disabled style={{ opacity: 1, fontWeight: 600, fontSize: 12 }}>
+              onClose={() => this.setState({ columnsButtonAnchorEl: null })}
+            >
+              <MenuItem
+                key={"text"}
+                disabled
+                style={{ opacity: 1, fontWeight: 600, fontSize: 12 }}
+              >
                 {localization.addRemoveColumns}
               </MenuItem>
-              {
-                this.props.columns.map((col) => {
-                  return (
-                    <li key={col.tableData.id}>
-                      <MenuItem
-                        className={classes.formControlLabel}
-                        component="label"
-                        htmlFor={`column-toggle-${col.tableData.id}`}
-                        disabled={col.removable === false}
-                      >
-                        <Checkbox
-                          checked={!col.hidden}
-                          id={`column-toggle-${col.tableData.id}`}
-                          onChange={() => this.props.onColumnsChanged(col, !col.hidden)}
-                        />
-                        <span>{col.title}</span>
-                      </MenuItem>
-                    </li>
-                  );
-                })
-              }
+              {this.props.columns.map((col) => {
+                return (
+                  <li key={col.tableData.id}>
+                    <MenuItem
+                      className={classes.formControlLabel}
+                      component="label"
+                      htmlFor={`column-toggle-${col.tableData.id}`}
+                      disabled={col.removable === false}
+                    >
+                      <Checkbox
+                        checked={!col.hidden}
+                        id={`column-toggle-${col.tableData.id}`}
+                        onChange={() =>
+                          this.props.onColumnsChanged(col, !col.hidden)
+                        }
+                      />
+                      <span>{col.title}</span>
+                    </MenuItem>
+                  </li>
+                );
+              })}
             </Menu>
           </span>
-        }
-        {this.props.exportButton &&
+        )}
+        {this.props.exportButton && (
           <span>
             <Tooltip title={localization.exportTitle}>
               <IconButton
                 color="inherit"
-                onClick={event => this.setState({ exportButtonAnchorEl: event.currentTarget })}
-                aria-label={localization.exportAriaLabel}>
+                onClick={(event) =>
+                  this.setState({ exportButtonAnchorEl: event.currentTarget })
+                }
+                aria-label={localization.exportAriaLabel}
+              >
                 <this.props.icons.Export />
               </IconButton>
             </Tooltip>
@@ -161,10 +163,15 @@ export class MTableToolbar extends React.Component {
               </MenuItem>
             </Menu>
           </span>
-
-        }
+        )}
         <span>
-          <this.props.components.Actions actions={this.props.actions && this.props.actions.filter(a => a.position === "toolbar")} components={this.props.components} />
+          <this.props.components.Actions
+            actions={
+              this.props.actions &&
+              this.props.actions.filter((a) => a.position === "toolbar")
+            }
+            components={this.props.components}
+          />
         </span>
       </div>
     );
@@ -173,7 +180,13 @@ export class MTableToolbar extends React.Component {
   renderSelectedActions() {
     return (
       <React.Fragment>
-        <this.props.components.Actions actions={this.props.actions.filter(a => a.position === "toolbarOnSelect")} data={this.props.selectedRows} components={this.props.components} />
+        <this.props.components.Actions
+          actions={this.props.actions.filter(
+            (a) => a.position === "toolbarOnSelect"
+          )}
+          data={this.props.selectedRows}
+          components={this.props.components}
+        />
       </React.Fragment>
     );
   }
@@ -186,8 +199,7 @@ export class MTableToolbar extends React.Component {
         <div>
           {this.props.selectedRows && this.props.selectedRows.length > 0
             ? this.renderSelectedActions()
-            : this.renderDefaultActions()
-          }
+            : this.renderDefaultActions()}
         </div>
       </div>
     );
@@ -195,32 +207,58 @@ export class MTableToolbar extends React.Component {
 
   renderToolbarTitle(title) {
     const { classes } = this.props;
-    const toolBarTitle = (typeof title === 'string') ? <Typography variant='h6' style={{
-      whiteSpace: 'nowrap',
-      overflow: 'hidden',
-      textOverflow: 'ellipsis'
-    }}>{title}</Typography> : title;
+    const toolBarTitle =
+      typeof title === "string" ? (
+        <Typography
+          variant="h6"
+          style={{
+            whiteSpace: "nowrap",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+          }}
+        >
+          {title}
+        </Typography>
+      ) : (
+        title
+      );
 
-    return (
-      <div className={classes.title}>
-        {toolBarTitle}
-      </div>
-    );
+    return <div className={classes.title}>{toolBarTitle}</div>;
   }
 
   render() {
     const { classes } = this.props;
-    const localization = { ...MTableToolbar.defaultProps.localization, ...this.props.localization };
-    const title = this.props.showTextRowsSelected && this.props.selectedRows && this.props.selectedRows.length > 0 ? localization.nRowsSelected.replace('{0}', this.props.selectedRows.length) : this.props.showTitle ? this.props.title : null;
+    const localization = {
+      ...MTableToolbar.defaultProps.localization,
+      ...this.props.localization,
+    };
+    const title =
+      this.props.showTextRowsSelected &&
+      this.props.selectedRows &&
+      this.props.selectedRows.length > 0
+        ? localization.nRowsSelected.replace(
+            "{0}",
+            this.props.selectedRows.length
+          )
+        : this.props.showTitle
+        ? this.props.title
+        : null;
     return (
-      <Toolbar className={classNames(classes.root, { [classes.highlight]: this.props.showTextRowsSelected && this.props.selectedRows && this.props.selectedRows.length > 0 })}>
-        { title && this.renderToolbarTitle(title)}
-        {this.props.searchFieldAlignment === 'left' && this.renderSearch()}
-        {this.props.toolbarButtonAlignment === 'left' && this.renderActions()}
+      <Toolbar
+        className={classNames(classes.root, {
+          [classes.highlight]:
+            this.props.showTextRowsSelected &&
+            this.props.selectedRows &&
+            this.props.selectedRows.length > 0,
+        })}
+      >
+        {title && this.renderToolbarTitle(title)}
+        {this.props.searchFieldAlignment === "left" && this.renderSearch()}
+        {this.props.toolbarButtonAlignment === "left" && this.renderActions()}
         <div className={classes.spacer} />
-        {this.props.searchFieldAlignment === 'right' && this.renderSearch()}
-        {this.props.toolbarButtonAlignment === 'right' && this.renderActions()}
-      </Toolbar >
+        {this.props.searchFieldAlignment === "right" && this.renderSearch()}
+        {this.props.toolbarButtonAlignment === "right" && this.renderActions()}
+      </Toolbar>
     );
   }
 }
@@ -230,24 +268,24 @@ MTableToolbar.defaultProps = {
   columns: [],
   columnsButton: false,
   localization: {
-    addRemoveColumns: 'Add or remove columns',
-    nRowsSelected: '{0} row(s) selected',
-    showColumnsTitle: 'Show Columns',
-    showColumnsAriaLabel: 'Show Columns',
-    exportTitle: 'Export',
-    exportAriaLabel: 'Export',
-    exportName: 'Export as CSV',
-    searchTooltip: 'Search',
-    searchPlaceholder: 'Search'
+    addRemoveColumns: "Add or remove columns",
+    nRowsSelected: "{0} row(s) selected",
+    showColumnsTitle: "Show Columns",
+    showColumnsAriaLabel: "Show Columns",
+    exportTitle: "Export",
+    exportAriaLabel: "Export",
+    exportName: "Export as CSV",
+    searchTooltip: "Search",
+    searchPlaceholder: "Search",
   },
   search: true,
   showTitle: true,
   showTextRowsSelected: true,
-  toolbarButtonAlignment: 'right',
-  searchFieldAlignment: 'right',
-  searchText: '',
+  toolbarButtonAlignment: "right",
+  searchFieldAlignment: "right",
+  searchText: "",
   selectedRows: [],
-  title: 'No Title!'
+  title: "No Title!",
 };
 
 MTableToolbar.propTypes = {
@@ -275,40 +313,40 @@ MTableToolbar.propTypes = {
   exportDelimiter: PropTypes.string,
   exportFileName: PropTypes.string,
   exportCsv: PropTypes.func,
-  classes: PropTypes.object
+  classes: PropTypes.object,
 };
 
-export const styles = theme => ({
+export const styles = (theme) => ({
   root: {
-    paddingRight: theme.spacing(1)
+    paddingRight: theme.spacing(1),
   },
   highlight:
-    theme.palette.type === 'light'
+    theme.palette.type === "light"
       ? {
-        color: theme.palette.secondary.main,
-        backgroundColor: lighten(theme.palette.secondary.light, 0.85)
-      }
+          color: theme.palette.secondary.main,
+          backgroundColor: lighten(theme.palette.secondary.light, 0.85),
+        }
       : {
-        color: theme.palette.text.primary,
-        backgroundColor: theme.palette.secondary.dark
-      },
+          color: theme.palette.text.primary,
+          backgroundColor: theme.palette.secondary.dark,
+        },
   spacer: {
-    flex: '1 1 10%'
+    flex: "1 1 10%",
   },
   actions: {
     color: theme.palette.text.secondary,
   },
   title: {
-    overflow: 'hidden'
+    overflow: "hidden",
   },
   searchField: {
     minWidth: 150,
-    paddingLeft: theme.spacing(2)
+    paddingLeft: theme.spacing(2),
   },
   formControlLabel: {
     paddingLeft: theme.spacing(1),
     paddingRight: theme.spacing(1),
-  }
+  },
 });
 
 export default withStyles(styles)(MTableToolbar);

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -1,17 +1,17 @@
 /* eslint-disable no-unused-vars */
-import Table from '@material-ui/core/Table';
-import TableFooter from '@material-ui/core/TableFooter';
-import TableRow from '@material-ui/core/TableRow';
-import LinearProgress from '@material-ui/core/LinearProgress';
+import Table from "@material-ui/core/Table";
+import TableFooter from "@material-ui/core/TableFooter";
+import TableRow from "@material-ui/core/TableRow";
+import LinearProgress from "@material-ui/core/LinearProgress";
 import DoubleScrollbar from "react-double-scrollbar";
-import * as React from 'react';
-import { MTablePagination, MTableSteppedPagination } from './components';
-import { DragDropContext, Droppable } from 'react-beautiful-dnd';
-import DataManager from './utils/data-manager';
-import { debounce } from 'debounce';
-import equal from 'fast-deep-equal';
-import { withStyles } from '@material-ui/core';
-import * as CommonValues from './utils/common-values';
+import * as React from "react";
+import { MTablePagination, MTableSteppedPagination } from "./components";
+import { DragDropContext, Droppable } from "react-beautiful-dnd";
+import DataManager from "./utils/data-manager";
+import { debounce } from "debounce";
+import equal from "fast-deep-equal";
+import { withStyles } from "@material-ui/core";
+import * as CommonValues from "./utils/common-values";
 
 /* eslint-enable no-unused-vars */
 
@@ -30,41 +30,54 @@ export default class MaterialTable extends React.Component {
       ...renderState,
       query: {
         filters: renderState.columns
-          .filter(a => a.tableData.filterValue)
-          .map(a => ({
+          .filter((a) => a.tableData.filterValue)
+          .map((a) => ({
             column: a,
             operator: "=",
-            value: a.tableData.filterValue
+            value: a.tableData.filterValue,
           })),
-        orderBy: renderState.columns.find(a => a.tableData.id === renderState.orderBy),
+        orderBy: renderState.columns.find(
+          (a) => a.tableData.id === renderState.orderBy
+        ),
         orderDirection: renderState.orderDirection,
         page: 0,
         pageSize: calculatedProps.options.pageSize,
         search: renderState.searchText,
 
-        totalCount: 0
+        totalCount: 0,
       },
       showAddRow: false,
-      width: 0
+      width: 0,
     };
 
     this.tableContainerDiv = React.createRef();
   }
 
   componentDidMount() {
-    this.setState({ ...this.dataManager.getRenderState(), width: this.tableContainerDiv.current.scrollWidth }, () => {
-      if (this.isRemoteData()) {
-        this.onQueryChange(this.state.query);
+    this.setState(
+      {
+        ...this.dataManager.getRenderState(),
+        width: this.tableContainerDiv.current.scrollWidth,
+      },
+      () => {
+        if (this.isRemoteData()) {
+          this.onQueryChange(this.state.query);
+        }
       }
-    });
+    );
   }
 
   setDataManagerFields(props, isInit) {
     let defaultSortColumnIndex = -1;
-    let defaultSortDirection = '';
+    let defaultSortDirection = "";
     if (props && props.options.sorting !== false) {
-      defaultSortColumnIndex = props.columns.findIndex(a => a.defaultSort && a.sorting !== false);
-      defaultSortDirection = defaultSortColumnIndex > -1 ? props.columns[defaultSortColumnIndex].defaultSort : '';
+      defaultSortColumnIndex = props.columns.findIndex(
+        (a) => a.defaultSort && a.sorting !== false
+      );
+      defaultSortDirection =
+        defaultSortColumnIndex > -1
+          ? props.columns[defaultSortColumnIndex].defaultSort
+          : "";
     }
 
     this.dataManager.setColumns(props.columns);
@@ -73,27 +86,42 @@ export default class MaterialTable extends React.Component {
     if (this.isRemoteData(props)) {
       this.dataManager.changeApplySearch(false);
       this.dataManager.changeApplyFilters(false);
-    }
-    else {
+    } else {
       this.dataManager.changeApplySearch(true);
       this.dataManager.changeApplyFilters(true);
       this.dataManager.setData(props.data);
     }
 
-    isInit && this.dataManager.changeOrder(defaultSortColumnIndex, defaultSortDirection);
-    isInit && this.dataManager.changeSearchText(props.options.searchText || '');
-    isInit && this.dataManager.changeCurrentPage(props.options.initialPage ? props.options.initialPage : 0);
-    (isInit || this.isRemoteData()) && this.dataManager.changePageSize(props.options.pageSize);
+    isInit &&
+      this.dataManager.changeOrder(
+        defaultSortColumnIndex,
+        defaultSortDirection
+      );
+    isInit && this.dataManager.changeSearchText(props.options.searchText || "");
+    isInit &&
+      this.dataManager.changeCurrentPage(
+        props.options.initialPage ? props.options.initialPage : 0
+      );
+    (isInit || this.isRemoteData()) &&
+      this.dataManager.changePageSize(props.options.pageSize);
     this.dataManager.changePaging(props.options.paging);
     isInit && this.dataManager.changeParentFunc(props.parentChildData);
     this.dataManager.changeDetailPanelType(props.options.detailPanelType);
+
+    // ==== NOTE added these ===
+    this.dataManager.setExportDelimeter(props.exportDelimiter);
+    this.dataManager.setAllExportData(props.exportAllData);
+    this.dataManager.setExportFileName(
+      props.exportFileName || props.title || "data"
+    );
   }
 
   componentDidUpdate(prevProps) {
     // const propsChanged = Object.entries(this.props).reduce((didChange, prop) => didChange || prop[1] !== prevProps[prop[0]], false);
 
     let propsChanged = !equal(prevProps.columns, this.props.columns);
-    propsChanged = propsChanged || !equal(prevProps.options, this.props.options);
+    propsChanged =
+      propsChanged || !equal(prevProps.options, this.props.options);
     propsChanged = propsChanged || !equal(prevProps.data, this.props.data);
 
     if (propsChanged) {
@@ -102,9 +130,15 @@ export default class MaterialTable extends React.Component {
       this.setState(this.dataManager.getRenderState());
     }
 
-    const count = this.isRemoteData() ? this.state.query.totalCount : this.state.data.length;
-    const currentPage = this.isRemoteData() ? this.state.query.page : this.state.currentPage;
-    const pageSize = this.isRemoteData() ? this.state.query.pageSize : this.state.pageSize;
+    const count = this.isRemoteData()
+      ? this.state.query.totalCount
+      : this.state.data.length;
+    const currentPage = this.isRemoteData()
+      ? this.state.query.page
+      : this.state.currentPage;
+    const pageSize = this.isRemoteData()
+      ? this.state.query.pageSize
+      : this.state.pageSize;
 
     if (count <= pageSize * currentPage && currentPage !== 0) {
       this.onChangePage(null, Math.max(0, Math.ceil(count / pageSize) - 1));
@@ -113,42 +147,63 @@ export default class MaterialTable extends React.Component {
 
   getProps(props) {
     const calculatedProps = { ...(props || this.props) };
-    calculatedProps.components = { ...MaterialTable.defaultProps.components, ...calculatedProps.components };
-    calculatedProps.icons = { ...MaterialTable.defaultProps.icons, ...calculatedProps.icons };
-    calculatedProps.options = { ...MaterialTable.defaultProps.options, ...calculatedProps.options };
 
-    const localization = { ...MaterialTable.defaultProps.localization.body, ...calculatedProps.localization.body };
+    calculatedProps.components = {
+      ...MaterialTable.defaultProps.components,
+      ...calculatedProps.components,
+    };
+    calculatedProps.icons = {
+      ...MaterialTable.defaultProps.icons,
+      ...calculatedProps.icons,
+    };
+    calculatedProps.options = {
+      ...MaterialTable.defaultProps.options,
+      ...calculatedProps.options,
+    };
+
+    const localization = {
+      ...MaterialTable.defaultProps.localization.body,
+      ...calculatedProps.localization.body,
+    };
 
     calculatedProps.actions = [...(calculatedProps.actions || [])];
 
     if (calculatedProps.options.selection)
-      calculatedProps.actions = calculatedProps.actions.filter(a => a).map(action => {
-        if (
-          (action.position === "auto") ||
-          (action.isFreeAction === false) ||
-          (action.position === undefined && action.isFreeAction === undefined)
-        )
-          if (typeof action === "function") return { action: action, position: "toolbarOnSelect" };
-          else return { ...action, position: "toolbarOnSelect" };
-        else if (action.isFreeAction)
-          if (typeof action === "function") return { action: action, position: "toolbar" };
-          else return { ...action, position: "toolbar" };
-        else return action;
-      });
+      calculatedProps.actions = calculatedProps.actions
+        .filter((a) => a)
+        .map((action) => {
+          if (
+            action.position === "auto" ||
+            action.isFreeAction === false ||
+            (action.position === undefined && action.isFreeAction === undefined)
+          )
+            if (typeof action === "function")
+              return { action: action, position: "toolbarOnSelect" };
+            else return { ...action, position: "toolbarOnSelect" };
+          else if (action.isFreeAction)
+            if (typeof action === "function")
+              return { action: action, position: "toolbar" };
+            else return { ...action, position: "toolbar" };
+          else return action;
+        });
     else
-      calculatedProps.actions = calculatedProps.actions.filter(a => a).map(action => {
-        if (
-          (action.position === "auto") ||
-          (action.isFreeAction === false) ||
-          (action.position === undefined && action.isFreeAction === undefined)
-        )
-          if (typeof action === "function") return { action: action, position: "row" };
-          else return { ...action, position: "row" };
-        else if (action.isFreeAction)
-          if (typeof action === "function") return { action: action, position: "toolbar" };
-          else return { ...action, position: "toolbar" };
-        else return action;
-      });
+      calculatedProps.actions = calculatedProps.actions
+        .filter((a) => a)
+        .map((action) => {
+          if (
+            action.position === "auto" ||
+            action.isFreeAction === false ||
+            (action.position === undefined && action.isFreeAction === undefined)
+          )
+            if (typeof action === "function")
+              return { action: action, position: "row" };
+            else return { ...action, position: "row" };
+          else if (action.isFreeAction)
+            if (typeof action === "function")
+              return { action: action, position: "toolbar" };
+            else return { ...action, position: "toolbar" };
+          else return action;
+        });
 
     if (calculatedProps.editable) {
       if (calculatedProps.editable.onRowAdd) {
@@ -160,37 +215,41 @@ export default class MaterialTable extends React.Component {
             this.dataManager.changeRowEditing();
             this.setState({
               ...this.dataManager.getRenderState(),
-              showAddRow: !this.state.showAddRow
+              showAddRow: !this.state.showAddRow,
             });
-          }
+          },
         });
       }
       if (calculatedProps.editable.onRowUpdate) {
-        calculatedProps.actions.push(rowData => ({
+        calculatedProps.actions.push((rowData) => ({
           icon: calculatedProps.icons.Edit,
           tooltip: localization.editTooltip,
-          disabled: calculatedProps.editable.isEditable && !calculatedProps.editable.isEditable(rowData),
+          disabled:
+            calculatedProps.editable.isEditable &&
+            !calculatedProps.editable.isEditable(rowData),
           onClick: (e, rowData) => {
             this.dataManager.changeRowEditing(rowData, "update");
             this.setState({
               ...this.dataManager.getRenderState(),
-              showAddRow: false
+              showAddRow: false,
             });
-          }
+          },
         }));
       }
       if (calculatedProps.editable.onRowDelete) {
-        calculatedProps.actions.push(rowData => ({
+        calculatedProps.actions.push((rowData) => ({
           icon: calculatedProps.icons.Delete,
           tooltip: localization.deleteTooltip,
-          disabled: calculatedProps.editable.isDeletable && !calculatedProps.editable.isDeletable(rowData),
+          disabled:
+            calculatedProps.editable.isDeletable &&
+            !calculatedProps.editable.isDeletable(rowData),
           onClick: (e, rowData) => {
             this.dataManager.changeRowEditing(rowData, "delete");
             this.setState({
               ...this.dataManager.getRenderState(),
-              showAddRow: false
+              showAddRow: false,
             });
-          }
+          },
         }));
       }
     }
@@ -198,45 +257,53 @@ export default class MaterialTable extends React.Component {
     return calculatedProps;
   }
 
-  isRemoteData = (props) => !Array.isArray((props || this.props).data)
+  isRemoteData = (props) => !Array.isArray((props || this.props).data);
 
-  isOutsidePageNumbers = (props) => (props.page !== undefined && props.totalCount !== undefined);
+  isOutsidePageNumbers = (props) =>
+    props.page !== undefined && props.totalCount !== undefined;
 
   onAllSelected = (checked) => {
     this.dataManager.changeAllSelected(checked);
-    this.setState(this.dataManager.getRenderState(), () => this.onSelectionChange());
-  }
+    this.setState(this.dataManager.getRenderState(), () =>
+      this.onSelectionChange()
+    );
+  };
 
   onChangeColumnHidden = (column, hidden) => {
     this.dataManager.changeColumnHidden(column, hidden);
     this.setState(this.dataManager.getRenderState(), () => {
-      this.props.onChangeColumnHidden && this.props.onChangeColumnHidden(column, hidden);
+      this.props.onChangeColumnHidden &&
+        this.props.onChangeColumnHidden(column, hidden);
     });
-  }
+  };
 
   onChangeGroupOrder = (groupedColumn) => {
     this.dataManager.changeGroupOrder(groupedColumn.tableData.id);
     this.setState(this.dataManager.getRenderState());
-  }
+  };
 
   onChangeOrder = (orderBy, orderDirection) => {
-    const newOrderBy = orderDirection === '' ? -1 : orderBy;
+    const newOrderBy = orderDirection === "" ? -1 : orderBy;
     this.dataManager.changeOrder(newOrderBy, orderDirection);
 
     if (this.isRemoteData()) {
       const query = { ...this.state.query };
       query.page = 0;
-      query.orderBy = this.state.columns.find(a => a.tableData.id === newOrderBy);
+      query.orderBy = this.state.columns.find(
+        (a) => a.tableData.id === newOrderBy
+      );
       query.orderDirection = orderDirection;
       this.onQueryChange(query, () => {
-        this.props.onOrderChange && this.props.onOrderChange(newOrderBy, orderDirection);
+        this.props.onOrderChange &&
+          this.props.onOrderChange(newOrderBy, orderDirection);
       });
     } else {
       this.setState(this.dataManager.getRenderState(), () => {
-        this.props.onOrderChange && this.props.onOrderChange(newOrderBy, orderDirection);
+        this.props.onOrderChange &&
+          this.props.onOrderChange(newOrderBy, orderDirection);
       });
     }
-  }
+  };
 
   onChangePage = (event, page) => {
     if (this.isRemoteData()) {
@@ -245,8 +312,7 @@ export default class MaterialTable extends React.Component {
       this.onQueryChange(query, () => {
         this.props.onChangePage && this.props.onChangePage(page);
       });
-    }
-    else {
+    } else {
       if (!this.isOutsidePageNumbers(this.props)) {
         this.dataManager.changeCurrentPage(page);
       }
@@ -254,7 +320,7 @@ export default class MaterialTable extends React.Component {
         this.props.onChangePage && this.props.onChangePage(page);
       });
     }
-  }
+  };
 
   onChangeRowsPerPage = (event) => {
     const pageSize = event.target.value;
@@ -268,32 +334,39 @@ export default class MaterialTable extends React.Component {
       query.pageSize = event.target.value;
       query.page = 0;
       this.onQueryChange(query, () => {
-        this.props.onChangeRowsPerPage && this.props.onChangeRowsPerPage(pageSize);
+        this.props.onChangeRowsPerPage &&
+          this.props.onChangeRowsPerPage(pageSize);
       });
-    }
-    else {
+    } else {
       this.dataManager.changeCurrentPage(0);
       this.setState(this.dataManager.getRenderState(), () => {
-        this.props.onChangeRowsPerPage && this.props.onChangeRowsPerPage(pageSize);
+        this.props.onChangeRowsPerPage &&
+          this.props.onChangeRowsPerPage(pageSize);
       });
     }
-  }
+  };
 
-  onDragEnd = result => {
+  onDragEnd = (result) => {
     if (!result || !result.source || !result.destination) return;
     this.dataManager.changeByDrag(result);
     this.setState(this.dataManager.getRenderState(), () => {
-      if (this.props.onColumnDragged && result.destination.droppableId === "headers" &&
-        result.source.droppableId === "headers") {
-        this.props.onColumnDragged(result.source.index, result.destination.index);
+      if (
+        this.props.onColumnDragged &&
+        result.destination.droppableId === "headers" &&
+        result.source.droppableId === "headers"
+      ) {
+        this.props.onColumnDragged(
+          result.source.index,
+          result.destination.index
+        );
       }
     });
-  }
+  };
 
   onGroupExpandChanged = (path) => {
     this.dataManager.changeGroupExpand(path);
     this.setState(this.dataManager.getRenderState());
-  }
+  };
 
   onGroupRemoved = (groupedColumn, index) => {
     const result = {
@@ -303,80 +376,86 @@ export default class MaterialTable extends React.Component {
       mode: "FLUID",
       reason: "DROP",
       source: { index, droppableId: "groups" },
-      type: "DEFAULT"
+      type: "DEFAULT",
     };
     this.dataManager.changeByDrag(result);
     this.setState(this.dataManager.getRenderState(), () => {
-      this.props.onGroupRemoved && this.props.onGroupRemoved(groupedColumn, index);
+      this.props.onGroupRemoved &&
+        this.props.onGroupRemoved(groupedColumn, index);
     });
-  }
+  };
 
   onEditingApproved = (mode, newData, oldData) => {
     if (mode === "add") {
       this.setState({ isLoading: true }, () => {
-        this.props.editable.onRowAdd(newData)
-          .then(result => {
+        this.props.editable
+          .onRowAdd(newData)
+          .then((result) => {
             this.setState({ isLoading: false, showAddRow: false }, () => {
               if (this.isRemoteData()) {
                 this.onQueryChange(this.state.query);
               }
             });
           })
-          .catch(reason => {
+          .catch((reason) => {
             this.setState({ isLoading: false });
           });
       });
-    }
-    else if (mode === "update") {
+    } else if (mode === "update") {
       this.setState({ isLoading: true }, () => {
-        this.props.editable.onRowUpdate(newData, oldData)
-          .then(result => {
+        this.props.editable
+          .onRowUpdate(newData, oldData)
+          .then((result) => {
             this.dataManager.changeRowEditing(oldData);
-            this.setState({
-              isLoading: false,
-              ...this.dataManager.getRenderState()
-            }, () => {
-              if (this.isRemoteData()) {
-                this.onQueryChange(this.state.query);
+            this.setState(
+              {
+                isLoading: false,
+                ...this.dataManager.getRenderState(),
+              },
+              () => {
+                if (this.isRemoteData()) {
+                  this.onQueryChange(this.state.query);
+                }
               }
-            });
+            );
           })
-          .catch(reason => {
+          .catch((reason) => {
             this.setState({ isLoading: false });
           });
       });
-
-    }
-    else if (mode === "delete") {
+    } else if (mode === "delete") {
       this.setState({ isLoading: true }, () => {
-        this.props.editable.onRowDelete(oldData)
-          .then(result => {
+        this.props.editable
+          .onRowDelete(oldData)
+          .then((result) => {
             this.dataManager.changeRowEditing(oldData);
-            this.setState({
-              isLoading: false,
-              ...this.dataManager.getRenderState()
-            }, () => {
-              if (this.isRemoteData()) {
-                this.onQueryChange(this.state.query);
+            this.setState(
+              {
+                isLoading: false,
+                ...this.dataManager.getRenderState(),
+              },
+              () => {
+                if (this.isRemoteData()) {
+                  this.onQueryChange(this.state.query);
+                }
               }
-            });
+            );
           })
-          .catch(reason => {
+          .catch((reason) => {
             this.setState({ isLoading: false });
           });
       });
     }
-  }
+  };
 
   onEditingCanceled = (mode, rowData) => {
     if (mode === "add") {
       this.setState({ showAddRow: false });
-    }
-    else if (mode === "update" || mode === "delete") {
+    } else if (mode === "update" || mode === "delete") {
       this.dataManager.changeRowEditing(rowData);
       this.setState(this.dataManager.getRenderState());
     }
-  }
+  };
 
   onQueryChange = (query, callback) => {
     query = { ...this.state.query, ...query };
@@ -386,28 +465,33 @@ export default class MaterialTable extends React.Component {
         query.totalCount = result.totalCount;
         query.page = result.page;
         this.dataManager.setData(result.data);
-        this.setState({
-          isLoading: false,
-          ...this.dataManager.getRenderState(),
-          query
-        }, () => {
-          callback && callback();
-        });
+        this.setState(
+          {
+            isLoading: false,
+            ...this.dataManager.getRenderState(),
+            query,
+          },
+          () => {
+            callback && callback();
+          }
+        );
       });
     });
-  }
+  };
 
   onRowSelected = (event, path, dataClicked) => {
     this.dataManager.changeRowSelected(event.target.checked, path);
-    this.setState(this.dataManager.getRenderState(), () => this.onSelectionChange(dataClicked));
-  }
+    this.setState(this.dataManager.getRenderState(), () =>
+      this.onSelectionChange(dataClicked)
+    );
+  };
 
   onSelectionChange = (dataClicked) => {
     if (this.props.onSelectionChange) {
       const selectedRows = [];
 
-      const findSelecteds = list => {
-        list.forEach(row => {
+      const findSelecteds = (list) => {
+        list.forEach((row) => {
           if (row.tableData.checked) {
             selectedRows.push(row);
           }
@@ -419,12 +503,20 @@ export default class MaterialTable extends React.Component {
       findSelecteds(this.state.originalData);
       this.props.onSelectionChange(selectedRows, dataClicked);
     }
-  }
+  };
 
-  onSearchChange = searchText => {
+  onSearchChange = (searchText) => {
     this.dataManager.changeSearchText(searchText);
-    this.setState(({ searchText }), this.onSearchChangeDebounce());
-  }
+    this.setState({ searchText }, this.onSearchChangeDebounce());
+  };
+
+  onHandleExport = () => {
+    if (this.props.options.exportCsv) {
+      this.props.options.exportCsv(this.props.columns, this.props.data);
+    } else {
+      this.dataManager.handleCsvExport();
+    }
+  };
 
   onSearchChangeDebounce = debounce(() => {
     if (this.isRemoteData()) {
@@ -433,69 +525,75 @@ export default class MaterialTable extends React.Component {
       query.search = this.state.searchText;
 
       this.onQueryChange(query);
-    }
-    else {
+    } else {
       this.setState(this.dataManager.getRenderState(), () => {
-        this.props.onSearchChange && this.props.onSearchChange(this.state.searchText);
+        this.props.onSearchChange &&
+          this.props.onSearchChange(this.state.searchText);
       });
     }
-  }, this.props.options.debounceInterval)
+  }, this.props.options.debounceInterval);
 
   onFilterChange = (columnId, value) => {
     this.dataManager.changeFilterValue(columnId, value);
     this.setState({}, this.onFilterChangeDebounce);
-  }
+  };
 
   onFilterChangeDebounce = debounce(() => {
     if (this.isRemoteData()) {
       const query = { ...this.state.query };
       query.page = 0;
       query.filters = this.state.columns
-        .filter(a => a.tableData.filterValue)
-        .map(a => ({
+        .filter((a) => a.tableData.filterValue)
+        .map((a) => ({
           column: a,
           operator: "=",
-          value: a.tableData.filterValue
+          value: a.tableData.filterValue,
         }));
 
       this.onQueryChange(query);
-    }
-    else {
+    } else {
       this.setState(this.dataManager.getRenderState(), () => {
         if (this.props.onFilterChange) {
           const appliedFilters = this.state.columns
-            .filter(a => a.tableData.filterValue)
-            .map(a => ({
+            .filter((a) => a.tableData.filterValue)
+            .map((a) => ({
               column: a,
               operator: "=",
-              value: a.tableData.filterValue
+              value: a.tableData.filterValue,
             }));
           this.props.onFilterChange(appliedFilters);
         }
       });
     }
-  }, this.props.options.debounceInterval)
+  }, this.props.options.debounceInterval);
 
   onTreeExpandChanged = (path, data) => {
     this.dataManager.changeTreeExpand(path);
     this.setState(this.dataManager.getRenderState(), () => {
-      this.props.onTreeExpandChange && this.props.onTreeExpandChange(data, data.tableData.isTreeExpanded);
+      this.props.onTreeExpandChange &&
+        this.props.onTreeExpandChange(data, data.tableData.isTreeExpanded);
     });
-  }
+  };
 
   onToggleDetailPanel = (path, render) => {
     this.dataManager.changeDetailPanelVisibility(path, render);
     this.setState(this.dataManager.getRenderState());
-  }
+  };
 
   renderFooter() {
     const props = this.getProps();
     if (props.options.paging) {
-      const localization = { ...MaterialTable.defaultProps.localization.pagination, ...this.props.localization.pagination };
+      const localization = {
+        ...MaterialTable.defaultProps.localization.pagination,
+        ...this.props.localization.pagination,
+      };
 
       const isOutsidePageNumbers = this.isOutsidePageNumbers(props);
       const currentPage = isOutsidePageNumbers
-        ? Math.min(props.page, Math.floor(props.totalCount / this.state.pageSize))
+        ? Math.min(
+            props.page,
+            Math.floor(props.totalCount / this.state.pageSize)
+          )
         : this.state.currentPage;
       const totalCount = isOutsidePageNumbers
         ? props.totalCount
@@ -503,7 +601,7 @@ export default class MaterialTable extends React.Component {
 
       return (
         <Table>
-          <TableFooter style={{ display: 'grid' }}>
+          <TableFooter style={{ display: "grid" }}>
             <TableRow>
               <props.components.Pagination
                 classes={{
@@ -512,22 +610,54 @@ export default class MaterialTable extends React.Component {
                   caption: props.classes.paginationCaption,
                   selectRoot: props.classes.paginationSelectRoot,
                 }}
-                style={{ float: props.theme.direction === "rtl" ? "" : "right", overflowX: 'auto' }}
+                style={{
+                  float: props.theme.direction === "rtl" ? "" : "right",
+                  overflowX: "auto",
+                }}
                 colSpan={3}
-                count={this.isRemoteData() ? this.state.query.totalCount : totalCount}
+                count={
+                  this.isRemoteData() ? this.state.query.totalCount : totalCount
+                }
                 icons={props.icons}
                 rowsPerPage={this.state.pageSize}
                 rowsPerPageOptions={props.options.pageSizeOptions}
                 SelectProps={{
-                  renderValue: value => <div style={{ padding: '0px 5px' }}>{value + ' ' + localization.labelRowsSelect + ' '}</div>
+                  renderValue: (value) => (
+                    <div style={{ padding: "0px 5px" }}>
+                      {value + " " + localization.labelRowsSelect + " "}
+                    </div>
+                  ),
                 }}
                 page={this.isRemoteData() ? this.state.query.page : currentPage}
                 onChangePage={this.onChangePage}
                 onChangeRowsPerPage={this.onChangeRowsPerPage}
-                ActionsComponent={(subProps) => props.options.paginationType === 'normal' ?
-                  <MTablePagination {...subProps} icons={props.icons} localization={localization} showFirstLastPageButtons={props.options.showFirstLastPageButtons} /> :
-                  <MTableSteppedPagination {...subProps} icons={props.icons} localization={localization} showFirstLastPageButtons={props.options.showFirstLastPageButtons} />}
-                labelDisplayedRows={(row) => localization.labelDisplayedRows.replace('{from}', row.from).replace('{to}', row.to).replace('{count}', row.count)}
+                ActionsComponent={(subProps) =>
+                  props.options.paginationType === "normal" ? (
+                    <MTablePagination
+                      {...subProps}
+                      icons={props.icons}
+                      localization={localization}
+                      showFirstLastPageButtons={
+                        props.options.showFirstLastPageButtons
+                      }
+                    />
+                  ) : (
+                    <MTableSteppedPagination
+                      {...subProps}
+                      icons={props.icons}
+                      localization={localization}
+                      showFirstLastPageButtons={
+                        props.options.showFirstLastPageButtons
+                      }
+                    />
+                  )
+                }
+                labelDisplayedRows={(row) =>
+                  localization.labelDisplayedRows
+                    .replace("{from}", row.from)
+                    .replace("{to}", row.to)
+                    .replace("{count}", row.count)
+                }
                 labelRowsPerPage={localization.labelRowsPerPage}
               />
             </TableRow>
@@ -538,24 +668,44 @@ export default class MaterialTable extends React.Component {
   }
 
   renderTable = (props) => (
-    <Table style={{ tableLayout: (props.options.fixedColumns && (props.options.fixedColumns.left || props.options.fixedColumns.right)) ? 'fixed' : props.options.tableLayout }}>
-      {props.options.header &&
+    <Table
+      style={{
+        tableLayout:
+          props.options.fixedColumns &&
+          (props.options.fixedColumns.left || props.options.fixedColumns.right)
+            ? "fixed"
+            : props.options.tableLayout,
+      }}
+    >
+      {props.options.header && (
         <props.components.Header
           actions={props.actions}
-          localization={{ ...MaterialTable.defaultProps.localization.header, ...this.props.localization.header }}
+          localization={{
+            ...MaterialTable.defaultProps.localization.header,
+            ...this.props.localization.header,
+          }}
           columns={this.state.columns}
           hasSelection={props.options.selection}
           headerStyle={props.options.headerStyle}
           icons={props.icons}
           selectedCount={this.state.selectedCount}
           dataCount={
-            props.parentChildData ? this.state.treefiedDataLength : (
-              (this.state.columns.filter(col => col.tableData.groupOrder > -1).length > 0) ? this.state.groupedDataLength : this.state.data.length
-            )
+            props.parentChildData
+              ? this.state.treefiedDataLength
+              : this.state.columns.filter(
+                  (col) => col.tableData.groupOrder > -1
+                ).length > 0
+              ? this.state.groupedDataLength
+              : this.state.data.length
           }
           hasDetailPanel={!!props.detailPanel}
           detailPanelColumnAlignment={props.options.detailPanelColumnAlignment}
-          showActionsColumn={props.actions && props.actions.filter(a => a.position === "row" || typeof a === "function").length > 0}
+          showActionsColumn={
+            props.actions &&
+            props.actions.filter(
+              (a) => a.position === "row" || typeof a === "function"
+            ).length > 0
+          }
           showSelectAllCheckbox={props.options.showSelectAllCheckbox}
           orderBy={this.state.orderBy}
           orderDirection={this.state.orderDirection}
@@ -570,7 +720,7 @@ export default class MaterialTable extends React.Component {
           treeDataMaxLevel={this.state.treeDataMaxLevel}
           options={props.options}
         />
-      }
+      )}
       <props.components.Body
         actions={props.actions}
         components={props.components}
@@ -591,60 +741,82 @@ export default class MaterialTable extends React.Component {
         onTreeExpandChanged={this.onTreeExpandChanged}
         onEditingCanceled={this.onEditingCanceled}
         onEditingApproved={this.onEditingApproved}
-        localization={{ ...MaterialTable.defaultProps.localization.body, ...this.props.localization.body }}
+        localization={{
+          ...MaterialTable.defaultProps.localization.body,
+          ...this.props.localization.body,
+        }}
         onRowClick={this.props.onRowClick}
         showAddRow={this.state.showAddRow}
-        hasAnyEditingRow={!!(this.state.lastEditingRow || this.state.showAddRow)}
+        hasAnyEditingRow={
+          !!(this.state.lastEditingRow || this.state.showAddRow)
+        }
         hasDetailPanel={!!props.detailPanel}
         treeDataMaxLevel={this.state.treeDataMaxLevel}
       />
     </Table>
-  )
+  );
 
   getColumnsWidth = (props, count) => {
     let result = [];
 
     const actionsWidth = CommonValues.actionsColumnWidth(props);
     if (actionsWidth > 0) {
-      if (count > 0 && props.options.actionsColumnIndex >= 0 && props.options.actionsColumnIndex < count) {
+      if (
+        count > 0 &&
+        props.options.actionsColumnIndex >= 0 &&
+        props.options.actionsColumnIndex < count
+      ) {
         result.push(actionsWidth + "px");
-      }
-      else if (count < 0 && props.options.actionsColumnIndex < 0 && props.options.actionsColumnIndex >= count) {
+      } else if (
+        count < 0 &&
+        props.options.actionsColumnIndex < 0 &&
+        props.options.actionsColumnIndex >= count
+      ) {
         result.push(actionsWidth + "px");
       }
     }
 
     if (props.options.selection) {
-      const selectionWidth = CommonValues.selectionMaxWidth(props, this.state.treeDataMaxLevel);
+      const selectionWidth = CommonValues.selectionMaxWidth(
+        props,
+        this.state.treeDataMaxLevel
+      );
       result.push(selectionWidth + "px");
     }
 
     for (let i = 0; i < Math.abs(count) && i < props.columns.length; i++) {
       const colDef = props.columns[i > 0 ? i : props.columns.length - 1 - i];
-      if(colDef.tableData) {
+      if (colDef.tableData) {
         if (typeof colDef.tableData.width === "number") {
           result.push(colDef.tableData.width + "px");
-        }
-        else {
+        } else {
           result.push(colDef.tableData.width);
         }
       }
     }
 
-    return "calc(" + result.join(' + ') + ")";
-  }
+    return "calc(" + result.join(" + ") + ")";
+  };
 
   render() {
     const props = this.getProps();
 
     return (
       <DragDropContext onDragEnd={this.onDragEnd}>
-        <props.components.Container style={{ position: 'relative', ...props.style }}>
-          {props.options.toolbar &&
+        <props.components.Container
+          style={{ position: "relative", ...props.style }}
+        >
+          {props.options.toolbar && (
             <props.components.Toolbar
               actions={props.actions}
               components={props.components}
-              selectedRows={this.state.selectedCount > 0 ? this.state.originalData.filter(a => { return a.tableData.checked }) : []}
+              selectedRows={
+                this.state.selectedCount > 0
+                  ? this.state.originalData.filter((a) => {
+                      return a.tableData.checked;
+                    })
+                  : []
+              }
               columns={this.state.columns}
               columnsButton={props.options.columnsButton}
               icons={props.icons}
@@ -653,6 +825,7 @@ export default class MaterialTable extends React.Component {
               exportDelimiter={props.options.exportDelimiter}
               exportFileName={props.options.exportFileName}
               exportCsv={props.options.exportCsv}
+              defaultExportCsv={this.dataManager.handleCsvExport}
               getFieldValue={this.dataManager.getFieldValue}
               data={this.state.data}
               renderData={this.state.renderData}
@@ -666,71 +839,144 @@ export default class MaterialTable extends React.Component {
               title={props.title}
               onSearchChanged={this.onSearchChange}
               onColumnsChanged={this.onChangeColumnHidden}
-              localization={{ ...MaterialTable.defaultProps.localization.toolbar, ...this.props.localization.toolbar }}
+              localization={{
+                ...MaterialTable.defaultProps.localization.toolbar,
+                ...this.props.localization.toolbar,
+              }}
             />
-          }
-          {props.options.grouping &&
+          )}
+          {props.options.grouping && (
             <props.components.Groupbar
               icons={props.icons}
-              localization={{ ...MaterialTable.defaultProps.localization.grouping, ...props.localization.grouping }}
+              localization={{
+                ...MaterialTable.defaultProps.localization.grouping,
+                ...props.localization.grouping,
+              }}
               groupColumns={this.state.columns
-                .filter(col => col.tableData.groupOrder > -1)
-                .sort((col1, col2) => col1.tableData.groupOrder - col2.tableData.groupOrder)
-              }
+                .filter((col) => col.tableData.groupOrder > -1)
+                .sort(
+                  (col1, col2) =>
+                    col1.tableData.groupOrder - col2.tableData.groupOrder
+                )}
               onSortChanged={this.onChangeGroupOrder}
               onGroupRemoved={this.onGroupRemoved}
             />
-          }
+          )}
           <ScrollBar double={props.options.doubleHorizontalScroll}>
             <Droppable droppableId="headers" direction="horizontal">
               {(provided, snapshot) => {
                 const table = this.renderTable(props);
                 return (
                   <div ref={provided.innerRef}>
-                    <div ref={this.tableContainerDiv} style={{ maxHeight: props.options.maxBodyHeight, minHeight: props.options.minBodyHeight, overflowY: props.options.overflowY }}>
-
-                      {this.state.width && props.options.fixedColumns && props.options.fixedColumns.right ?
-                        <div style={{ width: this.getColumnsWidth(props, -1 * props.options.fixedColumns.right), position: 'absolute', top: 0, right: 0, boxShadow: '-2px 0px 15px rgba(125,147,178,.25)', overflowX: 'hidden', zIndex: 11 }}>
-                          <div style={{ width: this.state.width, background: 'white', transform: `translateX(calc(${this.getColumnsWidth(props, -1 * props.options.fixedColumns.right)} - 100%))` }}>
+                    <div
+                      ref={this.tableContainerDiv}
+                      style={{
+                        maxHeight: props.options.maxBodyHeight,
+                        minHeight: props.options.minBodyHeight,
+                        overflowY: props.options.overflowY,
+                      }}
+                    >
+                      {this.state.width &&
+                      props.options.fixedColumns &&
+                      props.options.fixedColumns.right ? (
+                        <div
+                          style={{
+                            width: this.getColumnsWidth(
+                              props,
+                              -1 * props.options.fixedColumns.right
+                            ),
+                            position: "absolute",
+                            top: 0,
+                            right: 0,
+                            boxShadow: "-2px 0px 15px rgba(125,147,178,.25)",
+                            overflowX: "hidden",
+                            zIndex: 11,
+                          }}
+                        >
+                          <div
+                            style={{
+                              width: this.state.width,
+                              background: "white",
+                              transform: `translateX(calc(${this.getColumnsWidth(
+                                props,
+                                -1 * props.options.fixedColumns.right
+                              )} - 100%))`,
+                            }}
+                          >
                             {table}
                           </div>
-                        </div> : null
-                      }
+                        </div>
+                      ) : null}
 
-                      <div  >
-                        {table}
-                      </div>
+                      <div>{table}</div>
 
-                      {this.state.width && props.options.fixedColumns && props.options.fixedColumns.left ?
-                        <div style={{ width: this.getColumnsWidth(props, props.options.fixedColumns.left), position: 'absolute', top: 0, left: 0, boxShadow: '2px 0px 15px rgba(125,147,178,.25)', overflowX: 'hidden', zIndex: 11 }}>
-                          <div style={{ width: this.state.width, background: 'white' }}>
+                      {this.state.width &&
+                      props.options.fixedColumns &&
+                      props.options.fixedColumns.left ? (
+                        <div
+                          style={{
+                            width: this.getColumnsWidth(
+                              props,
+                              props.options.fixedColumns.left
+                            ),
+                            position: "absolute",
+                            top: 0,
+                            left: 0,
+                            boxShadow: "2px 0px 15px rgba(125,147,178,.25)",
+                            overflowX: "hidden",
+                            zIndex: 11,
+                          }}
+                        >
+                          <div
+                            style={{
+                              width: this.state.width,
+                              background: "white",
+                            }}
+                          >
                             {table}
                           </div>
-                        </div> : null
-                      }
-
+                        </div>
+                      ) : null}
                     </div>
                     {provided.placeholder}
                   </div>
                 );
               }}
             </Droppable>
-
           </ScrollBar>
-          {(this.state.isLoading || props.isLoading) && props.options.loadingType === "linear" &&
-            <div style={{ position: 'relative', width: '100%' }}>
-              <div style={{ position: 'absolute', top: 0, left: 0, height: '100%', width: '100%' }}>
-                <LinearProgress />
+          {(this.state.isLoading || props.isLoading) &&
+            props.options.loadingType === "linear" && (
+              <div style={{ position: "relative", width: "100%" }}>
+                <div
+                  style={{
+                    position: "absolute",
+                    top: 0,
+                    left: 0,
+                    height: "100%",
+                    width: "100%",
+                  }}
+                >
+                  <LinearProgress />
+                </div>
               </div>
-            </div>
-          }
+            )}
           {this.renderFooter()}
 
-          {(this.state.isLoading || props.isLoading) && props.options.loadingType === 'overlay' &&
-            <div style={{ position: 'absolute', top: 0, left: 0, height: '100%', width: '100%', zIndex: 11 }}>
-              <props.components.OverlayLoading theme={props.theme} />
-            </div>
-          }
+          {(this.state.isLoading || props.isLoading) &&
+            props.options.loadingType === "overlay" && (
+              <div
+                style={{
+                  position: "absolute",
+                  top: 0,
+                  left: 0,
+                  height: "100%",
+                  width: "100%",
+                  zIndex: 11,
+                }}
+              >
+                <props.components.OverlayLoading theme={props.theme} />
+              </div>
+            )}
         </props.components.Container>
       </DragDropContext>
     );
@@ -739,32 +985,29 @@ export default class MaterialTable extends React.Component {
 
 var style = () => ({
   horizontalScrollContainer: {
-    '& ::-webkit-scrollbar': {
-      '-webkit-appearance': 'none'
+    "& ::-webkit-scrollbar": {
+      "-webkit-appearance": "none",
     },
-    '& ::-webkit-scrollbar:horizontal': {
-      height: 8
+    "& ::-webkit-scrollbar:horizontal": {
+      height: 8,
     },
-    '& ::-webkit-scrollbar-thumb': {
+    "& ::-webkit-scrollbar-thumb": {
       borderRadius: 4,
-      border: '2px solid white',
-      backgroundColor: 'rgba(0, 0, 0, .3)'
-    }
-  }
+      border: "2px solid white",
+      backgroundColor: "rgba(0, 0, 0, .3)",
+    },
+  },
 });
-
 
 const ScrollBar = withStyles(style)(({ double, children, classes }) => {
   if (double) {
+    return <DoubleScrollbar>{children}</DoubleScrollbar>;
+  } else {
     return (
-      <DoubleScrollbar>
-        {children}
-      </DoubleScrollbar>
-    );
-  }
-  else {
-    return (
-      <div className={classes.horizontalScrollContainer} style={{ overflowX: 'auto', position: 'relative' }}>
+      <div
+        className={classes.horizontalScrollContainer}
+        style={{ overflowX: "auto", position: "relative" }}
+      >
         {children}
       </div>
     );


### PR DESCRIPTION
## Related Issue
I needed to be able to use the export functionality outside of the toolbar, so I moved the handler for the csv into the data manager. For those looking to customise the export functionality (e.g not having it be tied to an icon) this will be useful.

## Description
To move the csv export functionality into the data manager, and then create a handler on the MaterialTable component. This means that the handler, and the functionality can be accessed through the Material Table ref. 

I've moved around various bits of code but the core addition is this to MaterialTable:

` onHandleExport = () => {
    if (this.props.options.exportCsv) {
      this.props.options.exportCsv(this.props.columns, this.props.data);
    } else {
      this.dataManager.handleCsvExport();
    }
  };`

I've also added a defaultExportCsv prop to the MTableToolbar, but the functionality is unchanged, it's just a refactor. 

I've also added setters and properties to the data manager so that it has information about the csv props.

## Impacted Areas in Application
The toolbar - but users won't notice. 


## Additional Notes
My auto formatter means that there's lots of red and green here, but the places to look at are:
- the data manager, in particular the new handleCsvMethod and the new properties.
- the toolbar component, to see how I've adapted it to use the data manager method.
- the Material Table component to see how the props to the toolbar have changed