### PR TITLE
Fixed  Approve onEnter overriding textarea behavior

### DIFF
--- a/src/components/m-table-edit-row.js
+++ b/src/components/m-table-edit-row.js
@@ -234,7 +234,9 @@ export default class MTableEditRow extends React.Component {
   }
 
   handleKeyDown = (e) => {
-    if (e.keyCode === 13) {
+    if (e.keyCode === 13 && e.target.type !== "textarea") {
+      this.handleSave();
+    } else if (e.keyCode === 13 && e.target.type === "textarea" && e.shiftKey) {
       this.handleSave();
     } else if (e.keyCode === 27) {
       this.props.onEditingCanceled(this.props.mode, this.props.data);


### PR DESCRIPTION
## Related Issue

#1364
#1162

## Description

Fixed a bug from PR #2008 
* Approve save onEnter will be skipped for text-area a.k.a Material UI TextField mutliline
* Added shift + enter for approve save added for text-area

## Related PRs

#2008 

## Impacted Areas in Application

List general components of the application that this PR will affect:

* Edit Row
* Add Row
