### PR TITLE
Add align to tableCells from columnDef

### DIFF
--- a/src/components/m-table-cell.js
+++ b/src/components/m-table-cell.js
@@ -115,13 +115,13 @@ export default class MTableCell extends React.Component {
   render() {
 
     const { icons, columnDef, rowData, ...cellProps } = this.props;
-
+    const cellAlignment = columnDef.align !== undefined ? columnDef.align : ['numeric', 'currency'].indexOf(this.props.columnDef.type) !== -1 ? "right" : "left";
     return (
       <TableCell
         size={this.props.size}
         {...cellProps}
         style={this.getStyle()}
-        align={['numeric','currency'].indexOf(this.props.columnDef.type) !== -1 ? "right" : "left"}
+        align={cellAlignment}
         onClick={this.handleClickCell}
       >
         {this.props.children}

--- a/src/components/m-table-header.js
+++ b/src/components/m-table-header.js
@@ -71,11 +71,11 @@ export class MTableHeader extends React.Component {
         if (columnDef.tooltip) {
           content = <Tooltip title={columnDef.tooltip}><span>{content}</span></Tooltip>;
         }
-
+        const cellAlignment = columnDef.align !== undefined ? columnDef.align : ['numeric', 'currency'].indexOf(columnDef.type) !== -1 ? "right" : "left";
         return (
           <TableCell
             key={columnDef.tableData.id}
-            align={['numeric'].indexOf(columnDef.type) !== -1 ? "right" : "left"}
+            align={cellAlignment}
             className={this.props.classes.header}
             style={{ ...this.props.headerStyle, ...columnDef.headerStyle, boxSizing: 'border-box', width: columnDef.tableData.width }}
             size={size}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -105,6 +105,7 @@ export interface EditCellColumnDef {
 }
 
 export interface Column<RowData extends object> {
+  align?: 'center' | 'inherit' | 'justify' | 'left' | 'right';
   cellStyle?: React.CSSProperties | ((data: RowData[], rowData: RowData) => React.CSSProperties);
   currencySetting?: { locale?: string, currencyCode?: string, minimumFractionDigits?: number, maximumFractionDigits?: number };
   customFilterAndSearch?: (filter: any, rowData: RowData, columnDef: Column<RowData>) => boolean;


### PR DESCRIPTION
## Related Issue
#736 

## Description
This enables the override of the cell align to match the available [props from material-ui](https://material-ui.com/api/table-cell/#props).
By adding `align` to the column def, it will be passed down to the header and the cells for that column. It will override the default align which is either left or right for numeric values.
If not provided, the previous used alignment strategy will be the fallback.
The types are updated as well with all possible options:
`'center' |'inherit' | 'justify'|'left' |'right';`

## Impacted Areas in Application
List general components of the application that this PR will affect:

* types
* TableHeader
* TableCell