### PR TITLE
Ensure path data is not processed multiple times

### DIFF
--- a/src/utils/data-manager.js
+++ b/src/utils/data-manager.js
@@ -701,7 +701,7 @@ export default class DataManager {
 
         addRow(parent);
 
-        rowData.tableData.path = [...parent.tableData.path, parent.tableData.childRows.length - 1];
+        if(!rowData.tableData.path) rowData.tableData.path = [...parent.tableData.path, parent.tableData.childRows.length - 1];
         this.treeDataMaxLevel = Math.max(this.treeDataMaxLevel, rowData.tableData.path.length);
       }
       else {


### PR DESCRIPTION
The function `addRow` calls itself to add the `dataRows` parent `addRow(parent)`. This causes a reprocessing of the parent row, depending on the order of the data data source. If the parent row now has another sibling its path will be updated with the wrong index due to `parent.tableData.childRows.length - 1`. 

The `addRow(parent)` line is needed to ensure that the parent rows `tableData` is configured. However, once configured it shouldn't need to be reprocessed and can be skipped.

I believe adding check before setting the path value will solve an issue I've seen when searching tree based data. The error occures in markForTreeRemove while it tries to walk the hierarchy using path. see issue #958

## Related Issue
#958 

## Description
Fix search feature when tree based data is used.

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
other_pr_production | [link]()
other_pr_master | [link]()

## Impacted Areas in Application
List general components of the application that this PR will affect:

*

## Additional Notes
This is optional, feel free to follow your hearth and write here :)