### PR TITLE
Fix typescript error TS2304: Cannot find name 'RowData'

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -29,7 +29,7 @@ export interface MaterialTableProps<RowData extends object> {
   icons?: Icons;
   isLoading?: boolean;
   title?: string | React.ReactElement<any>;
-  options?: Options;
+  options?: Options<RowData>;
   parentChildData?: (row: RowData, rows: RowData[]) => RowData | undefined;
   localization?: Localization;
   onChangeRowsPerPage?: (pageSize: number) => void;
@@ -273,7 +273,7 @@ export interface Icons {
   Retry?: React.ForwardRefExoticComponent<React.RefAttributes<SVGSVGElement>>;
 }
 
-export interface Options {
+export interface Options<RowData extends object> {
   actionsCellStyle?: React.CSSProperties;
   detailPanelColumnStyle?: React.CSSProperties;
   editCellStyle?: React.CSSProperties;


### PR DESCRIPTION
## Description

Fix name error on RowData in index.d.ts

ERROR in [at-loader] ./node_modules/material-table/types/index.d.ts:294:25 
    TS2304: Cannot find name 'RowData'.

This was due to the fact that the RowData type variable available in MaterialTableProps should be transmitted to the Options type.
