### PR TITLE
Added field 'initialFormData' to MaterialTableProps

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -27,6 +27,7 @@ export interface MaterialTableProps<RowData extends object> {
     isDeleteHidden?: (rowData: RowData) => boolean;
   };
   icons?: Icons;
+  initialFormData?: RowData
   isLoading?: boolean;
   title?: string | React.ReactElement<any>;
   options?: Options<RowData>;


### PR DESCRIPTION
## Related Issue

Relate the Github issue with this PR using `#433`

## Description

Added field 'initialFormData' to MaterialTableProps as the JavaScript code can deal with such a property.

