### PR TITLE
Update table to track errors in the remote data source and display a …

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -195,21 +195,21 @@ class App extends Component {
                   searchPlaceholder: "Outlined Search Field",
                 }
               }}
-              data={query => new Promise((resolve, reject) => {
+              data={query => {
                 let url = 'https://reqres.in/api/users?'
                 url += 'per_page=' + query.pageSize
                 url += '&page=' + (query.page + 1)
                 console.log(query);
-                fetch(url)
+                return fetch(url)
                   .then(response => response.json())
                   .then(result => {
-                    resolve({
+                    return {
                       data: result.data,
                       page: result.page - 1,
                       totalCount: result.total,
-                    })
-                  })
-              })}
+                    }
+                  });
+              }}
             />
 
           </div>

--- a/src/components/m-table-body.js
+++ b/src/components/m-table-body.js
@@ -10,27 +10,33 @@ class MTableBody extends React.Component {
   renderEmpty(emptyRowCount, renderData) {
     const rowHeight = this.props.options.padding === 'default' ? 49 : 36;
     const localization = { ...MTableBody.defaultProps.localization, ...this.props.localization };
-    if (this.props.options.showEmptyDataSourceMessage && renderData.length === 0) {
-      let addColumn = 0;
-      if (this.props.options.selection) {
-        addColumn++;
+    if ( renderData.length === 0) {
+        if (this.props.options.showEmptyDataSourceMessage || (this.props.isDataSourceError && this.props.options.showDataSourceErrorMessage)) {
+          let addColumn = 0;
+          if (this.props.options.selection) {
+            addColumn++;
+          }
+          if (this.props.actions && this.props.actions.filter(a => a.position === "row" || typeof a === "function").length > 0) {
+            addColumn++;
+          }
+          if (this.props.hasDetailPanel) {
+            addColumn++;
+          }
+          if (this.props.isTreeData) {
+            addColumn++;
+          }
+          return (
+            <TableRow style={{ height: rowHeight * (this.props.options.paging && this.props.options.emptyRowsWhenPaging ? this.props.pageSize : 1) }} key={'empty-' + 0} >
+              <TableCell style={{ paddingTop: 0, paddingBottom: 0, textAlign: 'center' }} colSpan={this.props.columns.length + addColumn} key="empty-">
+                {
+                  this.props.isDataSourceError ? 
+                  localization.dataSourceErrorMessage :
+                  localization.emptyDataSourceMessage
+                }
+              </TableCell>
+            </TableRow>
+          );
       }
-      if (this.props.actions && this.props.actions.filter(a => a.position === "row" || typeof a === "function").length > 0) {
-        addColumn++;
-      }
-      if (this.props.hasDetailPanel) {
-        addColumn++;
-      }
-      if (this.props.isTreeData) {
-        addColumn++;
-      }
-      return (
-        <TableRow style={{ height: rowHeight * (this.props.options.paging && this.props.options.emptyRowsWhenPaging ? this.props.pageSize : 1) }} key={'empty-' + 0} >
-          <TableCell style={{ paddingTop: 0, paddingBottom: 0, textAlign: 'center' }} colSpan={this.props.columns.length + addColumn} key="empty-">
-            {localization.emptyDataSourceMessage}
-          </TableCell>
-        </TableRow>
-      );
     } else if (this.props.options.emptyRowsWhenPaging) {
       return (
         <React.Fragment>
@@ -205,9 +211,11 @@ MTableBody.defaultProps = {
   selection: false,
   localization: {
     emptyDataSourceMessage: 'No records to display',
+    dataSourceErrorMessage: 'An error occurred while retrieving the data',
     filterRow: {},
     editRow: {}
-  }
+  },
+  isDataSourceError: false,
 };
 
 MTableBody.propTypes = {
@@ -237,6 +245,7 @@ MTableBody.propTypes = {
   onRowClick: PropTypes.func,
   onEditingCanceled: PropTypes.func,
   onEditingApproved: PropTypes.func,
+  isDataSourceError: PropTypes.bool,
 };
 
 export default MTableBody;

--- a/src/default-props.js
+++ b/src/default-props.js
@@ -88,6 +88,7 @@ export const defaultProps = {
     pageSizeOptions: [5, 10, 20],
     paginationType: 'normal',
     showEmptyDataSourceMessage: true,
+    showDataSourceErrorMessage: true,
     showFirstLastPageButtons: true,
     showSelectAllCheckbox: true,
     search: true,

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -162,6 +162,7 @@ export const propTypes = {
     selection: PropTypes.bool,
     selectionProps: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
     showEmptyDataSourceMessage: PropTypes.bool,
+    showDataSourceErrorMessage: PropTypes.bool,
     showFirstLastPageButtons: PropTypes.bool,
     showSelectAllCheckbox: PropTypes.bool,
     showTitle: PropTypes.bool,


### PR DESCRIPTION
…message when they occur.

## Related Issue
#1429 

## Description
Add error handling for remote data sources.

This change only accounts for error handling with remote data sources. It's assumed that static data sources can't fail as they are defined/generated external to the table.

Introduced `isDataSourceError` state for tracking if an error has occurred in the data source.
Add `error` property to `query` state and pass it through to the table body. It is not currently used however allows for components overriding the MTableBody to have access to the error if required.

Add `showEmptyDataSourceMessage` option to control whether the error row is displayed.
Add `localization. dataSourceErrorMessage ` translation for the error row message.

## Impacted Areas in Application

* onQueryChange
* Table body