### PR TITLE
Add a specific action custom component

### DIFF
--- a/src/components/m-table-action.js
+++ b/src/components/m-table-action.js
@@ -4,6 +4,7 @@ import PropTypes from "prop-types";
 import Icon from "@material-ui/core/Icon";
 import IconButton from "@material-ui/core/IconButton";
 import Tooltip from "@material-ui/core/Tooltip";
+import { MyComponent } from "./m-table-custom-action-component";
 /* eslint-enable no-unused-vars */
 
 class MTableAction extends React.Component {
@@ -47,21 +48,20 @@ class MTableAction extends React.Component {
       );
 
     const button =
-     (action.isCustom || this.props.isCustom && action.component || this.props.component) ?
-         action.component|this.props.component
-         :
-            (
-              <IconButton
-                  size={this.props.size}
-                  color="inherit"
-                  disabled={disabled}
-                  onClick={handleOnClick}
-              >
-                {icon}
-              </IconButton>
-          );
-
-
+      action.isCustom ||
+      (this.props.isCustom && action.component) ||
+      this.props.component ? (
+        <MyComponent>{action.component}</MyComponent>
+      ) : (
+        <IconButton
+          size={this.props.size}
+          color="inherit"
+          disabled={disabled}
+          onClick={handleOnClick}
+        >
+          {icon}
+        </IconButton>
+      );
 
     if (action.tooltip) {
       // fix for issue #1049

--- a/src/components/m-table-action.js
+++ b/src/components/m-table-action.js
@@ -46,16 +46,22 @@ class MTableAction extends React.Component {
         <action.icon />
       );
 
-    const button = (
-      <IconButton
-        size={this.props.size}
-        color="inherit"
-        disabled={disabled}
-        onClick={handleOnClick}
-      >
-        {icon}
-      </IconButton>
-    );
+    const button =
+     (action.isCustom || this.props.isCustom && action.component || this.props.component) ?
+         action.component|this.props.component
+         :
+            (
+              <IconButton
+                  size={this.props.size}
+                  color="inherit"
+                  disabled={disabled}
+                  onClick={handleOnClick}
+              >
+                {icon}
+              </IconButton>
+          );
+
+
 
     if (action.tooltip) {
       // fix for issue #1049

--- a/src/components/m-table-custom-action-component.js
+++ b/src/components/m-table-custom-action-component.js
@@ -1,0 +1,9 @@
+import * as React from "react";
+
+export const MyComponent = React.forwardRef(function MyComponent(props, ref) {
+  return (
+    <div {...props} ref={ref}>
+      {props.children}
+    </div>
+  );
+});

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -29,6 +29,12 @@ export const propTypes = {
         iconProps: PropTypes.object,
         disabled: PropTypes.bool,
         hidden: PropTypes.bool,
+        isCustom:PropTypes.bool,
+        component:PropTypes.oneOfType([
+          PropTypes.element,
+          PropTypes.func,
+          RefComponent,
+        ]),
       }),
     ])
   ),

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -102,6 +102,8 @@ export interface Action<RowData extends object> {
   onClick: (event: any, data: RowData | RowData[]) => void;
   iconProps?: IconProps;
   hidden?: boolean;
+  isCustom?:boolean;
+  component?:React.ReactElement<any> | (() => React.ReactElement<any>)
 }
 
 export interface EditComponentProps<RowData extends object> {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -169,7 +169,7 @@ export interface Column<RowData extends object> {
   filterPlaceholder?: string;
   filterCellStyle?: React.CSSProperties;
   grouping?: boolean;
-  groupTitle?: string | ((groupData: any) => any) | React.Node;
+  groupTitle?: string | ((groupData: any) => any) | React.ReactNode;
   headerStyle?: React.CSSProperties;
   hidden?: boolean;
   hideFilterIcon?: boolean;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -102,8 +102,8 @@ export interface Action<RowData extends object> {
   onClick: (event: any, data: RowData | RowData[]) => void;
   iconProps?: IconProps;
   hidden?: boolean;
-  isCustom?:boolean;
-  component?:React.ReactElement<any> | (() => React.ReactElement<any>)
+  isCustom?: boolean;
+  component?: React.ReactElement<any> | (() => React.ReactElement<any>);
 }
 
 export interface EditComponentProps<RowData extends object> {
@@ -170,7 +170,7 @@ export interface Column<RowData extends object> {
   filterPlaceholder?: string;
   filterCellStyle?: React.CSSProperties;
   grouping?: boolean;
-  groupTitle?: string | ((groupData: any) => any) | React.Node; 
+  groupTitle?: string | ((groupData: any) => any) | React.Node;
   headerStyle?: React.CSSProperties;
   hidden?: boolean;
   hideFilterIcon?: boolean;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,7 +1,6 @@
 import * as React from "react";
 import { IconProps } from "@material-ui/core/Icon";
 import SvgIcon from "@material-ui/core/SvgIcon";
-import { string } from "prop-types";
 
 type SvgIconComponent = typeof SvgIcon;
 


### PR DESCRIPTION
## Related Issue

https://github.com/mbrn/material-table/issues/2186

## Description

Added support to add custom action component.

## Impacted Areas in Application

When adding actions Array,  
now each action support isCustom, and Component Properties.  
when isCustom enabled and there is Component supplied.  
it will be assign instead of the normal Button wrapper supplied.
```
                  actions={[
                    {
                      icon: ()=> </>,
                      tooltip: "Delete Row",
                      onClick: (event, rowData) => console.log(rowData),
                      isCustom: true,
                      component: <CustomButton />,
                      isFreeAction:false
                   }]}
```
\*

## Additional Notes

It will be displayed with no errors about Warning: validateDOMNesting or FowardRef.
