### PR TITLE
Close #2021

### DIFF
--- a/src/components/m-table-filter-row.js
+++ b/src/components/m-table-filter-row.js
@@ -44,8 +44,8 @@ class MTableFilterRow extends React.Component {
       <Select
         multiple
         value={selectedFilter}
-        onClose={event => {
-          this.props.onFilterChanged(columnDef.tableData.id, event.target.value);
+        onClose={() => {
+          this.props.onFilterChanged(columnDef.tableData.id, selectedFilter);
         }}
         onChange={event => {
           setSelectedFilter(event.target.value);


### PR DESCRIPTION
## Description
Fixes #2021. The event.target from the onClose method of the Material UI Select was undefined. This uses the controlled selectFilter state instead of relying on `event.target.value`.

## Impacted Areas in Application
* Remote data lookup filters