### PR TITLE
Fix for formating the edit datepickers

### DIFF
--- a/src/components/m-table-body.js
+++ b/src/components/m-table-body.js
@@ -117,6 +117,8 @@ class MTableBody extends React.Component {
             localization={{
               ...MTableBody.defaultProps.localization.editRow,
               ...this.props.localization.editRow,
+              dateTimePickerLocalization: this.props.localization
+                .dateTimePickerLocalization,
             }}
             onRowSelected={this.props.onRowSelected}
             actions={this.props.actions}
@@ -168,6 +170,8 @@ class MTableBody extends React.Component {
         localization={{
           ...MTableBody.defaultProps.localization.editRow,
           ...this.props.localization.editRow,
+          dateTimePickerLocalization: this.props.localization
+            .dateTimePickerLocalization,
         }}
         cellEditable={this.props.cellEditable}
         onCellEditStarted={this.props.onCellEditStarted}
@@ -234,6 +238,8 @@ class MTableBody extends React.Component {
               localization={{
                 ...MTableBody.defaultProps.localization.editRow,
                 ...this.props.localization.editRow,
+                dateTimePickerLocalization: this.props.localization
+                  .dateTimePickerLocalization,
               }}
               options={this.props.options}
               isTreeData={this.props.isTreeData}
@@ -262,6 +268,8 @@ class MTableBody extends React.Component {
             localization={{
               ...MTableBody.defaultProps.localization.editRow,
               ...this.props.localization.editRow,
+              dateTimePickerLocalization: this.props.localization
+                .dateTimePickerLocalization,
             }}
             options={this.props.options}
             isTreeData={this.props.isTreeData}

--- a/src/components/m-table-edit-field.js
+++ b/src/components/m-table-edit-field.js
@@ -84,11 +84,16 @@ class MTableEditField extends React.Component {
   }
 
   renderDateField() {
+    const dateFormat =
+      this.props.columnDef.dateSetting &&
+      this.props.columnDef.dateSetting.format
+        ? this.props.columnDef.dateSetting.format
+        : "dd.MM.yyyy";
     return (
       <MuiPickersUtilsProvider utils={DateFnsUtils} locale={this.props.locale}>
         <DatePicker
           {...this.getProps()}
-          format="dd.MM.yyyy"
+          format={dateFormat}
           value={this.props.value || null}
           onChange={this.props.onChange}
           clearable
@@ -237,7 +242,7 @@ MTableEditField.propTypes = {
   value: PropTypes.any,
   onChange: PropTypes.func.isRequired,
   columnDef: PropTypes.object.isRequired,
-  dateTimePickerLocalization: PropTypes.object,
+  locale: PropTypes.object,
 };
 
 export default MTableEditField;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -148,7 +148,7 @@ export interface Column<RowData extends object> {
     minimumFractionDigits?: number;
     maximumFractionDigits?: number;
   };
-  dateSetting?: { locale?: string };
+  dateSetting?: { locale?: string; format?: string };
   customFilterAndSearch?: (
     filter: any,
     rowData: RowData,


### PR DESCRIPTION
## Description
This fixes a few missing dateTimePickerLocalization passes and allows to set the format of the datepicker by adding a format to the column dateSetting definition.