### PR TITLE
Add align to tableCells from columnDef

### DIFF
--- a/src/components/m-table-cell.js
+++ b/src/components/m-table-cell.js
@@ -32,7 +32,7 @@ export default class MTableCell extends React.Component {
     } else if (this.props.columnDef.type === 'date') {
       if (this.props.value instanceof Date) {
         return this.props.value.toLocaleDateString();
-      } else if (isoDateRegex.exec(this.props.value)) {
+      } else if(isoDateRegex.exec(this.props.value)) {
         return new Date(this.props.value).toLocaleDateString();
       } else {
         return this.props.value;
@@ -45,7 +45,7 @@ export default class MTableCell extends React.Component {
       } else {
         return this.props.value;
       }
-    } else if(this.props.columnDef.type === 'datetime') {
+    } else if (this.props.columnDef.type === 'datetime') {
       if (this.props.value instanceof Date) {
         return this.props.value.toLocaleString();
       } else if(isoDateRegex.exec(this.props.value)) {

--- a/src/components/m-table-cell.js
+++ b/src/components/m-table-cell.js
@@ -40,15 +40,15 @@ export default class MTableCell extends React.Component {
     } else if (this.props.columnDef.type === 'time') {
       if (this.props.value instanceof Date) {
         return this.props.value.toLocaleTimeString();
-      } else if (isoDateRegex.exec(this.props.value)) {
+      } else if(isoDateRegex.exec(this.props.value)) {
         return new Date(this.props.value).toLocaleTimeString();
       } else {
         return this.props.value;
       }
-    } else if (this.props.columnDef.type === 'datetime') {
+    } else if(this.props.columnDef.type === 'datetime') {
       if (this.props.value instanceof Date) {
         return this.props.value.toLocaleString();
-      } else if (isoDateRegex.exec(this.props.value)) {
+      } else if(isoDateRegex.exec(this.props.value)) {
         return new Date(this.props.value).toLocaleString();
       } else {
         return this.props.value;
@@ -56,7 +56,7 @@ export default class MTableCell extends React.Component {
     } else if (this.props.columnDef.type === 'currency') {
       return this.getCurrencyValue(this.props.columnDef.currencySetting, this.props.value);
     }
-    else if (typeof this.props.value === "boolean") {
+    else if(typeof this.props.value === "boolean") {
       // To avoid forwardref boolean children. 
       return this.props.value.toString();
     }

--- a/src/components/m-table-cell.js
+++ b/src/components/m-table-cell.js
@@ -32,7 +32,7 @@ export default class MTableCell extends React.Component {
     } else if (this.props.columnDef.type === 'date') {
       if (this.props.value instanceof Date) {
         return this.props.value.toLocaleDateString();
-      } else if(isoDateRegex.exec(this.props.value)) {
+      } else if (isoDateRegex.exec(this.props.value)) {
         return new Date(this.props.value).toLocaleDateString();
       } else {
         return this.props.value;
@@ -40,7 +40,7 @@ export default class MTableCell extends React.Component {
     } else if (this.props.columnDef.type === 'time') {
       if (this.props.value instanceof Date) {
         return this.props.value.toLocaleTimeString();
-      } else if(isoDateRegex.exec(this.props.value)) {
+      } else if (isoDateRegex.exec(this.props.value)) {
         return new Date(this.props.value).toLocaleTimeString();
       } else {
         return this.props.value;
@@ -48,7 +48,7 @@ export default class MTableCell extends React.Component {
     } else if (this.props.columnDef.type === 'datetime') {
       if (this.props.value instanceof Date) {
         return this.props.value.toLocaleString();
-      } else if(isoDateRegex.exec(this.props.value)) {
+      } else if (isoDateRegex.exec(this.props.value)) {
         return new Date(this.props.value).toLocaleString();
       } else {
         return this.props.value;
@@ -56,7 +56,7 @@ export default class MTableCell extends React.Component {
     } else if (this.props.columnDef.type === 'currency') {
       return this.getCurrencyValue(this.props.columnDef.currencySetting, this.props.value);
     }
-    else if(typeof this.props.value === "boolean") {
+    else if (typeof this.props.value === "boolean") {
       // To avoid forwardref boolean children. 
       return this.props.value.toString();
     }
@@ -115,13 +115,13 @@ export default class MTableCell extends React.Component {
   render() {
 
     const { icons, columnDef, rowData, ...cellProps } = this.props;
-
+    const cellAlignment = columnDef.align !== undefined ? columnDef.align : ['numeric', 'currency'].indexOf(this.props.columnDef.type) !== -1 ? "right" : "left";
     return (
       <TableCell
         size={this.props.size}
         {...cellProps}
         style={this.getStyle()}
-        align={['numeric','currency'].indexOf(this.props.columnDef.type) !== -1 ? "right" : "left"}
+        align={cellAlignment}
         onClick={this.handleClickCell}
       >
         {this.props.children}

--- a/src/components/m-table-header.js
+++ b/src/components/m-table-header.js
@@ -71,11 +71,11 @@ export class MTableHeader extends React.Component {
         if (columnDef.tooltip) {
           content = <Tooltip title={columnDef.tooltip}><span>{content}</span></Tooltip>;
         }
-
+        const cellAlignment = columnDef.align !== undefined ? columnDef.align : ['numeric', 'currency'].indexOf(columnDef.type) !== -1 ? "right" : "left";
         return (
           <TableCell
             key={columnDef.tableData.id}
-            align={['numeric'].indexOf(columnDef.type) !== -1 ? "right" : "left"}
+            align={cellAlignment}
             className={this.props.classes.header}
             style={{ ...this.props.headerStyle, ...columnDef.headerStyle, boxSizing: 'border-box', width: columnDef.tableData.width }}
             size={size}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -105,6 +105,7 @@ export interface EditCellColumnDef {
 }
 
 export interface Column<RowData extends object> {
+  align?: 'center' |'inherit' | 'justify'|'left' |'right';
   cellStyle?: React.CSSProperties | ((data: RowData[], rowData: RowData) => React.CSSProperties);
   currencySetting?: { locale?: string, currencyCode?: string, minimumFractionDigits?: number, maximumFractionDigits?: number };
   customFilterAndSearch?: (filter: any, rowData: RowData, columnDef: Column<RowData>) => boolean;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -26,16 +26,16 @@ export interface MaterialTableProps<RowData extends object> {
   localization?: Localization;
   onChangeRowsPerPage?: (pageSize: number) => void;
   onChangePage?: (page: number) => void;
-  onChangeColumnHidden?: (column:Column<RowData>, hidden:boolean) => void;
+  onChangeColumnHidden?: (column: Column<RowData>, hidden: boolean) => void;
   onColumnDragged?: (sourceIndex: number, destinationIndex: number) => void;
   onOrderChange?: (orderBy: number, orderDirection: ("asc" | "desc")) => void;
-  onGroupRemoved?: (column:Column<RowData>, index:boolean) => void;
+  onGroupRemoved?: (column: Column<RowData>, index: boolean) => void;
   onRowClick?: (event?: React.MouseEvent, rowData?: RowData, toggleDetailPanel?: (panelIndex?: number) => void) => void;
   onRowSelected?: (rowData: RowData) => void;
   onSearchChange?: (searchText: string) => void;
- /** An event fired when the table has finished filtering data
-  * @param {Filter<RowData>[]} filters All the filters that are applied to the table
-  */
+  /** An event fired when the table has finished filtering data
+   * @param {Filter<RowData>[]} filters All the filters that are applied to the table
+   */
   onFilterChange?: (filters: Filter<RowData>[]) => void;
   onSelectionChange?: (data: RowData[], rowData?: RowData) => void;
   onTreeExpandChange?: (data: any, isExpanded: boolean) => void;
@@ -105,7 +105,7 @@ export interface EditCellColumnDef {
 }
 
 export interface Column<RowData extends object> {
-  align?: 'center' |'inherit' | 'justify'|'left' |'right';
+  align?: 'center' | 'inherit' | 'justify' | 'left' | 'right';
   cellStyle?: React.CSSProperties | ((data: RowData[], rowData: RowData) => React.CSSProperties);
   currencySetting?: { locale?: string, currencyCode?: string, minimumFractionDigits?: number, maximumFractionDigits?: number };
   customFilterAndSearch?: (filter: any, rowData: RowData, columnDef: Column<RowData>) => boolean;
@@ -120,7 +120,7 @@ export interface Column<RowData extends object> {
   export?: boolean;
   field?: keyof RowData | string;
   filtering?: boolean;
-  filterComponent?: ((props: {columnDef: Column<RowData>, onFilterChanged: (rowId: string, value: any) => void}) => React.ReactElement<any>);
+  filterComponent?: ((props: { columnDef: Column<RowData>, onFilterChanged: (rowId: string, value: any) => void }) => React.ReactElement<any>);
   filterPlaceholder?: string;
   filterCellStyle?: React.CSSProperties;
   grouping?: boolean;
@@ -299,4 +299,4 @@ export interface Localization {
   };
 }
 
-export default class MaterialTable<RowData extends object> extends React.Component<MaterialTableProps<RowData>> {}
+export default class MaterialTable<RowData extends object> extends React.Component<MaterialTableProps<RowData>> { }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -26,16 +26,16 @@ export interface MaterialTableProps<RowData extends object> {
   localization?: Localization;
   onChangeRowsPerPage?: (pageSize: number) => void;
   onChangePage?: (page: number) => void;
-  onChangeColumnHidden?: (column: Column<RowData>, hidden: boolean) => void;
+  onChangeColumnHidden?: (column:Column<RowData>, hidden:boolean) => void;
   onColumnDragged?: (sourceIndex: number, destinationIndex: number) => void;
   onOrderChange?: (orderBy: number, orderDirection: ("asc" | "desc")) => void;
-  onGroupRemoved?: (column: Column<RowData>, index: boolean) => void;
+  onGroupRemoved?: (column:Column<RowData>, index:boolean) => void;
   onRowClick?: (event?: React.MouseEvent, rowData?: RowData, toggleDetailPanel?: (panelIndex?: number) => void) => void;
   onRowSelected?: (rowData: RowData) => void;
   onSearchChange?: (searchText: string) => void;
-  /** An event fired when the table has finished filtering data
-   * @param {Filter<RowData>[]} filters All the filters that are applied to the table
-   */
+ /** An event fired when the table has finished filtering data
+  * @param {Filter<RowData>[]} filters All the filters that are applied to the table
+  */
   onFilterChange?: (filters: Filter<RowData>[]) => void;
   onSelectionChange?: (data: RowData[], rowData?: RowData) => void;
   onTreeExpandChange?: (data: any, isExpanded: boolean) => void;
@@ -120,7 +120,7 @@ export interface Column<RowData extends object> {
   export?: boolean;
   field?: keyof RowData | string;
   filtering?: boolean;
-  filterComponent?: ((props: { columnDef: Column<RowData>, onFilterChanged: (rowId: string, value: any) => void }) => React.ReactElement<any>);
+  filterComponent?: ((props: {columnDef: Column<RowData>, onFilterChanged: (rowId: string, value: any) => void}) => React.ReactElement<any>);
   filterPlaceholder?: string;
   filterCellStyle?: React.CSSProperties;
   grouping?: boolean;
@@ -299,4 +299,4 @@ export interface Localization {
   };
 }
 
-export default class MaterialTable<RowData extends object> extends React.Component<MaterialTableProps<RowData>> { }
+export default class MaterialTable<RowData extends object> extends React.Component<MaterialTableProps<RowData>> {}


### PR DESCRIPTION
## Related Issue
#736 

## Description
This enables the override of the cell align to match the available [props from material-ui](https://material-ui.com/api/table-cell/#props).
By adding `align` to the column def, it will be passed down to the header and the cells for that column. It will override the default align which is either left or right for numeric values.
If not provided, the previous used alignment strategy will be the fallback.
The types are updated as well with all possible options:
`'center' |'inherit' | 'justify'|'left' |'right';`

## Impacted Areas in Application
List general components of the application that this PR will affect:

* types
* TableHeader
* TableCell