### PR TITLE
Send correct pageSize onChangePage without remoteData

### DIFF
--- a/src/material-table.js
+++ b/src/material-table.js
@@ -344,7 +344,7 @@ export default class MaterialTable extends React.Component {
       }
       this.setState(this.dataManager.getRenderState(), () => {
         this.props.onChangePage &&
-          this.props.onChangePage(page, this.state.query.pageSize);
+          this.props.onChangePage(page, this.state.pageSize);
       });
     }
   };


### PR DESCRIPTION
## Description
Currently it's send query state pageSize on without remote data pagination onChangePage.


