### PR TITLE
Fix invalid expressions

### DIFF
--- a/src/material-table.js
+++ b/src/material-table.js
@@ -848,7 +848,7 @@ export default class MaterialTable extends React.Component {
     }
 
     for (let i = 0; i < Math.abs(count) && i < props.columns.length; i++) {
-      const colDef = props.columns[i >= 0 ? i : props.columns.length - 1 - i];
+      const colDef = props.columns[count >= 0 ? i : props.columns.length - 1 - i];
       if (colDef.tableData) {
         if (typeof colDef.tableData.width === "number") {
           result.push(colDef.tableData.width + "px");


### PR DESCRIPTION
## Description


When I use the options:

``` javascript
options: {
  fixedColumns: {
    right: 1,
  },
}
```

I found that the width of the right fixed column will use the width of the first column. So I found the code below:

``` javascript
for (let i = 0; i < Math.abs(count) && i < props.columns.length; i++) {
  const colDef = props.columns[i >= 0 ? i : props.columns.length - 1 - i];
  if (colDef.tableData) {
    if (typeof colDef.tableData.width === "number") {
      result.push(colDef.tableData.width + "px");
    } else {
      result.push(colDef.tableData.width);
    }
  }
}
```
The Code `i >= 0 ? i : props.columns.length - 1 - i` do not trigger the latter, and the right fixed column use this func like: `width: this.getColumnsWidth(props, -1 * props.options.fixedColumns.right),` with a negative width.

When I changed this line of code, everything worked fine.
