### PR TITLE
guarding jsPDF to only import / run when window is present (aka not d…

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "dist",
     "types"
   ],
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
   "babel": {
     "extends": "./configs/.babelrc"
   },
@@ -82,8 +85,6 @@
     "debounce": "^1.2.0",
     "fast-deep-equal": "2.0.1",
     "filefy": "0.1.10",
-    "jspdf": "1.5.3",
-    "jspdf-autotable": "3.5.3",
     "prop-types": "^15.6.2",
     "react-beautiful-dnd": "^13.0.0",
     "react-double-scrollbar": "0.0.15"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "material-table",
-  "version": "1.64.0",
+  "version": "1.65.0",
   "description": "Datatable for React based on https://material-ui.com/api/table/ with additional features",
   "main": "dist/index.js",
   "types": "types/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -85,6 +85,8 @@
     "debounce": "^1.2.0",
     "fast-deep-equal": "2.0.1",
     "filefy": "0.1.10",
+    "jspdf": "1.5.3",
+    "jspdf-autotable": "3.5.3",
     "prop-types": "^15.6.2",
     "react-beautiful-dnd": "^13.0.0",
     "react-double-scrollbar": "0.0.15"

--- a/package.json
+++ b/package.json
@@ -8,9 +8,6 @@
     "dist",
     "types"
   ],
-  "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
-  },
   "babel": {
     "extends": "./configs/.babelrc"
   },

--- a/src/components/m-table-toolbar.js
+++ b/src/components/m-table-toolbar.js
@@ -14,9 +14,10 @@ import { lighten } from "@material-ui/core/styles/colorManipulator";
 import classNames from "classnames";
 import { CsvBuilder } from "filefy";
 import PropTypes, { oneOf } from "prop-types";
-import jsPDF from "jspdf";
 import "jspdf-autotable";
 import * as React from "react";
+
+const jsPDF = typeof window !== `undefined` ? require("jsPDF") : null;
 /* eslint-enable no-unused-vars */
 
 export class MTableToolbar extends React.Component {
@@ -73,25 +74,27 @@ export class MTableToolbar extends React.Component {
   };
 
   defaultExportPdf = () => {
-    const [columns, data] = this.getTableData();
+    if (jsPDF !== null) {
+      const [columns, data] = this.getTableData();
 
-    let content = {
-      startY: 50,
-      head: [columns.map((columnDef) => columnDef.title)],
-      body: data,
-    };
+      let content = {
+        startY: 50,
+        head: [columns.map((columnDef) => columnDef.title)],
+        body: data,
+      };
 
-    const unit = "pt";
-    const size = "A4";
-    const orientation = "landscape";
+      const unit = "pt";
+      const size = "A4";
+      const orientation = "landscape";
 
-    const doc = new jsPDF(orientation, unit, size);
-    doc.setFontSize(15);
-    doc.text(this.props.title, 40, 40);
-    doc.autoTable(content);
-    doc.save(
-      (this.props.exportFileName || this.props.title || "data") + ".pdf"
-    );
+      const doc = new jsPDF(orientation, unit, size);
+      doc.setFontSize(15);
+      doc.text(this.props.title, 40, 40);
+      doc.autoTable(content);
+      doc.save(
+        (this.props.exportFileName || this.props.title || "data") + ".pdf"
+      );
+    }
   };
 
   exportCsv = () => {

--- a/src/components/m-table-toolbar.js
+++ b/src/components/m-table-toolbar.js
@@ -16,9 +16,7 @@ import { CsvBuilder } from "filefy";
 import PropTypes, { oneOf } from "prop-types";
 import "jspdf-autotable";
 import * as React from "react";
-
-const jsPDF = typeof window !== `undefined` ? require("jsPDF") : null;
-
+const jsPDF = typeof window !== "undefined" ? require("jspdf") : null;
 /* eslint-enable no-unused-vars */
 
 export class MTableToolbar extends React.Component {
@@ -58,10 +56,15 @@ export class MTableToolbar extends React.Component {
   defaultExportCsv = () => {
     const [columns, data] = this.getTableData();
 
-    const builder = new CsvBuilder(
-      (this.props.exportFileName || this.props.title || "data") + ".csv"
-    );
+    let fileName = this.props.title || "data";
+    if (this.props.exportFileName) {
+      fileName =
+        typeof this.props.exportFileName === "function"
+          ? this.props.exportFileName()
+          : this.props.exportFileName;
+    }
 
+    const builder = new CsvBuilder(fileName + ".csv");
     builder
       .setDelimeter(this.props.exportDelimiter)
       .setColumns(columns.map((columnDef) => columnDef.title))
@@ -143,15 +146,16 @@ export class MTableToolbar extends React.Component {
                 <IconButton
                   disabled={!this.state.searchText}
                   onClick={() => this.onSearchChange("")}
+                  aria-label={localization.clearSearchAriaLabel}
                 >
-                  <this.props.icons.ResetSearch fontSize="small" />
+                  <this.props.icons.ResetSearch fontSize="small" aria-label="clear"/>
                 </IconButton>
               </InputAdornment>
             ),
             style: this.props.searchFieldStyle,
             inputProps: {
-              "aria-label": "Search",
-            },
+              'aria-label': localization.searchAriaLabel
+            }
           }}
         />
       );
@@ -354,16 +358,18 @@ MTableToolbar.defaultProps = {
   columns: [],
   columnsButton: false,
   localization: {
-    addRemoveColumns: "Add or remove columns",
-    nRowsSelected: "{0} row(s) selected",
-    showColumnsTitle: "Show Columns",
-    showColumnsAriaLabel: "Show Columns",
-    exportTitle: "Export",
-    exportAriaLabel: "Export",
+    addRemoveColumns: 'Add or remove columns',
+    nRowsSelected: '{0} row(s) selected',
+    showColumnsTitle: 'Show Columns',
+    showColumnsAriaLabel: 'Show Columns',
+    exportTitle: 'Export',
+    exportAriaLabel: 'Export',
     exportCSVName: "Export as CSV",
     exportPDFName: "Export as PDF",
-    searchTooltip: "Search",
-    searchPlaceholder: "Search",
+    searchTooltip: 'Search',
+    searchPlaceholder: 'Search',
+    searchAriaLabel: 'Search',
+    clearSearchAriaLabel: 'Clear Search'
   },
   search: true,
   showTitle: true,

--- a/src/components/m-table-toolbar.js
+++ b/src/components/m-table-toolbar.js
@@ -16,8 +16,7 @@ import { CsvBuilder } from "filefy";
 import PropTypes, { oneOf } from "prop-types";
 import "jspdf-autotable";
 import * as React from "react";
-
-const jsPDF = typeof window !== `undefined` ? require("jsPDF") : null;
+const jsPDF = typeof window !== "undefined" ? require("jspdf") : null;
 /* eslint-enable no-unused-vars */
 
 export class MTableToolbar extends React.Component {


### PR DESCRIPTION
…uring ssr build)

This guards the jsPDF using in a check if we have a present window (aka running in a browser) this will allow to build server side (ignoring the pdf export here) and then rehydrate it back in when the user runs the webpage

## Related Issue

#2112

## Description

Quick fix until jsPDF fixes theeir own issues (https://github.com/MrRio/jsPDF/issues/2753)



