### PR TITLE
add capacity to style the detail panel column <td> via detailPanelColumnStyle prop

### DIFF
--- a/src/components/m-table-body-row.js
+++ b/src/components/m-table-body-row.js
@@ -85,7 +85,7 @@ export default class MTableBodyRow extends React.Component {
 
     if (typeof this.props.detailPanel == 'function') {
       return (
-        <TableCell size={size} padding="none" key="key-detail-panel-column" style={{ width: 42, textAlign: 'center' }}>
+        <TableCell size={size} padding="none" key="key-detail-panel-column" style={{ width: 42, textAlign: 'center', ...this.props.options.detailPanelColumnStyle }}>
           <IconButton
             size={size}
             style={{ transition: 'all ease 200ms', ...this.rotateIconStyle(this.props.data.tableData.showDetailPanel) }}
@@ -102,7 +102,7 @@ export default class MTableBodyRow extends React.Component {
     else {
       return (
         <TableCell size={size} padding="none" key="key-detail-panel-column">
-          <div style={{ width: 42 * this.props.detailPanel.length, textAlign: 'center', display: 'flex' }}>
+          <div style={{ width: 42 * this.props.detailPanel.length, textAlign: 'center', display: 'flex', ...this.props.options.detailPanelColumnStyle }}>
             {this.props.detailPanel.map((panel, index) => {
 
               if (typeof panel === "function") {

--- a/src/components/m-table-edit-row.js
+++ b/src/components/m-table-edit-row.js
@@ -135,7 +135,7 @@ export default class MTableEditRow extends React.Component {
       }
     ];
     return (
-      <TableCell padding="none" key="key-actions-column" style={{ width: 42 * actions.length, padding: '0px 5px' }}>
+      <TableCell padding="none" key="key-actions-column" style={{ width: 42 * actions.length, padding: '0px 5px', ...this.props.options.editCellStyle }}>
         <div style={{ display: 'flex' }}>
           <this.props.components.Actions data={this.props.data} actions={actions} components={this.props.components} />
         </div>

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -111,6 +111,7 @@ export const propTypes = {
   title: PropTypes.oneOfType([PropTypes.element, PropTypes.string]),
   options: PropTypes.shape({
     actionsCellStyle: PropTypes.object,
+    editCellStyle: PropTypes.object,
     actionsColumnIndex: PropTypes.number,
     addRowPosition: PropTypes.oneOf(['first', 'last']),
     columnsButton: PropTypes.bool,

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -112,6 +112,7 @@ export const propTypes = {
   options: PropTypes.shape({
     actionsCellStyle: PropTypes.object,
     editCellStyle: PropTypes.object,
+    detailPanelColumnStyle: PropTypes.object,
     actionsColumnIndex: PropTypes.number,
     addRowPosition: PropTypes.oneOf(['first', 'last']),
     columnsButton: PropTypes.bool,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -193,6 +193,7 @@ export interface Icons {
 
 export interface Options {
   actionsCellStyle?: React.CSSProperties;
+  detailPanelColumnStyle?: React.CSSProperties;
   editCellStyle?: React.CSSProperties;
   actionsColumnIndex?: number;
   addRowPosition?: ('first' | 'last');

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -193,6 +193,7 @@ export interface Icons {
 
 export interface Options {
   actionsCellStyle?: React.CSSProperties;
+  editCellStyle?: React.CSSProperties;
   actionsColumnIndex?: number;
   addRowPosition?: ('first' | 'last');
   columnsButton?: boolean;


### PR DESCRIPTION
### Related Issue
Related to #1956 

### Description
Add new option called `detailPanelColumnStyle`, working like `actionsCellStyle`

### Impacted Areas in Application
m-table-body-row.js

### Additional Notes
Thank you for this amazing library ❤️