### PR TITLE
[Bug]: Table results do not filter after selecting a lookup filter

### DIFF
--- a/src/components/m-table-filter-row.js
+++ b/src/components/m-table-filter-row.js
@@ -44,8 +44,8 @@ class MTableFilterRow extends React.Component {
       <Select
         multiple
         value={selectedFilter}
-        onClose={event => {
-          this.props.onFilterChanged(columnDef.tableData.id, event.target.value);
+        onClose={() => {
+          this.props.onFilterChanged(columnDef.tableData.id, selectedFilter);
         }}
         onChange={event => {
           setSelectedFilter(event.target.value);


### PR DESCRIPTION
## Related Issue
I was able to resolve the bug that does not filter the table results after clicking a lookup filter without creating an issue, but will open one if necessary

## Description
After rendering a table that has a column containing a `lookup`, then in the UI after selecting a lookup filter from the Select dropdown the Table does not update with the filtered result set

Bug Demo: https://codesandbox.io/s/material-tablelookup-filter-bug-m9lmi?file=/src/App.js

## Solution
Inside the `m-table-filter-row.js` component there is an onClose handler that passes `event` into `this.props.onFilterChanged(columnDef.tableData.id, event.target.value);`. When onClose is called `event` is `undefined`, which is the source of the bug. Since `m-table-filter-row.js` already has declared a piece of state that has the `selectedFilter`, I have updated the onClose handler to pass `selectedFilter` i.e. `this.props.onFilterChanged(columnDef.tableData.id, selectedFilter);` which resolves the bug and will actually filter the result set in the UI when a lookup filter is selected.

## Impacted Areas in Application
List general components of the application that this PR will affect:
- `m-table-filter-row.js`