### PR TITLE
Filter row misaligns when details panel column is to the right.

### DIFF
--- a/src/components/m-table-body.js
+++ b/src/components/m-table-body.js
@@ -217,6 +217,9 @@ class MTableBody extends React.Component {
                 .dateTimePickerLocalization,
             }}
             hasDetailPanel={!!this.props.detailPanel}
+            detailPanelColumnAlignment={
+              this.props.options.detailPanelColumnAlignment
+            }
             isTreeData={this.props.isTreeData}
             filterCellStyle={this.props.options.filterCellStyle}
             filterRowStyle={this.props.options.filterRowStyle}

--- a/src/components/m-table-filter-row.js
+++ b/src/components/m-table-filter-row.js
@@ -246,8 +246,8 @@ class MTableFilterRow extends React.Component {
     }
 
     if (this.props.hasDetailPanel) {
-      const aligment = this.props.detailPanelColumnAlignment;
-      const index = aligment === "left" ? 0 : columns.length;
+      const alignment = this.props.detailPanelColumnAlignment;
+      const index = alignment === "left" ? 0 : columns.length;
       columns.splice(
         index,
         0,

--- a/src/components/m-table-filter-row.js
+++ b/src/components/m-table-filter-row.js
@@ -246,8 +246,10 @@ class MTableFilterRow extends React.Component {
     }
 
     if (this.props.hasDetailPanel) {
+      const aligment = this.props.detailPanelColumnAlignment;
+      const index = aligment === "left" ? 0 : columns.length;
       columns.splice(
-        0,
+        index,
         0,
         <TableCell padding="none" key="key-detail-panel-column" />
       );
@@ -284,6 +286,7 @@ class MTableFilterRow extends React.Component {
 
 MTableFilterRow.defaultProps = {
   columns: [],
+  detailPanelColumnAlignment: "left",
   selection: false,
   hasActions: false,
   localization: {
@@ -295,6 +298,7 @@ MTableFilterRow.defaultProps = {
 MTableFilterRow.propTypes = {
   columns: PropTypes.array.isRequired,
   hasDetailPanel: PropTypes.bool.isRequired,
+  detailPanelColumnAlignment: PropTypes.string,
   isTreeData: PropTypes.bool.isRequired,
   onFilterChanged: PropTypes.func.isRequired,
   filterCellStyle: PropTypes.object,


### PR DESCRIPTION
## Related Issue
#1538 

## Description

Filter row gets misaligned when the details panel column is aligned right.

## Related PRs

N/A

## Impacted Areas in Application

* m-table-filter-row.js
* m-table-body.js

## Additional Notes

![filter-misalignment](https://user-images.githubusercontent.com/60660388/89725774-9d184c00-d9d8-11ea-9066-ac3f103a9f85.png)
