### PR TITLE
Allow falsy value as initialEditValue

### DIFF
--- a/src/components/m-table-edit-row.js
+++ b/src/components/m-table-edit-row.js
@@ -21,11 +21,7 @@ export default class MTableEditRow extends React.Component {
 
   createRowData() {
     return this.props.columns
-      .filter(
-        (column) =>
-          (column.initialEditValue || column.initialEditValue === 0) &&
-          column.field
-      )
+      .filter((column) => "initialEditValue" in column && column.field)
       .reduce((prev, column) => {
         prev[column.field] = column.initialEditValue;
         return prev;


### PR DESCRIPTION
## Related Issue

#1163
#1355

## Description

Currently falsy values except `0` are ignored as `initialEditValue`. This PR allows falsy values including `false` and `undefined`.

## Related PRs

#1177

## Impacted Areas in Application

* table-edit-row