### PR TITLE
Typescript: Added field 'initialFormData' to MaterialTableProps

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -27,7 +27,7 @@ export interface MaterialTableProps<RowData extends object> {
     isDeleteHidden?: (rowData: RowData) => boolean;
   };
   icons?: Icons;
-  initialFormData?: RowData
+  initialFormData?: object
   isLoading?: boolean;
   title?: string | React.ReactElement<any>;
   options?: Options<RowData>;


### PR DESCRIPTION
## Description

Let the typescript programmer use the field 'initialFormData'

