### PR TITLE
Upgrade jspdf and jspdf-autoTable dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,8 +82,8 @@
     "debounce": "^1.2.0",
     "fast-deep-equal": "2.0.1",
     "filefy": "0.1.10",
-    "jspdf": "1.5.3",
-    "jspdf-autotable": "3.5.3",
+    "jspdf": "2.0.0",
+    "jspdf-autotable": "3.5.9",
     "prop-types": "^15.6.2",
     "react-beautiful-dnd": "^13.0.0",
     "react-double-scrollbar": "0.0.15"

--- a/src/components/m-table-toolbar.js
+++ b/src/components/m-table-toolbar.js
@@ -16,7 +16,7 @@ import { CsvBuilder } from "filefy";
 import PropTypes, { oneOf } from "prop-types";
 import "jspdf-autotable";
 import * as React from "react";
-const jsPDF = typeof window !== "undefined" ? require("jspdf") : null;
+const jsPDF = typeof window !== "undefined" ? require("jspdf").jsPDF : null;
 /* eslint-enable no-unused-vars */
 
 export class MTableToolbar extends React.Component {


### PR DESCRIPTION
## Related Issue

#2109 #2137 

## Description

Upgraded jsPDF to next version.

This removes the FileSaver GitHub dependency that was preventing people from upgrading to next version of material-table.

https://github.com/MrRio/jsPDF/issues/2208

## Impacted Areas in Application

m-table-toolbar

## Additional Notes

The require statement within m-table-toolbar.js has been edited as jsPDF is no-longer a default export in v2.0.0 (see https://github.com/MrRio/jsPDF/releases/tag/v2.0.0).

AutoTable also needed to be upgraded to support jsPDF 2.0.0 (see https://github.com/simonbengtsson/jsPDF-AutoTable/releases/tag/v3.5.9).