### PR TITLE
Expand EditCellColumnDef properties

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -130,10 +130,12 @@ export interface EditCellColumnDef {
   field: string;
   title: string;
   tableData: {
+    columnOrder: number;
     filterValue: any;
     groupOrder: any;
     groupSort: string;
     id: number;
+    width: string;
   };
 }
 


### PR DESCRIPTION

## Related Issue

N/A

## Description

This PR expands the type definitions of the EditCellColumnDef to ensure that they capture the different information found on the `tableData` section of the definition which is useful while implementing a custom row editing function.

## Related PRs

N/A

## Impacted Areas in Application

Typescript definitions

## Additional Notes

You rock, thanks for the great product and for allowing me to contribute and help improve the tool
