### PR TITLE
add support for FilterRow styling to options

### DIFF
--- a/src/components/m-table-body.js
+++ b/src/components/m-table-body.js
@@ -147,6 +147,7 @@ class MTableBody extends React.Component {
             hasDetailPanel={!!this.props.detailPanel}
             isTreeData={this.props.isTreeData}
             filterCellStyle={this.props.options.filterCellStyle}
+            filterRowStyle={this.props.options.filterRowStyle}
             hideFilterIcons={this.props.options.hideFilterIcons}
           />
         }

--- a/src/components/m-table-filter-row.js
+++ b/src/components/m-table-filter-row.js
@@ -170,7 +170,7 @@ class MTableFilterRow extends React.Component {
     if (this.props.selection) {
       columns.splice(0, 0, <TableCell padding="none" key="key-selection-column" />);
     }
-    
+
     if (this.props.hasActions) {
       if (this.props.actionsColumnIndex === -1) {
         columns.push(<TableCell key="key-action-column" />);
@@ -203,7 +203,7 @@ class MTableFilterRow extends React.Component {
       });
 
     return (
-      <TableRow style={{ height: 10 }}>
+      <TableRow style={{ height: 10, ...this.props.filterRowStyle }}>
         {columns}
       </TableRow>
     );
@@ -226,6 +226,7 @@ MTableFilterRow.propTypes = {
   isTreeData: PropTypes.bool.isRequired,
   onFilterChanged: PropTypes.func.isRequired,
   filterCellStyle: PropTypes.object,
+  filterRowStyle: PropTypes.object,
   selection: PropTypes.bool.isRequired,
   actionsColumnIndex: PropTypes.number,
   hasActions: PropTypes.bool,

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -126,6 +126,7 @@ export const propTypes = {
     exportCsv: PropTypes.func,
     filtering: PropTypes.bool,
     filterCellStyle: PropTypes.object,
+    filterRowStyle: PropTypes.object,
     header: PropTypes.bool,
     headerStyle: PropTypes.object,
     hideFilterIcons: PropTypes.bool,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -31,8 +31,8 @@ export interface MaterialTableProps<RowData extends object> {
   onRowSelected?: (rowData: RowData) => void;
   onSearchChange?: (searchText: string) => void;
  /** An event fired when the table has finished filtering data
-  * @param {Filter<RowData>[]} filters All the filters that are applied to the table 
-  */ 
+  * @param {Filter<RowData>[]} filters All the filters that are applied to the table
+  */
   onFilterChange?: (filters: Filter<RowData>[]) => void;
   onSelectionChange?: (data: RowData[], rowData?: RowData) => void;
   onTreeExpandChange?: (data: any, isExpanded: boolean) => void;
@@ -206,6 +206,7 @@ export interface Options {
   exportCsv?: (columns: any[], renderData: any[]) => void;
   filtering?: boolean;
   filterCellStyle?: React.CSSProperties;
+  filterRowStyle?: React.CSSProperties;
   fixedColumns?: { left?: number; right?: number; };
   groupRowSeparator?: string;
   header?: boolean;


### PR DESCRIPTION
## Description
There exists support for filter cell styling via the `filterCellStyle` prop(s).  It would be useful to extend similar functionality to the FilterRow via a similar property in `options`, `filterRowStyle`.

## Impacted Areas in Application
List general components of the application that this PR will affect:

* FilterRow