### PR TITLE
Fix styling value error when grouping

### DIFF
--- a/src/components/m-table-body.js
+++ b/src/components/m-table-body.js
@@ -156,6 +156,7 @@ class MTableBody extends React.Component {
         groups={groups}
         icons={this.props.icons}
         level={0}
+        treeDataMaxLevel={this.props.treeDataMaxLevel}
         path={[index + this.props.pageSize * this.props.currentPage]}
         onGroupExpandChanged={this.props.onGroupExpandChanged}
         onRowSelected={this.props.onRowSelected}

--- a/src/components/m-table-group-row.js
+++ b/src/components/m-table-group-row.js
@@ -35,6 +35,7 @@ export default class MTableGroupRow extends React.Component {
             groups={this.props.groups}
             icons={this.props.icons}
             level={this.props.level + 1}
+            treeDataMaxLevel={this.props.treeDataMaxLevel}
             path={[...this.props.path, index]}
             onGroupExpandChanged={this.props.onGroupExpandChanged}
             onRowSelected={this.props.onRowSelected}
@@ -78,6 +79,7 @@ export default class MTableGroupRow extends React.Component {
               <this.props.components.Row
                 actions={this.props.actions}
                 key={index}
+                level={this.props.level + 1}
                 columns={this.props.columns}
                 components={this.props.components}
                 data={rowData}
@@ -92,6 +94,7 @@ export default class MTableGroupRow extends React.Component {
                 isTreeData={this.props.isTreeData}
                 onTreeExpandChanged={this.props.onTreeExpandChanged}
                 onEditingCanceled={this.props.onEditingCanceled}
+                treeDataMaxLevel={this.props.treeDataMaxLevel}
                 onEditingApproved={this.props.onEditingApproved}
                 hasAnyEditingRow={this.props.hasAnyEditingRow}
                 cellEditable={this.props.cellEditable}
@@ -189,6 +192,7 @@ MTableGroupRow.propTypes = {
   onEditingApproved: PropTypes.func,
   options: PropTypes.object,
   path: PropTypes.arrayOf(PropTypes.number),
+  treeDataMaxLevel: PropTypes.number,
   cellEditable: PropTypes.object,
   onCellEditStarted: PropTypes.func,
   onCellEditFinished: PropTypes.func,


### PR DESCRIPTION
## Related Issue

Fixes #1707

## Description

It appears that this issue has been fixed in the past by [this commit](https://github.com/mbrn/material-table/pull/1759/commits/c1a8806cd33d4d0f52ed6d6d4f7ccfd5d18e9b31), however, it has since been reverted by [this commit](https://github.com/mbrn/material-table/commit/0249979b6d912fa9d9f75a6a579cc3df66d6c5c5).

Although this commit did fix the issue, I don't believe it tackled the root cause of the error which I believe was a missing property on the m-table-group-row component.

## Related PRs

The PR containing the previous fix:

| branch              | PR       |
| ------------------- | -------- |
| oze4:master| [link](https://github.com/mbrn/material-table/pull/1759) |

## Impacted Areas in Application

- m-table-group-row.js