### PR TITLE
Fix Bug with displaying error text

### DIFF
--- a/src/material-table.js
+++ b/src/material-table.js
@@ -1047,7 +1047,7 @@ export default class MaterialTable extends React.Component {
                 <props.components.OverlayLoading theme={props.theme} />
               </div>
             )}
-          {this.state.errorState && this.state.errorCause === "query" && (
+          {this.state.errorState && this.state.errorState.errorCause === "query" && (
             <div
               style={{
                 position: "absolute",


### PR DESCRIPTION
## Related Issue

Relate the Github issue with this PR using `#1998`

## Description

 stepped through THE CATCH AND it does look to set state for errorState as expected, but nothing is rendered

I think maybe the logic is off you set errorState like below

```
["catch"](function (error) {
          var localization = (0, _objectSpread2["default"])({}, MaterialTable.defaultProps.localization, _this.props.localization);
          var errorState = {
            message: (0, _typeof2["default"])(error) === "object" ? error.message : error !== undefined ? error : localization.error,
            errorCause: "query"
          };

          _this.setState((0, _objectSpread2["default"])({
            isLoading: false,
            errorState: errorState
          }, _this.dataManager.getRenderState()));
        });
```

but you are checking this for the display.
```
this.state.errorState && this.state.errorCause === "query"
```

 I think it needs to be updated to `this.state.errorState.errorCause`


## Related PRs

List related PRs against other branches:

| branch              | PR       |
| ------------------- | -------- |
| fix for error state   | [link](https://github.com/mbrn/material-table/pull/1998) |

