### PR TITLE
Added prop to support pagination on top, bottom, or both

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -497,6 +497,7 @@ class App extends Component {
                     headerSelectionProps: {
                       color: "primary",
                     },
+                    paginationPosition: "both",
                     selection: true,
                     selectionProps: (rowData) => {
                       rowData.tableData.disabled = rowData.name === "A1";

--- a/src/default-props.js
+++ b/src/default-props.js
@@ -210,6 +210,7 @@ export const defaultProps = {
     pageSize: 5,
     pageSizeOptions: [5, 10, 20],
     paginationType: "normal",
+    paginationPosition: "bottom",
     showEmptyDataSourceMessage: true,
     showFirstLastPageButtons: true,
     showSelectAllCheckbox: true,

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -873,6 +873,7 @@ export default class MaterialTable extends React.Component {
         <props.components.Container
           style={{ position: "relative", ...props.style }}
         >
+          {(props.options.paginationPosition === "top" || props.options.paginationPosition === "both" ) ? this.renderFooter() : null}
           {props.options.toolbar && (
             <props.components.Toolbar
               actions={props.actions}
@@ -1030,7 +1031,7 @@ export default class MaterialTable extends React.Component {
                 </div>
               </div>
             )}
-          {this.renderFooter()}
+          { (props.options.paginationPosition === "bottom" || props.options.paginationPosition === "both" ) ? this.renderFooter() : null }
 
           {(this.state.isLoading || props.isLoading) &&
             props.options.loadingType === "overlay" && (

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -336,6 +336,7 @@ export const propTypes = {
     pageSize: PropTypes.number,
     pageSizeOptions: PropTypes.arrayOf(PropTypes.number),
     paginationType: PropTypes.oneOf(["normal", "stepped"]),
+    paginationPosition: PropTypes.oneOf(["bottom", "top", "both"]),
     rowStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
     search: PropTypes.bool,
     searchText: PropTypes.string,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -316,6 +316,7 @@ export interface Options<RowData extends object> {
   pageSize?: number;
   pageSizeOptions?: number[];
   paginationType?: "normal" | "stepped";
+  paginationPosition?: "bottom" | "top" | "both";
   rowStyle?:
     | React.CSSProperties
     | ((data: any, index: number, level: number) => React.CSSProperties);


### PR DESCRIPTION
## Related Issue

#540 

## Description

This allows a user to specify the position of the footer containing the pagination with a new paginationPosition prop. Acceptable values are top|bottom|both, with "bottom" being set as the default.

## Related PRs

None

## Impacted Areas in Application

Table Pagination

\*

