### PR TITLE
[Bug] add ability to use cellProps in MTableCell

### DIFF
--- a/src/components/m-table-cell.js
+++ b/src/components/m-table-cell.js
@@ -117,7 +117,7 @@ export default class MTableCell extends React.Component {
 
   render() {
 
-    const { icons, columnDef, rowData, ...cellProps } = this.props;
+    const { icons, columnDef, rowData, cellProps } = this.props;
 
     return (
       <TableCell


### PR DESCRIPTION
## Related Issue
Relate the Github issue with this PR using `#` (not available)

## Description

Currently the cellProps is not usable, because by the time it is being used inside <TableCell /> component it is undefined.

This PR solves that issue.

## Related PRs
List related PRs against other branches:

n/a

## Impacted Areas in Application
List general components of the application that this PR will affect:

* MTableCell

## Additional Notes
This is optional, feel free to follow your hearth and write here :)