### PR TITLE
support export all remote data

### DIFF
--- a/src/components/m-table-toolbar.js
+++ b/src/components/m-table-toolbar.js
@@ -46,7 +46,7 @@ export class MTableToolbar extends React.Component {
         a.tableData.columnOrder > b.tableData.columnOrder ? 1 : -1
       );
     const data = (this.props.exportAllData
-      ? await this.getAllData()
+      ? await Promise.resolve(this.getAllData())
       : this.props.renderData
     ).map((rowData) =>
       columns.map((columnDef) => this.props.getFieldValue(rowData, columnDef))
@@ -55,22 +55,10 @@ export class MTableToolbar extends React.Component {
     return [columns, data];
   };
 
-  getAllData = async () => {
-    if (typeof this.props.remoteDataGetter !== "function")
-      return this.props.data;
-    let total = 0,
-      size = 0,
-      page = 0;
-    const allData = [];
-    do {
-      const { data, pageSize, totalCount } = await this.props.remoteDataGetter(
-        page++
-      );
-      total = totalCount;
-      size = pageSize;
-      allData.push(...data);
-    } while (total !== 0 && size !== 0 && page * size < total);
-    return allData;
+  getAllData = () => {
+    if (typeof this.props.remoteDataGetter === "function")
+      return this.props.remoteDataGetter();
+    else return this.props.data;
   };
 
   defaultExportCsv = async () => {

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -982,6 +982,24 @@ export default class MaterialTable extends React.Component {
               exportPdf={props.options.exportPdf}
               getFieldValue={this.dataManager.getFieldValue}
               data={this.state.data}
+              remoteDataGetter={
+                this.isRemoteData()
+                  ? async (page) => {
+                      const { query } = this.state,
+                        { pageSize } = query;
+                      const result = await Promise.resolve(
+                        props.data({
+                          ...query,
+                          page,
+                        })
+                      );
+                      return {
+                        ...result,
+                        pageSize,
+                      };
+                    }
+                  : null
+              }
               renderData={this.state.renderData}
               search={props.options.search}
               showTitle={props.options.showTitle}

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -984,19 +984,18 @@ export default class MaterialTable extends React.Component {
               data={this.state.data}
               remoteDataGetter={
                 this.isRemoteData()
-                  ? async (page) => {
+                  ? async () => {
                       const { query } = this.state,
-                        { pageSize } = query;
-                      const result = await Promise.resolve(
+                        { totalCount } = query;
+                      const { data } = await Promise.resolve(
                         props.data({
                           ...query,
-                          page,
+                          page: 0,
+                          pageSize: totalCount,
+                          totalCount,
                         })
                       );
-                      return {
-                        ...result,
-                        pageSize,
-                      };
+                      return data;
                     }
                   : null
               }


### PR DESCRIPTION
## Related Issue

N/A

## Description

Currently, the default export functions export data loaded on the current page.
Even when `exportAllData: true`, the table exports the rendered remote data only (on the current page).
This patch allows it to get all remote data for export.

## Additional Notes

Not sure if async/await is allow to use :)
