### PR TITLE
Add types for localization of the export button

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -399,7 +399,6 @@ export interface Localization {
     showColumnsAriaLabel?: string;
     exportTitle?: React.ReactNode;
     exportAriaLabel?: string;
-    exportName?: React.ReactNode;
     exportCSVName?:React.ReactNode;
     exportPDFName?:React.ReactNode;
     searchTooltip?: React.ReactNode;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -400,6 +400,8 @@ export interface Localization {
     exportTitle?: React.ReactNode;
     exportAriaLabel?: string;
     exportName?: React.ReactNode;
+    exportCSVName?:React.ReactNode;
+    exportPDFName?:React.ReactNode;
     searchTooltip?: React.ReactNode;
     searchPlaceholder?: React.ReactNode;
   };


### PR DESCRIPTION
## Description

Edited for better typescript support

- Add typescript types for `localization.toolbar.exportPDFName` and `localization.toolbar.exportPDFName`.
- Remove unused type `localization.toolbar.exportName`

## Impacted Areas in Application

- `types/index.d.ts`
- `src/components/m-table-toolbar.js`