### PR TITLE
Adds datePickerProps property to column definition to override filter props

### DIFF
--- a/src/components/m-table-filter-row.js
+++ b/src/components/m-table-filter-row.js
@@ -121,7 +121,7 @@ class MTableFilterRow extends React.Component {
       value: columnDef.tableData.filterValue || null,
       onChange: onDateInputChange,
       placeholder: this.getLocalizedFilterPlaceHolder(columnDef),
-      clearable: true,
+      clearable: true
     };
 
     if (columnDef.datePickerProps !== null && typeof columnDef.datePickerProps === 'object') {

--- a/src/components/m-table-filter-row.js
+++ b/src/components/m-table-filter-row.js
@@ -117,12 +117,16 @@ class MTableFilterRow extends React.Component {
 
   renderDateTypeFilter = (columnDef) => {
     const onDateInputChange = date => this.props.onFilterChanged(columnDef.tableData.id, date);
-    const pickerProps = {
+    let pickerProps = {
       value: columnDef.tableData.filterValue || null,
       onChange: onDateInputChange,
       placeholder: this.getLocalizedFilterPlaceHolder(columnDef),
-      clearable: true
+      clearable: true,
     };
+
+    if (columnDef.datePickerProps !== null && typeof columnDef.datePickerProps === 'object') {
+      pickerProps = { ...pickerProps, ...columnDef.datePickerProps };
+    }
 
     let dateInputElement = null;
     if (columnDef.type === 'date') {

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -27,6 +27,7 @@ export const propTypes = {
     }),
     customFilterAndSearch: PropTypes.func,
     customSort: PropTypes.func,
+    datePickerProps: PropTypes.object,
     defaultFilter: PropTypes.any,
     defaultSort: PropTypes.oneOf(['asc', 'desc']),
     editComponent: PropTypes.oneOfType([PropTypes.element, PropTypes.func]),


### PR DESCRIPTION
## Related Issue
#2042 (encountered the issue while searching for a solution to this problem)

## Description
The date picker used to filter date/datetime/time columns is not customizable beyond the default value and the placeholder.
I want the filter to display a full date ("YYYY-MM-DD" or "DD/MM/YYYY") instead of "MMMM do". This code allows for full picker props customization while retaining the default values.

## Related PRs
None

## Impacted Areas in Application

* m-table-filter-row
* prop-types

## Additional Notes
First PR ever, hope i'm doing it right ! Feedback is appreciated