### PR TITLE
fix(typings): added missing totalCount type on Query interface

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -60,6 +60,7 @@ export interface Query<RowData extends object> {
   filters: Filter<RowData>[];
   page: number;
   pageSize: number;
+  totalCount: number;
   search: string;
   orderBy: Column<RowData>;
   orderDirection: "asc" | "desc";


### PR DESCRIPTION
## Related Issue
N/A

## Description
`totalCount` is missing on the query interface, while it's defined on the query object: https://github.com/mbrn/material-table/blob/5a5eca0114f5a81c96c3c848bb6308c241828d91/src/material-table.js#L45 

## Related PRs
N/A

## Impacted Areas in Application
typescript typings