### PR TITLE
Add group selection

### DIFF
--- a/src/components/m-table-body.js
+++ b/src/components/m-table-body.js
@@ -159,6 +159,7 @@ class MTableBody extends React.Component {
         path={[index + this.props.pageSize * this.props.currentPage]}
         onGroupExpandChanged={this.props.onGroupExpandChanged}
         onRowSelected={this.props.onRowSelected}
+        onGroupSelected={this.props.onGroupSelected}
         onRowClick={this.props.onRowClick}
         onEditingCanceled={this.props.onEditingCanceled}
         onEditingApproved={this.props.onEditingApproved}
@@ -316,6 +317,7 @@ MTableBody.propTypes = {
   icons: PropTypes.object.isRequired,
   isTreeData: PropTypes.bool.isRequired,
   onRowSelected: PropTypes.func,
+  onGroupSelected: PropTypes.func,
   options: PropTypes.object.isRequired,
   pageSize: PropTypes.number,
   renderData: PropTypes.array,

--- a/src/components/m-table-group-row.js
+++ b/src/components/m-table-group-row.js
@@ -2,6 +2,7 @@
 import TableCell from "@material-ui/core/TableCell";
 import TableRow from "@material-ui/core/TableRow";
 import IconButton from "@material-ui/core/IconButton";
+import Checkbox from "@material-ui/core/Checkbox";
 import PropTypes from "prop-types";
 import * as React from "react";
 /* eslint-enable no-unused-vars */
@@ -37,6 +38,7 @@ export default class MTableGroupRow extends React.Component {
             level={this.props.level + 1}
             path={[...this.props.path, index]}
             onGroupExpandChanged={this.props.onGroupExpandChanged}
+            onGroupSelected={this.props.onGroupSelected}
             onRowSelected={this.props.onRowSelected}
             onRowClick={this.props.onRowClick}
             onToggleDetailPanel={this.props.onToggleDetailPanel}
@@ -123,6 +125,35 @@ export default class MTableGroupRow extends React.Component {
 
     let separator = this.props.options.groupRowSeparator || ": ";
 
+    const showSelectGroupCheckbox =
+      this.props.options.selection &&
+      this.props.options.showSelectGroupCheckbox;
+
+    const mapSelectedRows = (groupData) => {
+      let totalRows = 0;
+      let selectedRows = 0;
+
+      if (showSelectGroupCheckbox) {
+        if (groupData.data.length) {
+          totalRows += groupData.data.length;
+          groupData.data.forEach(
+            (row) => row.tableData.checked && selectedRows++
+          );
+        } else {
+          groupData.groups.forEach((group) => {
+            const [groupTotalRows, groupSelectedRows] = mapSelectedRows(group);
+
+            totalRows += groupTotalRows;
+            selectedRows += groupSelectedRows;
+          });
+        }
+      }
+
+      return [totalRows, selectedRows];
+    };
+
+    const [totalRows, selectedRows] = mapSelectedRows(this.props.groupData);
+
     return (
       <>
         <TableRow>
@@ -145,6 +176,17 @@ export default class MTableGroupRow extends React.Component {
             >
               <this.props.icons.DetailPanel />
             </IconButton>
+            {showSelectGroupCheckbox && (
+              <Checkbox
+                indeterminate={selectedRows > 0 && totalRows !== selectedRows}
+                checked={totalRows === selectedRows}
+                onChange={(event, checked) =>
+                  this.props.onGroupSelected &&
+                  this.props.onGroupSelected(checked, this.props.path)
+                }
+                style={{ marginRight: 8 }}
+              />
+            )}
             <b>
               {title}
               {separator}
@@ -182,6 +224,7 @@ MTableGroupRow.propTypes = {
   localization: PropTypes.object,
   onGroupExpandChanged: PropTypes.func,
   onRowSelected: PropTypes.func,
+  onGroupSelected: PropTypes.func,
   onRowClick: PropTypes.func,
   onToggleDetailPanel: PropTypes.func.isRequired,
   onTreeExpandChanged: PropTypes.func.isRequired,

--- a/src/components/m-table-group-row.js
+++ b/src/components/m-table-group-row.js
@@ -182,7 +182,7 @@ export default class MTableGroupRow extends React.Component {
                 checked={totalRows === selectedRows}
                 onChange={(event, checked) =>
                   this.props.onGroupSelected &&
-                  this.props.onGroupSelected(checked, this.props.path)
+                  this.props.onGroupSelected(checked, this.props.groupData.path)
                 }
                 style={{ marginRight: 8 }}
               />

--- a/src/default-props.js
+++ b/src/default-props.js
@@ -215,6 +215,7 @@ export const defaultProps = {
     showEmptyDataSourceMessage: true,
     showFirstLastPageButtons: true,
     showSelectAllCheckbox: true,
+    showSelectGroupCheckbox: true,
     search: true,
     showTitle: true,
     showTextRowsSelected: true,

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -325,6 +325,13 @@ export default class MaterialTable extends React.Component {
     );
   };
 
+  onGroupSelected = (checked, path) => {
+    this.dataManager.changeGroupSelected(checked, path);
+    this.setState(this.dataManager.getRenderState(), () =>
+      this.onSelectionChange()
+    );
+  };
+
   onChangeColumnHidden = (column, hidden) => {
     this.dataManager.changeColumnHidden(column, hidden);
     this.setState(this.dataManager.getRenderState(), () => {
@@ -846,6 +853,7 @@ export default class MaterialTable extends React.Component {
             ).length > 0
           }
           showSelectAllCheckbox={props.options.showSelectAllCheckbox}
+          showSelectGroupCheckbox={props.options.showSelectGroupCheckbox}
           orderBy={this.state.orderBy}
           orderDirection={this.state.orderDirection}
           onAllSelected={this.onAllSelected}
@@ -876,6 +884,7 @@ export default class MaterialTable extends React.Component {
         isTreeData={this.props.parentChildData !== undefined}
         onFilterChanged={this.onFilterChange}
         onRowSelected={this.onRowSelected}
+        onGroupSelected={this.onGroupSelected}
         onToggleDetailPanel={this.onToggleDetailPanel}
         onGroupExpandChanged={this.onGroupExpandChanged}
         onTreeExpandChanged={this.onTreeExpandChanged}

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -350,6 +350,7 @@ export const propTypes = {
     showEmptyDataSourceMessage: PropTypes.bool,
     showFirstLastPageButtons: PropTypes.bool,
     showSelectAllCheckbox: PropTypes.bool,
+    showSelectGroupCheckbox: PropTypes.bool,
     showTitle: PropTypes.bool,
     showTextRowsSelected: PropTypes.bool,
     sorting: PropTypes.bool,

--- a/src/utils/data-manager.js
+++ b/src/utils/data-manager.js
@@ -242,6 +242,33 @@ export default class DataManager {
     this.selectedCount = checked ? selectedCount : 0;
   }
 
+  changeGroupSelected = (checked, path) => {
+    let currentGroup;
+    let currentGroupArray = this.groupedData;
+
+    path.forEach((_, index) => {
+      currentGroup = currentGroupArray[path[index]];
+      currentGroupArray = currentGroup.groups;
+    });
+
+    const setCheck = (data) => {
+      data.forEach((element) => {
+        if (element.groups.length > 0) {
+          setCheck(element.groups);
+        } else {
+          element.data.forEach((d) => {
+            if (d.tableData.checked != checked) {
+              d.tableData.checked = d.tableData.disabled ? false : checked;
+              this.selectedCount = this.selectedCount + (checked ? 1 : -1);
+            }
+          });
+        }
+      });
+    };
+
+    setCheck([currentGroup]);
+  };
+
   changeOrder(orderBy, orderDirection) {
     this.orderBy = orderBy;
     this.orderDirection = orderDirection;

--- a/src/utils/data-manager.js
+++ b/src/utils/data-manager.js
@@ -246,8 +246,8 @@ export default class DataManager {
     let currentGroup;
     let currentGroupArray = this.groupedData;
 
-    path.forEach((_, index) => {
-      currentGroup = currentGroupArray[path[index]];
+    path.forEach((value) => {
+      currentGroup = currentGroupArray.find((group) => group.value == value);
       currentGroupArray = currentGroup.groups;
     });
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -336,6 +336,7 @@ export interface Options<RowData extends object> {
   showEmptyDataSourceMessage?: boolean;
   showFirstLastPageButtons?: boolean;
   showSelectAllCheckbox?: boolean;
+  showSelectGroupCheckbox?: boolean;
   showTitle?: boolean;
   showTextRowsSelected?: boolean;
   search?: boolean;


### PR DESCRIPTION
## Related Issue

resolves #503
resolves #2314 
relates to #1017

## Description

Group selection has been added to allow users to select all rows within a given group.

This feature is enabled by default when selection is enabled along with grouping, however, it can be toggled off by setting the 'showSelectGroupCheckbox' option to false.

## Impacted Areas in Application

MTableGroupRow

## Additional Notes

I'm aware that you've requested for people to not make pull requests with many changes, so I'm happy for this to be put on hold if needed. Thanks

![group selection](https://user-images.githubusercontent.com/46567570/90806476-f8b9d200-e314-11ea-8987-6ea8ec35a632.PNG)