### PR TITLE
Correctly centers the boolean checkbox

### DIFF
--- a/src/components/m-table-edit-field.js
+++ b/src/components/m-table-edit-field.js
@@ -58,7 +58,7 @@ class MTableEditField extends React.Component {
         checked={Boolean(this.props.value)}
         onChange={(event) => this.props.onChange(event.target.checked)}
         style={{
-          padding: 0
+          padding: 0,
         }}
         inputProps={{
           "aria-label": this.props.columnDef.title,

--- a/src/components/m-table-edit-field.js
+++ b/src/components/m-table-edit-field.js
@@ -58,9 +58,7 @@ class MTableEditField extends React.Component {
         checked={Boolean(this.props.value)}
         onChange={(event) => this.props.onChange(event.target.checked)}
         style={{
-          paddingLeft: 0,
-          paddingTop: 0,
-          paddingBottom: 0,
+          padding: 0
         }}
         inputProps={{
           "aria-label": this.props.columnDef.title,

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -848,7 +848,8 @@ export default class MaterialTable extends React.Component {
     }
 
     for (let i = 0; i < Math.abs(count) && i < props.columns.length; i++) {
-      const colDef = props.columns[count >= 0 ? i : props.columns.length - 1 - i];
+      const colDef =
+        props.columns[count >= 0 ? i : props.columns.length - 1 - i];
       if (colDef.tableData) {
         if (typeof colDef.tableData.width === "number") {
           result.push(colDef.tableData.width + "px");

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -27,7 +27,7 @@ export interface MaterialTableProps<RowData extends object> {
     isDeleteHidden?: (rowData: RowData) => boolean;
   };
   icons?: Icons;
-  initialFormData?: object
+  initialFormData?: object;
   isLoading?: boolean;
   title?: string | React.ReactElement<any>;
   options?: Options<RowData>;


### PR DESCRIPTION
## Description

This PR centers the checkbox for the edit boolean field correctly by removing the right padding.

![image](https://user-images.githubusercontent.com/17567991/87985983-caaa5d80-cadc-11ea-954e-96135b226e53.png)
