### PR TITLE
Fix initialPage value not being applied when using a remote data sour…

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -1,9 +1,13 @@
 import { Grid, MuiThemeProvider, Button } from '@material-ui/core';
 import { createMuiTheme } from '@material-ui/core/styles';
+import ExpansionPanel from '@material-ui/core/ExpansionPanel';
+import ExpansionPanelSummary from '@material-ui/core/ExpansionPanelSummary';
+import ExpansionPanelDetails from '@material-ui/core/ExpansionPanelDetails';
+import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+import Typography from '@material-ui/core/Typography';
 import React, { Component } from 'react';
 import ReactDOM from 'react-dom';
 import MaterialTable from '../src';
-import Typography from "@material-ui/core/Typography";
 
 let direction = 'ltr';
 // direction = 'rtl';
@@ -96,121 +100,149 @@ class App extends Component {
       <>
         <MuiThemeProvider theme={theme}>
           <div style={{ maxWidth: '100%', direction }}>
-            <Grid container>
-              <Grid item xs={12}>
-                {this.state.selectedRows && this.state.selectedRows.length}
+          { 
+            // expansion panels with unmountonExit make it easy to test componentDidMount logic
+          }
+          <ExpansionPanel TransitionProps={{ unmountOnExit: true }}>
+            <ExpansionPanelSummary
+              aria-controls="local-data-demo"
+              id="local-data-demo"
+              expandIcon={<ExpandMoreIcon />}
+            >
+              <Typography>Local Data Demo</Typography>
+            </ExpansionPanelSummary>
+            <ExpansionPanelDetails>
+              <Grid container>
+                <Grid item xs={12}>
+                  {this.state.selectedRows && this.state.selectedRows.length}
+                  <MaterialTable
+                    tableRef={this.tableRef}
+                    columns={this.state.columns}
+                    data={this.state.data}
+                    title="Demo Title"
+                    options={{
+                      pageSize: 50,
+                      pageSizeOptions: [5, 50, 100]
+                    }}
+                    editable={{
+                      onRowAdd: newData =>
+                        new Promise((resolve, reject) => {
+                          setTimeout(() => {
+                            {
+                              /* const data = this.state.data;
+                              data.push(newData);
+                              this.setState({ data }, () => resolve()); */
+                            }
+                            resolve();
+                          }, 1000);
+                        }),
+                      onRowUpdate: (newData, oldData) =>
+                        new Promise((resolve, reject) => {
+                          setTimeout(() => {
+                            {
+                              /* const data = this.state.data;
+                              const index = data.indexOf(oldData);
+                              data[index] = newData;                
+                              this.setState({ data }, () => resolve()); */
+                            }
+                            resolve();
+                          }, 1000);
+                        }),
+                      onRowDelete: oldData =>
+                        new Promise((resolve, reject) => {
+                          setTimeout(() => {
+                            {
+                              /* let data = this.state.data;
+                              const index = data.indexOf(oldData);
+                              data.splice(index, 1);
+                              this.setState({ data }, () => resolve()); */
+                            }
+                            resolve();
+                          }, 1000);
+                        })
+                    }}
+                    localization={{
+                      body: {
+                        emptyDataSourceMessage: 'No records to display',
+                        filterRow: {
+                          filterTooltip: 'Filter',
+                          filterPlaceHolder: "Filtaaer"
+                        }
+                      }
+                    }}
+                    onSearchChange={(e) => console.log("search changed: " + e)}
+                    onColumnDragged={(oldPos, newPos) => console.log("Dropped column from " + oldPos + " to position " + newPos)}
+                  // parentChildData={(row, rows) => rows.find(a => a.id === row.parentId)}
+                  />
+                </Grid>
+              </Grid>
+            </ExpansionPanelDetails>
+          </ExpansionPanel>
+          <ExpansionPanel TransitionProps={{ unmountOnExit: true }}>
+            <ExpansionPanelSummary
+              aria-controls="remote-data-demo"
+              id="remote-data-demo"
+              expandIcon={<ExpandMoreIcon />}
+            >
+              <Typography>Remote Data Demo</Typography>
+            </ExpansionPanelSummary>
+            <ExpansionPanelDetails>
+              <div>
+                {this.state.text}
+                <button onClick={() => this.tableRef.current.onAllSelected(true)} style={{ margin: 10 }}>
+                  Select
+                </button>
                 <MaterialTable
-                  tableRef={this.tableRef}
-                  columns={this.state.columns}
-                  data={this.state.data}
-                  title="Demo Title"
+                  title={
+                    <Typography variant='h6' color='primary'>Remote Data Preview</Typography>
+                  }
+                  columns={[
+                    {
+                      title: 'Avatar',
+                      field: 'avatar',
+                      render: rowData => (
+                        <img
+                          style={{ height: 36, borderRadius: '50%' }}
+                          src={rowData.avatar}
+                        />
+                      ),
+                    },
+                    { title: 'Id', field: 'id', filterPlaceholder: 'placeholder',
+                      lookup: {1: '1', 2: '2', 3: '3', 4: '4', 5: '5', 6: '6', 7: '7', 8: '8', 9: '9', 10: '10', 11: '11', 12: '12'}},
+                    { title: 'First Name', field: 'first_name' },
+                    { title: 'Last Name', field: 'last_name' },
+                  ]}
                   options={{
-                    pageSize: 50,
-                    pageSizeOptions: [5, 50, 100]
-                  }}
-                  editable={{
-                    onRowAdd: newData =>
-                      new Promise((resolve, reject) => {
-                        setTimeout(() => {
-                          {
-                            /* const data = this.state.data;
-                            data.push(newData);
-                            this.setState({ data }, () => resolve()); */
-                          }
-                          resolve();
-                        }, 1000);
-                      }),
-                    onRowUpdate: (newData, oldData) =>
-                      new Promise((resolve, reject) => {
-                        setTimeout(() => {
-                          {
-                            /* const data = this.state.data;
-                            const index = data.indexOf(oldData);
-                            data[index] = newData;                
-                            this.setState({ data }, () => resolve()); */
-                          }
-                          resolve();
-                        }, 1000);
-                      }),
-                    onRowDelete: oldData =>
-                      new Promise((resolve, reject) => {
-                        setTimeout(() => {
-                          {
-                            /* let data = this.state.data;
-                            const index = data.indexOf(oldData);
-                            data.splice(index, 1);
-                            this.setState({ data }, () => resolve()); */
-                          }
-                          resolve();
-                        }, 1000);
-                      })
+                    initialPage: 2,
+                    filtering: true,
+                    grouping: true,
+                    groupTitle: group => group.data.length,
+                    searchFieldVariant: 'outlined',
                   }}
                   localization={{
-                    body: {
-                      emptyDataSourceMessage: 'No records to display',
-                      filterRow: {
-                        filterTooltip: 'Filter',
-                        filterPlaceHolder: "Filtaaer"
-                      }
+                    toolbar: {
+                      searchPlaceholder: "Outlined Search Field",
                     }
                   }}
-                  onSearchChange={(e) => console.log("search changed: " + e)}
-                  onColumnDragged={(oldPos, newPos) => console.log("Dropped column from " + oldPos + " to position " + newPos)}
-                // parentChildData={(row, rows) => rows.find(a => a.id === row.parentId)}
+                  data={query => new Promise((resolve, reject) => {
+                    let url = 'https://reqres.in/api/users?'
+                    url += 'per_page=' + query.pageSize
+                    url += '&page=' + (query.page + 1)
+                    console.log(query);
+                    fetch(url)
+                      .then(response => response.json())
+                      .then(result => {
+                        resolve({
+                          data: result.data,
+                          page: result.page - 1,
+                          totalCount: result.total,
+                        })
+                      })
+                  })}
                 />
-              </Grid>
-            </Grid>
-            {this.state.text}
-            <button onClick={() => this.tableRef.current.onAllSelected(true)} style={{ margin: 10 }}>
-              Select
-            </button>
-            <MaterialTable
-              title={
-                <Typography variant='h6' color='primary'>Remote Data Preview</Typography>
-              }
-              columns={[
-                {
-                  title: 'Avatar',
-                  field: 'avatar',
-                  render: rowData => (
-                    <img
-                      style={{ height: 36, borderRadius: '50%' }}
-                      src={rowData.avatar}
-                    />
-                  ),
-                },
-                { title: 'Id', field: 'id', filterPlaceholder: 'placeholder',
-                  lookup: {1: '1', 2: '2', 3: '3', 4: '4', 5: '5', 6: '6', 7: '7', 8: '8', 9: '9', 10: '10', 11: '11', 12: '12'}},
-                { title: 'First Name', field: 'first_name' },
-                { title: 'Last Name', field: 'last_name' },
-              ]}
-              options={{
-                filtering: true,
-                grouping: true,
-                groupTitle: group => group.data.length,
-                searchFieldVariant: 'outlined',
-              }}
-              localization={{
-                toolbar: {
-                  searchPlaceholder: "Outlined Search Field",
-                }
-              }}
-              data={query => new Promise((resolve, reject) => {
-                let url = 'https://reqres.in/api/users?'
-                url += 'per_page=' + query.pageSize
-                url += '&page=' + (query.page + 1)
-                console.log(query);
-                fetch(url)
-                  .then(response => response.json())
-                  .then(result => {
-                    resolve({
-                      data: result.data,
-                      page: result.page - 1,
-                      totalCount: result.total,
-                    })
-                  })
-              })}
-            />
+              </div>  
+              </ExpansionPanelDetails>
+            </ExpansionPanel>
 
           </div>
         </MuiThemeProvider>

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@babel/preset-env": "^7.2.0",
     "@babel/preset-react": "7.0.0",
     "@material-ui/core": "^4.0.1",
+    "@material-ui/icons": "^4.9.1",
     "babel-eslint": "10.0.1",
     "babel-loader": "^8.0.4",
     "babel-polyfill": "^6.26.0",


### PR DESCRIPTION
…ce. Add material-icon as dev dependency. Move demo elements into expansion panels.

## Related Issue
#964

## Description
Fix for the initialPage prop not being applied when using remote data sources.

## Key Changes

- setting paging to false when data source is remote as other parameters such as search, filter and sort delegate the responsibility to the data source rather than the table. This assumption should apply to the paging as well as it's already expecting the count and page to be returned by the data source.
- setting the isLoading to true when the state is initially constructed. On mount it is set to false if the data source is not remote, else left as true until the data source returns.
- Page overflow check in the onComponentUpdate is no longer applied while isLoading is true (prevents infinite update loop due to page being > 0 and count === 0 on mount)

## Additional Changes
I can revert these changes if preferred.
- Added expansion panels to the demo page. It made it easier to test the on mount logic as the tables remount when the panel is expanded and removes the need to scroll to the remote data table on refresh.
- Added the material icon library as a dev dependency. Only needed it for the expansion panel icon.

## Related PRs
#974
#1518
#1381

## Impacted Areas in Application

- Remote data sources
- Static data sources
This may introduce breaking changes to dependents that expect the table to apply it's pagination/result set trimming when using remote data sources that return a result set greater than the page size. With this change the pagination/result set trimming is no longer applied by the table. If the result set is now greater than the page size, a result set > the page size will be displayed. I specifically have decided not to address this as in my opinion if the table is delegating search etc. to the remote data source, it is the data source's responsibility to trim the result set to size. If it doesn't, it's a bug in the data source, not the table.

## Acceptance Criteria
### Remote Data source
- [ ] When intialPage is set, query object passed to data source contains the initialPage value.
- [ ] When intialPage is unset, query object passed to data source contains the default value of 0.
- [ ] When initialPage is greater than count returned by the data source (pageSize * page > count), the page current page is set to the max page.

### Static Data Source
- [ ] When intialPage is set, pagination should be set to the initial value on load.
- [ ] When intialPage is unset, the initial value should be 0.
- [ ] When initialPage is greater than count of the data source, the page should be set to the max page value.