### PR TITLE
Added hideSortIcon true to TableSortLabel for actions

### DIFF
--- a/src/components/m-table-header.js
+++ b/src/components/m-table-header.js
@@ -99,7 +99,7 @@ export class MTableHeader extends React.Component {
         className={this.props.classes.header}
         style={{ ...this.props.headerStyle, width: width, textAlign: 'center', boxSizing: 'border-box' }}
       >
-        <TableSortLabel disabled>{localization.actions}</TableSortLabel>
+        <TableSortLabel hideSortIcon={true} disabled>{localization.actions}</TableSortLabel>
       </TableCell>
     );
   }


### PR DESCRIPTION
## Description
This adds hideSortLabel to TableSortLabel used in the actions header. From what i can see it's never being used, and it takes up a lot of space.

## Impacted Areas in Application
List general components of the application that this PR will affect:
MTableHeader