### PR TITLE
Removal of onBulkEditRowChanged from spreaded props

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -539,9 +539,10 @@ class App extends Component {
                       new Promise((resolve, reject) => {
                         setTimeout(() => {
                           {
-                            /* const data = this.state.data;
-                            data.push(newData);
-                            this.setState({ data }, () => resolve()); */
+                            /*
+                            const data = [...this.state.data, newData];
+                            this.setState({ data }, () => resolve());
+                            */
                           }
                           resolve();
                         }, 1000);
@@ -550,10 +551,10 @@ class App extends Component {
                       new Promise((resolve, reject) => {
                         setTimeout(() => {
                           {
-                            /* const data = this.state.data;
-                            const index = data.indexOf(oldData);
-                            data[index] = newData;
-                            this.setState({ data }, () => resolve()); */
+                            /*
+                            const data = this.state.data.filter(d => d !== oldData);
+                            this.setState({ data: [...data, newData] }, () => resolve());
+                            */
                           }
                           resolve();
                         }, 1000);
@@ -562,10 +563,10 @@ class App extends Component {
                       new Promise((resolve, reject) => {
                         setTimeout(() => {
                           {
-                            /* let data = this.state.data;
-                            const index = data.indexOf(oldData);
-                            data.splice(index, 1);
-                            this.setState({ data }, () => resolve()); */
+                            /*
+                            const data = this.state.data.filter(d => d !== oldData);
+                            this.setState({ data }, () => resolve());
+                            */
                           }
                           resolve();
                         }, 1000);

--- a/src/components/m-table-edit-field.js
+++ b/src/components/m-table-edit-field.js
@@ -23,6 +23,7 @@ class MTableEditField extends React.Component {
       rowData,
       onRowDataChange,
       errorState,
+      onBulkEditRowChanged,
       ...props
     } = this.props;
     return props;

--- a/src/components/m-table-edit-row.js
+++ b/src/components/m-table-edit-row.js
@@ -359,6 +359,7 @@ export default class MTableEditRow extends React.Component {
       options,
       actions,
       errorState,
+      onBulkEditRowChanged,
       ...rowProps
     } = this.props;
 

--- a/src/components/m-table-edit-row.js
+++ b/src/components/m-table-edit-row.js
@@ -142,14 +142,18 @@ export default class MTableEditRow extends React.Component {
                   const data = { ...this.state.data };
                   setByString(data, columnDef.field, value);
                   // data[columnDef.field] = value;
-                  this.setState({ data }, () =>
-                    this.props.onBulkEditRowChanged(this.props.data, data)
-                  );
+                  this.setState({ data }, () => {
+                    if (this.props.onBulkEditRowChanged) {
+                      this.props.onBulkEditRowChanged(this.props.data, data);
+                    }
+                  });
                 }}
                 onRowDataChange={(data) => {
-                  this.setState({ data }, () =>
-                    this.props.onBulkEditRowChanged(this.props.data, data)
-                  );
+                  this.setState({ data }, () => {
+                    if (this.props.onBulkEditRowChanged) {
+                      this.props.onBulkEditRowChanged(this.props.data, data);
+                    }
+                  });
                 }}
               />
             </TableCell>


### PR DESCRIPTION
## Related Issue

Fixes #2284, fixes #2304, fixes #2276, fixes #2269

## Description

This removes the unnecessary spreading of onBulkEditRowChanged from the editRow and editCell.
Also it fixes the breaking error if onBulkEditRowChanged is not passed during add/edit.
It also improves the demo add/edit code.

## Impacted Areas in Application

List general components of the application that this PR will affect:

* Demo
* EditField
* EditRow

## Additional Notes

@mbrn I think is will be really important to be fixes fast, because the add/edit functionally does not work currently.
