### PR TITLE
Trigger reorder if column default sort changed

### DIFF
--- a/src/material-table.js
+++ b/src/material-table.js
@@ -84,7 +84,7 @@ export default class MaterialTable extends React.Component {
     }
 
     // If the columns changed and the defaultSorting differs from the current sorting, it will trigger a new sorting
-    const shouldReorder = (isInit || (defaultSortColumnIndex !== this.dataManager.orderBy && defaultSortDirection !== this.dataManager.orderDirection))
+    const shouldReorder = (isInit || (defaultSortColumnIndex !== this.dataManager.orderBy && defaultSortDirection !== this.dataManager.orderDirection));
     shouldReorder && this.dataManager.changeOrder(defaultSortColumnIndex, defaultSortDirection);
     isInit && this.dataManager.changeSearchText(props.options.searchText || '');
     isInit && this.dataManager.changeCurrentPage(props.options.initialPage ? props.options.initialPage : 0);

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -83,7 +83,9 @@ export default class MaterialTable extends React.Component {
       this.dataManager.setData(props.data);
     }
 
-    isInit && this.dataManager.changeOrder(defaultSortColumnIndex, defaultSortDirection);
+    // If the columns changed and the defaultSorting differs from the current sorting, it will trigger a new sorting
+    const shouldReorder = (isInit || (defaultSortColumnIndex !== this.dataManager.orderBy && defaultSortDirection !== this.dataManager.orderDirection))
+    shouldReorder && this.dataManager.changeOrder(defaultSortColumnIndex, defaultSortDirection);
     isInit && this.dataManager.changeSearchText(props.options.searchText || '');
     isInit && this.dataManager.changeCurrentPage(props.options.initialPage ? props.options.initialPage : 0);
     (isInit || this.isRemoteData()) && this.dataManager.changePageSize(props.options.pageSize);


### PR DESCRIPTION
## Related Issue
#1868

## Description
This PR fixes #1868 by reordering the columns, if the default column sorting changes and the current sorting differs from that.

This fixes a bug, where the sorting of defaultSort columns is skipped, if the columns are initialized after the table is rendered, for example in a useEffect callback.

For details, see the attached issue.

This also allows the user to trigger a sort by changing the column object programmatically for example on a button click.


## Impacted Areas in Application
List general components of the application that this PR will affect:

* Material Table => setDataManagerFields
