### PR TITLE
Missing hiddenByColumnsButton in Column type 

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -181,6 +181,7 @@ export interface Column<RowData extends object> {
   groupTitle?: string | ((groupData: any) => any) | React.ReactNode;
   headerStyle?: React.CSSProperties;
   hidden?: boolean;
+  hiddenByColumnsButton?: boolean;
   hideFilterIcon?: boolean;
   initialEditValue?: any;
   lookup?: object;


### PR DESCRIPTION
Column type is missing hiddenByColumnsButton property.

## Description

Without that field you cannot set column to be hidden by default and also available to be shown with "Add or remove columns" window.

## Impacted Areas in Application

List general components of the application that this PR will affect:

- "Add or remove columns" window
