### PR TITLE
Adding detail panel hooks for custom actions when panel is toggled

### DIFF
--- a/src/material-table.js
+++ b/src/material-table.js
@@ -503,8 +503,23 @@ export default class MaterialTable extends React.Component {
     });
   }
 
+  onExpandedHook = (rowData) => {
+    const isHookDefined = !!this.props.onDetailPanelExpanded;
+    if (isHookDefined) {
+      this.props.onDetailPanelExpanded(rowData);
+    }
+  }
+
+  onClosedHook = (rowData) => {
+    const isHookDefined = !!this.props.onDetailPanelClosed;
+    if (isHookDefined) {
+      this.props.onDetailPanelClosed(rowData);
+    }
+  }
+
   onToggleDetailPanel = (path, render) => {
-    this.dataManager.changeDetailPanelVisibility(path, render);
+    const detailPanelHooks = { onExpanded: this.onExpandedHook, onClosed: this.onClosedHook };
+    this.dataManager.changeDetailPanelVisibility(path, render, detailPanelHooks);
     this.setState(this.dataManager.getRenderState());
   }
 

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -189,6 +189,8 @@ export const propTypes = {
   onChangeRowsPerPage: PropTypes.func,
   onChangePage: PropTypes.func,
   onChangeColumnHidden: PropTypes.func,
+  onDetailPanelExpanded: PropTypes.func,
+  onDetailPanelClosed: PropTypes.func,
   onOrderChange: PropTypes.func,
   onRowClick: PropTypes.func,
   onTreeExpandChange: PropTypes.func,

--- a/src/utils/data-manager.js
+++ b/src/utils/data-manager.js
@@ -156,13 +156,15 @@ export default class DataManager {
     this.filtered = false;
   }
 
-  changeDetailPanelVisibility(path, render) {
+  changeDetailPanelVisibility(path, render, hooks) {
     const rowData = this.findDataByPath(this.sortedData, path);
 
     if ((rowData.tableData.showDetailPanel || '').toString() === render.toString()) {
+      hooks.onClosed(rowData);
       rowData.tableData.showDetailPanel = undefined;
     }
     else {
+      hooks.onExpanded(rowData);
       rowData.tableData.showDetailPanel = render;
     }
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -44,6 +44,8 @@ export interface MaterialTableProps<RowData extends object> {
   onSelectionChange?: (data: RowData[], rowData?: RowData) => void;
   onTreeExpandChange?: (data: any, isExpanded: boolean) => void;
   onQueryChange?: (query: Query<RowData>) => void;
+  onDetailPanelExpanded?: (rowData?: RowData) => void;
+  onDetailPanelClosed?: (rowData?: RowData) => void;
   style?: React.CSSProperties;
   tableRef?: any;
   page?: number;


### PR DESCRIPTION
## Related Issue

#1274
#2012 

## Description
Clients need some mechanism to tap into when the detail panel is expanded/closed. This creates two new hooks so clients can record state, metrics and much more. There are at least 3-4 issues/questions about this feature, over Github, StackOverflow and Gitter.

## Related PRs
The PR below the author provides the suggestion of creating these hooks.
* https://github.com/mbrn/material-table/pull/1452

## Impacted Areas in Application
List general components of the application that this PR will affect:

* Detail Panel

## Additional Notes
This is a sample test showing the hook doing a simple log when the detail panel is expanded.
![](https://i.imgur.com/7P0Jtpi.gif)