### PR TITLE
Fix redundant recursive check in onSelectionChange

### DIFF
--- a/src/material-table.js
+++ b/src/material-table.js
@@ -438,8 +438,6 @@ export default class MaterialTable extends React.Component {
           if (row.tableData.checked) {
             selectedRows.push(row);
           }
-
-          row.tableData.childRows && findSelecteds(row.tableData.childRows);
         });
       };
 


### PR DESCRIPTION
## Related Issue

#1785 
#322

## Description

when both `selection` and `parentChildData` are used together, `onSelectionChange` callback receives duplicate rows, because there's a logic inspecting `tableData.childRows` while iterating rows, but since the function is already iterating every rows including child rows, there's no need to check child rows twice in this case.

## Impacted Areas in Application
I've only tested with 1 level depth tree data, so not sure if there are other corner case
