### PR TITLE
Dense padding prop is applied to EditRow

### DIFF
--- a/src/components/m-table-edit-row.js
+++ b/src/components/m-table-edit-row.js
@@ -5,6 +5,7 @@ import Typography from '@material-ui/core/Typography';
 import PropTypes from 'prop-types';
 import * as React from 'react';
 import { byString, setByString } from '../utils';
+import * as CommonValues from "../utils/common-values";
 /* eslint-enable no-unused-vars */
 
 
@@ -24,8 +25,9 @@ export default class MTableEditRow extends React.Component {
       return prev;
     },{});
   }
-  
+
   renderColumns() {
+    const size = CommonValues.elementSize(this.props);
     const mapArr = this.props.columns.filter(columnDef => !columnDef.hidden && !(columnDef.tableData.groupOrder > -1))
       .sort((a, b) => a.tableData.columnOrder - b.tableData.columnOrder)
       .map((columnDef, index) => {
@@ -72,6 +74,7 @@ export default class MTableEditRow extends React.Component {
           const readonlyValue = this.props.getFieldValue(this.state.data, columnDef);
           return (
             <this.props.components.Cell
+              size={size}
               icons={this.props.icons}
               columnDef={columnDef}
               value={readonlyValue}
@@ -87,6 +90,7 @@ export default class MTableEditRow extends React.Component {
           
           return (
             <TableCell
+              size={size}
               key={columnDef.tableData.id}
               align={['numeric'].indexOf(columnDef.type) !== -1 ? "right" : "left"}
               style={getCellStyle(columnDef, value)}
@@ -115,6 +119,7 @@ export default class MTableEditRow extends React.Component {
   }
 
   renderActions() {
+    const size = CommonValues.elementSize(this.props);
     const localization = { ...MTableEditRow.defaultProps.localization, ...this.props.localization };
     const actions = [
       {
@@ -135,9 +140,9 @@ export default class MTableEditRow extends React.Component {
       }
     ];
     return (
-      <TableCell padding="none" key="key-actions-column" style={{ width: 42 * actions.length, padding: '0px 5px' }}>
+      <TableCell size={size} padding="none" key="key-actions-column" style={{ width: 42 * actions.length, padding: '0px 5px' }}>
         <div style={{ display: 'flex' }}>
-          <this.props.components.Actions data={this.props.data} actions={actions} components={this.props.components} />
+          <this.props.components.Actions data={this.props.data} actions={actions} components={this.props.components} size={size} />
         </div>
       </TableCell>
     );
@@ -153,6 +158,7 @@ export default class MTableEditRow extends React.Component {
   }
 
   render() {
+    const size = CommonValues.elementSize(this.props);
     const localization = { ...MTableEditRow.defaultProps.localization, ...this.props.localization };
     let columns;
     if (this.props.mode === "add" || this.props.mode === "update") {
@@ -162,6 +168,7 @@ export default class MTableEditRow extends React.Component {
       const colSpan = this.props.columns.filter(columnDef => !columnDef.hidden && !(columnDef.tableData.groupOrder > -1)).length;
       columns = [
         <TableCell
+          size={size}
           padding={this.props.options.actionsColumnIndex === 0 ? "none" : undefined}
           key="key-selection-cell"
           colSpan={colSpan}>


### PR DESCRIPTION
## Related Issue
#1908 

## Description
The paddingProp is also applied to the EditRow.

## Related PRs
-

## Impacted Areas in Application
List general components of the application that this PR will affect:
* m-table-edit-row.js

## Additional Notes
This makes sure that the table has the same look and feel even when you are editing or deleting rows. See screenshot from the change:
![editSmallExample](https://user-images.githubusercontent.com/24369528/81719578-87e55d00-947d-11ea-8261-728f1a45f882.PNG)
![deleteSmallExample](https://user-images.githubusercontent.com/24369528/81719589-8ae04d80-947d-11ea-804d-279388ffa281.PNG)
