### PR TITLE
Add support for getFieldValue to type definition

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -38,6 +38,7 @@ export interface MaterialTableProps<RowData extends object> {
     isEditHidden?: (rowData: RowData) => boolean;
     isDeleteHidden?: (rowData: RowData) => boolean;
   };
+  getFieldValue?: (rowData: RowData, columnDef: EditCellColumnDef, lookup?: boolean) => any;
   icons?: Icons;
   initialFormData?: object;
   isLoading?: boolean;


### PR DESCRIPTION
## Related Issue

N/A

## Description

Add support for getFieldValue to allow easier editing of rows by end-user replacement components.

## Impacted Areas in Application

Typescript definition
