### PR TITLE
Allow tree shaking to remove export dependencies if not used

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -2,8 +2,10 @@ import { Grid, MuiThemeProvider, Button } from "@material-ui/core";
 import { createMuiTheme } from "@material-ui/core/styles";
 import React, { Component } from "react";
 import ReactDOM from "react-dom";
-import MaterialTable from "../src";
 import Typography from "@material-ui/core/Typography";
+
+import MaterialTable from "../src";
+import { defaultExportCsv, defaultExportPdf } from "../src/exports";
 
 let direction = "ltr";
 // direction = 'rtl';
@@ -494,6 +496,9 @@ class App extends Component {
                     console.log("selected Filters : ", appliedFilter);
                   }}
                   options={{
+                    exportButton: true,
+                    exportCsv: defaultExportCsv,
+                    exportPdf: defaultExportPdf,
                     headerSelectionProps: {
                       color: "primary",
                     },

--- a/src/components/m-table-toolbar.js
+++ b/src/components/m-table-toolbar.js
@@ -12,11 +12,9 @@ import Typography from "@material-ui/core/Typography";
 import withStyles from "@material-ui/core/styles/withStyles";
 import { lighten } from "@material-ui/core/styles/colorManipulator";
 import classNames from "classnames";
-import { CsvBuilder } from "filefy";
 import PropTypes, { oneOf } from "prop-types";
-import "jspdf-autotable";
 import * as React from "react";
-const jsPDF = typeof window !== "undefined" ? require("jspdf") : null;
+
 /* eslint-enable no-unused-vars */
 
 export class MTableToolbar extends React.Component {
@@ -55,63 +53,16 @@ export class MTableToolbar extends React.Component {
     return [columns, data];
   };
 
-  defaultExportCsv = () => {
-    const [columns, data] = this.getTableData();
-
-    let fileName = this.props.title || "data";
-    if (this.props.exportFileName) {
-      fileName =
-        typeof this.props.exportFileName === "function"
-          ? this.props.exportFileName()
-          : this.props.exportFileName;
-    }
-
-    const builder = new CsvBuilder(fileName + ".csv");
-    builder
-      .setDelimeter(this.props.exportDelimiter)
-      .setColumns(columns.map((columnDef) => columnDef.title))
-      .addRows(data)
-      .exportFile();
-  };
-
-  defaultExportPdf = () => {
-    if (jsPDF !== null) {
-      const [columns, data] = this.getTableData();
-
-      let content = {
-        startY: 50,
-        head: [columns.map((columnDef) => columnDef.title)],
-        body: data,
-      };
-
-      const unit = "pt";
-      const size = "A4";
-      const orientation = "landscape";
-
-      const doc = new jsPDF(orientation, unit, size);
-      doc.setFontSize(15);
-      doc.text(this.props.title, 40, 40);
-      doc.autoTable(content);
-      doc.save(
-        (this.props.exportFileName || this.props.title || "data") + ".pdf"
-      );
-    }
-  };
-
   exportCsv = () => {
     if (this.props.exportCsv) {
-      this.props.exportCsv(this.props.columns, this.props.data);
-    } else {
-      this.defaultExportCsv();
+      this.props.exportCsv(this.props.columns, this.props.data, this.props);
     }
     this.setState({ exportButtonAnchorEl: null });
   };
 
   exportPdf = () => {
     if (this.props.exportPdf) {
-      this.props.exportPdf(this.props.columns, this.props.data);
-    } else {
-      this.defaultExportPdf();
+      this.props.exportPdf(this.props.columns, this.props.data, this.props);
     }
     this.setState({ exportButtonAnchorEl: null });
   };

--- a/src/exports.js
+++ b/src/exports.js
@@ -1,0 +1,44 @@
+import { CsvBuilder } from "filefy";
+import "jspdf-autotable";
+const jsPDF = typeof window !== "undefined" ? require("jspdf") : null;
+
+export const defaultExportCsv = (columns, data, props) => {
+  let fileName = props.title || "data";
+  if (props.exportFileName) {
+    fileName =
+      typeof props.exportFileName === "function"
+        ? props.exportFileName()
+        : props.exportFileName;
+  }
+
+  const dataarray = data.map((row) => columns.map((c) => row[c.field]));
+
+  const builder = new CsvBuilder(fileName + ".csv");
+  builder
+    .setDelimeter(props.exportDelimiter)
+    .setColumns(columns.map((columnDef) => columnDef.title))
+    .addRows(dataarray)
+    .exportFile();
+};
+
+export const defaultExportPdf = (columns, data, props) => {
+  if (jsPDF !== null) {
+    const dataarray = data.map((row) => columns.map((c) => row[c.field]));
+
+    const content = {
+      startY: 50,
+      head: [columns.map((columnDef) => columnDef.title)],
+      body: dataarray,
+    };
+
+    const unit = "pt";
+    const size = "A4";
+    const orientation = "landscape";
+
+    const doc = new jsPDF(orientation, unit, size);
+    doc.setFontSize(15);
+    doc.text(props.title, 40, 40);
+    doc.autoTable(content);
+    doc.save((props.exportFileName || props.title || "data") + ".pdf");
+  }
+};


### PR DESCRIPTION
## Related Issue

#2168 and #2164

## Description

Move default export function into a different file.  
This will reduce file size a lot (remove jspdf and csvbuilder).  
It will also remove default export function which will have to be defined manually

## Impacted Areas in Application

List general components of the application that this PR will affect:

- Remove default export functions
- Examples for exports will have to be updated
