### PR TITLE
bump jspdf to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "debounce": "^1.2.0",
     "fast-deep-equal": "2.0.1",
     "filefy": "0.1.10",
-    "jspdf": "1.5.3",
+    "jspdf": "2.0.0",
     "jspdf-autotable": "3.5.3",
     "prop-types": "^15.6.2",
     "react-beautiful-dnd": "^13.0.0",


### PR DESCRIPTION
## Related Issue

#2109 #2137 

## Description

jspdf got a new [2.0.0 release ](https://github.com/MrRio/jsPDF/releases/tag/v2.0.0) 

## Impacted Areas in Application

Im not really sure if it's affected, maybe export to pdf only.

## Additional Notes

Maybe jspdf should be optional for the lib as I've seen in some other issues. If there is some plan for that this will fixe related issues while it's not implemented.
