### PR TITLE
Added CSS font properties to inherit in cellStyle

### DIFF
--- a/src/components/m-table-cell.js
+++ b/src/components/m-table-cell.js
@@ -96,7 +96,10 @@ export default class MTableCell extends React.Component {
     let cellStyle = {
       color: 'inherit',
       width: this.props.columnDef.tableData.width,
-      boxSizing: 'border-box'
+      boxSizing: 'border-box',
+      fontSize: "inherit",
+      fontFamily: "inherit",
+      fontWeight: "inherit",
     };
 
     if (typeof this.props.columnDef.cellStyle === 'function') {


### PR DESCRIPTION
## Related Issue
#1830 

## Description
When rowStyle option contains `fontSize`, `fontFamily` or `fontWeight`, the table cell does not take those styles.

To achieve that, the cellStyles have those properties with `inherit` value.

## Impacted Areas in Application
List general components of the application that this PR will affect:

* TableCell