### PR TITLE
Restore editvalues on bulk edit paging

### DIFF
--- a/src/components/m-table-body-row.js
+++ b/src/components/m-table-body-row.js
@@ -317,7 +317,12 @@ export default class MTableBodyRow extends React.Component {
     if (typeof this.props.options.rowStyle === "function") {
       style = {
         ...style,
-        ...this.props.options.rowStyle(this.props.data, index, level, this.props.hasAnyEditingRow),
+        ...this.props.options.rowStyle(
+          this.props.data,
+          index,
+          level,
+          this.props.hasAnyEditingRow
+        ),
       };
     } else if (this.props.options.rowStyle) {
       style = {
@@ -331,7 +336,7 @@ export default class MTableBodyRow extends React.Component {
     }
 
     if (this.props.hasAnyEditingRow) {
-      style.opacity = (style.opacity) ? style.opacity : 0.2;
+      style.opacity = style.opacity ? style.opacity : 0.2;
     }
 
     return style;

--- a/src/components/m-table-body.js
+++ b/src/components/m-table-body.js
@@ -183,6 +183,13 @@ class MTableBody extends React.Component {
 
   render() {
     let renderData = this.props.renderData;
+    if (this.props.bulkEditOpen) {
+      renderData.forEach((data) => {
+        this.props.columns.forEach((column) => {
+          data[column.field] = this.props.getFieldValue(data, column);
+        });
+      });
+    }
     const groups = this.props.columns
       .filter((col) => col.tableData.groupOrder > -1)
       .sort(

--- a/src/components/m-table-body.js
+++ b/src/components/m-table-body.js
@@ -101,6 +101,7 @@ class MTableBody extends React.Component {
             onEditingApproved={this.props.onEditingApproved}
             getFieldValue={this.props.getFieldValue}
             onBulkEditRowChanged={this.props.onBulkEditRowChanged}
+            bulkEditChangedRows={this.props.bulkEditChangedRows}
           />
         );
       } else {
@@ -182,14 +183,8 @@ class MTableBody extends React.Component {
   }
 
   render() {
-    let renderData = this.props.renderData;
-    if (this.props.bulkEditOpen) {
-      renderData.forEach((data) => {
-        this.props.columns.forEach((column) => {
-          data[column.field] = this.props.getFieldValue(data, column);
-        });
-      });
-    }
+    const renderData = this.props.renderData;
+
     const groups = this.props.columns
       .filter((col) => col.tableData.groupOrder > -1)
       .sort(
@@ -344,6 +339,7 @@ MTableBody.propTypes = {
   onCellEditFinished: PropTypes.func,
   bulkEditOpen: PropTypes.bool,
   onBulkEditRowChanged: PropTypes.func,
+  bulkEditChangedRows: PropTypes.array,
 };
 
 export default MTableBody;

--- a/src/components/m-table-edit-row.js
+++ b/src/components/m-table-edit-row.js
@@ -11,11 +11,16 @@ import * as CommonValues from "../utils/common-values";
 export default class MTableEditRow extends React.Component {
   constructor(props) {
     super(props);
+    let data = props.data
+      ? JSON.parse(JSON.stringify(props.data))
+      : this.createRowData();
+
+    if (props.mode === "bulk" && props.bulkEditChangedRows[data.tableData.id]) {
+      data = props.bulkEditChangedRows[data.tableData.id].newData;
+    }
 
     this.state = {
-      data: props.data
-        ? JSON.parse(JSON.stringify(props.data))
-        : this.createRowData(),
+      data,
     };
   }
 
@@ -410,4 +415,6 @@ MTableEditRow.propTypes = {
   getFieldValue: PropTypes.func,
   errorState: PropTypes.oneOfType([PropTypes.object, PropTypes.bool]),
   onBulkEditRowChanged: PropTypes.func,
+  mode: PropTypes.oneOf([PropTypes.bool, "bulk"]),
+  bulkEditChangedRows: PropTypes.array,
 };

--- a/src/components/m-table-toolbar.js
+++ b/src/components/m-table-toolbar.js
@@ -256,12 +256,14 @@ export class MTableToolbar extends React.Component {
               open={Boolean(this.state.exportButtonAnchorEl)}
               onClose={() => this.setState({ exportButtonAnchorEl: null })}
             >
-              {(this.props.exportButton === true || this.props.exportButton.csv ) && (
+              {(this.props.exportButton === true ||
+                this.props.exportButton.csv) && (
                 <MenuItem key="export-csv" onClick={this.exportCsv}>
                   {localization.exportCSVName}
                 </MenuItem>
               )}
-              {(this.props.exportButton === true || this.props.exportButton.pdf ) && (
+              {(this.props.exportButton === true ||
+                this.props.exportButton.pdf) && (
                 <MenuItem key="export-pdf" onClick={this.exportPdf}>
                   {localization.exportPDFName}
                 </MenuItem>
@@ -423,7 +425,10 @@ MTableToolbar.propTypes = {
   renderData: PropTypes.array,
   data: PropTypes.array,
   exportAllData: PropTypes.bool,
-  exportButton: PropTypes.oneOfType([PropTypes.bool, PropTypes.shape({ csv: PropTypes.bool, pdf: PropTypes.bool })]),
+  exportButton: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.shape({ csv: PropTypes.bool, pdf: PropTypes.bool }),
+  ]),
   exportDelimiter: PropTypes.string,
   exportFileName: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
   exportCsv: PropTypes.func,

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -897,6 +897,7 @@ export default class MaterialTable extends React.Component {
         onCellEditFinished={this.onCellEditFinished}
         bulkEditOpen={this.dataManager.bulkEditOpen}
         onBulkEditRowChanged={this.dataManager.onBulkEditRowChanged}
+        bulkEditChangedRows={this.dataManager.bulkEditChangedRows}
       />
     </Table>
   );

--- a/src/utils/data-manager.js
+++ b/src/utils/data-manager.js
@@ -488,7 +488,11 @@ export default class DataManager {
     if (columnDef.lookup && lookup) {
       value = columnDef.lookup[value];
     }
-
+    if (this.bulkEditOpen && this.bulkEditChangedRows[rowData.tableData.id]) {
+      value = this.bulkEditChangedRows[rowData.tableData.id].newData[
+        columnDef.field
+      ];
+    }
     return value;
   };
 

--- a/src/utils/data-manager.js
+++ b/src/utils/data-manager.js
@@ -488,11 +488,6 @@ export default class DataManager {
     if (columnDef.lookup && lookup) {
       value = columnDef.lookup[value];
     }
-    if (this.bulkEditOpen && this.bulkEditChangedRows[rowData.tableData.id]) {
-      value = this.bulkEditChangedRows[rowData.tableData.id].newData[
-        columnDef.field
-      ];
-    }
     return value;
   };
 


### PR DESCRIPTION
## Description

This PR adds the restoring of the bulkEdited values on paging.
Without this, the default values are shown if the user navigates back to previously edited page, instead of the edited value.

For that, to access the current bulk editValue, getFieldValue is modified to return the last bulk edit data if data is present.
This returned value updates the passed renderData to show these new last edited values.

## Impacted Areas in Application

List general components of the application that this PR will affect:

* TableBody
* Data-Manager