### PR TITLE
Option to disable export pdf button

### DIFF
--- a/src/components/m-table-toolbar.js
+++ b/src/components/m-table-toolbar.js
@@ -259,9 +259,11 @@ export class MTableToolbar extends React.Component {
               <MenuItem key="export-csv" onClick={this.exportCsv}>
                 {localization.exportCSVName}
               </MenuItem>
-              <MenuItem key="export-pdf" onClick={this.exportPdf}>
-                {localization.exportPDFName}
-              </MenuItem>
+              {this.props.isExportPdf && (
+                <MenuItem key="export-pdf" onClick={this.exportPdf}>
+                  {localization.exportPDFName}
+                </MenuItem>
+              )}
             </Menu>
           </span>
         )}
@@ -424,6 +426,7 @@ MTableToolbar.propTypes = {
   exportFileName: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
   exportCsv: PropTypes.func,
   exportPdf: PropTypes.func,
+  isExportPdf: PropTypes.bool,
   classes: PropTypes.object,
   searchAutoFocus: PropTypes.bool,
 };

--- a/src/default-props.js
+++ b/src/default-props.js
@@ -198,6 +198,7 @@ export const defaultProps = {
     emptyRowsWhenPaging: true,
     exportAllData: false,
     exportButton: false,
+    isExportPdf: true,
     exportDelimiter: ",",
     filtering: false,
     groupTitle: false,

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -980,6 +980,7 @@ export default class MaterialTable extends React.Component {
               exportFileName={props.options.exportFileName}
               exportCsv={props.options.exportCsv}
               exportPdf={props.options.exportPdf}
+              isExportPdf={props.options.isExportPdf}
               getFieldValue={this.dataManager.getFieldValue}
               data={this.state.data}
               renderData={this.state.renderData}

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -312,6 +312,7 @@ export const propTypes = {
     exportDelimiter: PropTypes.string,
     exportFileName: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
     exportCsv: PropTypes.func,
+    isExportPdf: PropTypes.bool,
     filtering: PropTypes.bool,
     filterCellStyle: PropTypes.object,
     filterRowStyle: PropTypes.object,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -308,6 +308,7 @@ export interface Options<RowData extends object> {
     | string
     | ((columns: Column<RowData>, data: string[][]) => string);
   exportCsv?: (columns: any[], renderData: any[]) => void;
+  isExportPdf?: boolean;
   filtering?: boolean;
   filterCellStyle?: React.CSSProperties;
   filterRowStyle?: React.CSSProperties;


### PR DESCRIPTION
## Related Issue
#2216 

## Description
By default when `exportButton` is true it will display export PDF and CSV. If you want to disable export pdf button you can set `isExportPdf: false`

## Related PRs
<img width="426" alt="export" src="https://user-images.githubusercontent.com/40540002/90569419-8cd73e00-e149-11ea-8b58-29da3f6454b2.png">

List related PRs against other branches:

| branch              | PR       |
| ------------------- | -------- |
| other_pr_production | [link]() |
| other_pr_master     | [link]() |

## Impacted Areas in Application

List general components of the application that this PR will affect:

\*

## Additional Notes
This is my first open-source contribution. Let me know if this commit worth merging into master and feel free to make any comments or give me your feedback that can be improved.
 
This is optional, feel free to follow your hearth and write here :)
