### PR TITLE
Remote-data orderby always -1 fix, issue #2177

### DIFF
--- a/src/material-table.js
+++ b/src/material-table.js
@@ -99,9 +99,9 @@ export default class MaterialTable extends React.Component {
 
     // If the columns changed and the defaultSorting differs from the current sorting, it will trigger a new sorting
     const shouldReorder =
-      isInit ||
-      (defaultSortColumnIndex !== this.dataManager.orderBy &&
-        defaultSortDirection !== this.dataManager.orderDirection);
+      isInit &&
+      defaultSortColumnIndex !== this.dataManager.orderBy &&
+      defaultSortDirection !== this.dataManager.orderDirection;
     shouldReorder &&
       this.dataManager.changeOrder(
         defaultSortColumnIndex,


### PR DESCRIPTION
## Related Issue

Remote data orderBy always use the default value of -1, shouldReload been triggered again after click passing default values again. 

Related issue: https://github.com/mbrn/material-table/issues/2177
