### PR TITLE
Added Feature - Multiple rows update in parallel

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -473,6 +473,8 @@ class App extends Component {
     ],
   };
 
+  // getCopyOfSelectedRows = () => JSON.parse(JSON.stringify(this.state.data.filter(row => row.tableData.checked)));
+
   render() {
     return (
       <>
@@ -567,11 +569,21 @@ class App extends Component {
                   //         resolve();
                   //       }, 1000);
                   //     }),
-                  //   onMultipleRowsUpdate: (newData) => new Promise((resolve, reject) => {
+                  //   onMultipleRowsUpdate: (multipleRowsEditChanges) => new Promise((resolve, reject) => {
                   //     setTimeout(() => {
                   //       {
-                  //       /* this.setState({ data: newData }, () => resolve()); */
+                  //         // const selectedRows = this.getCopyOfSelectedRows();
+                  //         // const newData = this.state.data.map((_data) => {
+                  //         //   if (selectedRows.some(row => row.id === _data.id)) {
+                  //         //     Object.keys(multipleRowsEditChanges).forEach((key) => {
+                  //         //       _data[key] = multipleRowsEditChanges[key];
+                  //         //     });
+                  //         //   }
+                  //         //   return _data;
+                  //         // });
+                  //         // this.setState({ data: newData }, () => resolve());
                   //       }
+
                   //       resolve();
                   //     }, 1000);
                   //   }),

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -428,14 +428,15 @@ class App extends Component {
         filterPlaceholder: "Adı filter",
         tooltip: "This is tooltip text",
         editPlaceholder: "This is placeholder",
+        maxWidth: 50,
       },
       {
-        width: 200,
         title: "Soyadı",
         field: "surname",
         initialEditValue: "test",
         tooltip: "This is tooltip text",
         editable: "never",
+        resizable: false,
       },
       { title: "Evli", field: "isMarried" },
       {
@@ -453,12 +454,6 @@ class App extends Component {
       },
       { title: "Kayıt Tarihi", field: "insertDateTime", type: "datetime" },
       { title: "Zaman", field: "time", type: "time" },
-      {
-        title: "Adı",
-        field: "name",
-        filterPlaceholder: "Adı filter",
-        tooltip: "This is tooltip text",
-      },
     ],
     remoteColumns: [
       {
@@ -509,6 +504,8 @@ class App extends Component {
                   //   },
                   // }}
                   options={{
+                    tableLayout: "fixed",
+                    columnResizable: true,
                     headerSelectionProps: {
                       color: "primary",
                     },
@@ -522,63 +519,63 @@ class App extends Component {
                       };
                     },
                   }}
-                  editable={{
-                    onBulkUpdate: (changedRows) =>
-                      new Promise((resolve, reject) => {
-                        console.log(changedRows);
-                        setTimeout(() => {
-                          {
-                            /* const data = this.state.data;
-                            data.push(newData);
-                            this.setState({ data }, () => resolve()); */
-                          }
-                          resolve();
-                        }, 1000);
-                      }),
-                    onRowAdd: (newData) =>
-                      new Promise((resolve, reject) => {
-                        setTimeout(() => {
-                          {
-                            /*
-                            const data = [...this.state.data, newData];
-                            this.setState({ data }, () => resolve());
-                            */
-                          }
-                          resolve();
-                        }, 1000);
-                      }),
-                    onRowUpdate: (newData, oldData) =>
-                      new Promise((resolve, reject) => {
-                        setTimeout(() => {
-                          {
-                            /*
-                            const data = this.state.data.filter(d => d !== oldData);
-                            this.setState({ data: [...data, newData] }, () => resolve());
-                            */
-                          }
-                          resolve();
-                        }, 1000);
-                      }),
-                    onRowDelete: (oldData) =>
-                      new Promise((resolve, reject) => {
-                        setTimeout(() => {
-                          {
-                            /*
-                            const data = this.state.data.filter(d => d !== oldData);
-                            this.setState({ data }, () => resolve());
-                            */
-                          }
-                          resolve();
-                        }, 1000);
-                      }),
-
-                    onMultipleRowsUpdate: (newData) => new Promise((resolve, reject) => {
-                      setTimeout(() => {
-                        this.setState({ data:newData }, () => resolve());
-                        resolve();
-                      }, 1000);
-                    }),
-                  }}
+                  // editable={{
+                  //   onBulkUpdate: (changedRows) =>
+                  //     new Promise((resolve, reject) => {
+                  //       console.log(changedRows);
+                  //       setTimeout(() => {
+                  //         {
+                  //           /* const data = this.state.data;
+                  //           data.push(newData);
+                  //           this.setState({ data }, () => resolve()); */
+                  //         }
+                  //         resolve();
+                  //       }, 1000);
+                  //     }),
+                  //   onRowAdd: (newData) =>
+                  //     new Promise((resolve, reject) => {
+                  //       setTimeout(() => {
+                  //         {
+                  //           /* const data = this.state.data;
+                  //           data.push(newData);
+                  //           this.setState({ data }, () => resolve()); */
+                  //         }
+                  //         resolve();
+                  //       }, 1000);
+                  //     }),
+                  //   onRowUpdate: (newData, oldData) =>
+                  //     new Promise((resolve, reject) => {
+                  //       setTimeout(() => {
+                  //         {
+                  //           /* const data = this.state.data;
+                  //           const index = data.indexOf(oldData);
+                  //           data[index] = newData;
+                  //           this.setState({ data }, () => resolve()); */
+                  //         }
+                  //         resolve();
+                  //       }, 1000);
+                  //     }),
+                  //   onRowDelete: (oldData) =>
+                  //     new Promise((resolve, reject) => {
+                  //       setTimeout(() => {
+                  //         {
+                  //           /* let data = this.state.data;
+                  //           const index = data.indexOf(oldData);
+                  //           data.splice(index, 1);
+                  //           this.setState({ data }, () => resolve()); */
+                  //         }
+                  //         resolve();
+                  //       }, 1000);
+                  //     }),
+                  //   onMultipleRowsUpdate: (newData) => new Promise((resolve, reject) => {
+                  //     setTimeout(() => {
+                  //       {
+                  //       /* this.setState({ data: newData }, () => resolve()); */
+                  //       }
+                  //       resolve();
+                  //     }, 1000);
+                  //   }),
+                  // }}
                   localization={{
                     body: {
                       emptyDataSourceMessage: "No records to display",
@@ -605,7 +602,7 @@ class App extends Component {
             >
               Select
             </button>
-            <MaterialTable
+            {/* <MaterialTable
               title={
                 <Typography variant="h6" color="primary">
                   Remote Data Preview
@@ -673,7 +670,7 @@ class App extends Component {
                     });
                 })
               }
-            />
+            /> */}
           </div>
         </MuiThemeProvider>
       </>

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -571,6 +571,13 @@ class App extends Component {
                           resolve();
                         }, 1000);
                       }),
+
+                    onMultipleRowsUpdate: (newData) => new Promise((resolve, reject) => {
+                      setTimeout(() => {
+                        this.setState({ data:newData }, () => resolve());
+                        resolve();
+                      }, 1000);
+                    }),
                   }}
                   localization={{
                     body: {

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -473,7 +473,10 @@ class App extends Component {
     ],
   };
 
-  // getCopyOfSelectedRows = () => JSON.parse(JSON.stringify(this.state.data.filter(row => row.tableData.checked)));
+  getCopyOfSelectedRows = () =>
+    JSON.parse(
+      JSON.stringify(this.state.data.filter((row) => row.tableData.checked))
+    );
 
   render() {
     return (
@@ -522,71 +525,75 @@ class App extends Component {
                     },
                   }}
                   // editable={{
-                  //   onBulkUpdate: (changedRows) =>
-                  //     new Promise((resolve, reject) => {
-                  //       console.log(changedRows);
-                  //       setTimeout(() => {
-                  //         {
-                  //           /* const data = this.state.data;
-                  //           data.push(newData);
-                  //           this.setState({ data }, () => resolve()); */
-                  //         }
-                  //         resolve();
-                  //       }, 1000);
-                  //     }),
-                  //   onRowAdd: (newData) =>
-                  //     new Promise((resolve, reject) => {
-                  //       setTimeout(() => {
-                  //         {
-                  //           /* const data = this.state.data;
-                  //           data.push(newData);
-                  //           this.setState({ data }, () => resolve()); */
-                  //         }
-                  //         resolve();
-                  //       }, 1000);
-                  //     }),
-                  //   onRowUpdate: (newData, oldData) =>
-                  //     new Promise((resolve, reject) => {
-                  //       setTimeout(() => {
-                  //         {
-                  //           /* const data = this.state.data;
-                  //           const index = data.indexOf(oldData);
-                  //           data[index] = newData;
-                  //           this.setState({ data }, () => resolve()); */
-                  //         }
-                  //         resolve();
-                  //       }, 1000);
-                  //     }),
-                  //   onRowDelete: (oldData) =>
-                  //     new Promise((resolve, reject) => {
-                  //       setTimeout(() => {
-                  //         {
-                  //           /* let data = this.state.data;
-                  //           const index = data.indexOf(oldData);
-                  //           data.splice(index, 1);
-                  //           this.setState({ data }, () => resolve()); */
-                  //         }
-                  //         resolve();
-                  //       }, 1000);
-                  //     }),
-                  //   onMultipleRowsUpdate: (multipleRowsEditChanges) => new Promise((resolve, reject) => {
+                  // onBulkUpdate: (changedRows) =>
+                  //   new Promise((resolve, reject) => {
+                  //     console.log(changedRows);
                   //     setTimeout(() => {
                   //       {
-                  //         // const selectedRows = this.getCopyOfSelectedRows();
-                  //         // const newData = this.state.data.map((_data) => {
-                  //         //   if (selectedRows.some(row => row.id === _data.id)) {
-                  //         //     Object.keys(multipleRowsEditChanges).forEach((key) => {
-                  //         //       _data[key] = multipleRowsEditChanges[key];
-                  //         //     });
-                  //         //   }
-                  //         //   return _data;
-                  //         // });
-                  //         // this.setState({ data: newData }, () => resolve());
+                  //         /* const data = this.state.data;
+                  //         data.push(newData);
+                  //         this.setState({ data }, () => resolve()); */
                   //       }
-
                   //       resolve();
                   //     }, 1000);
                   //   }),
+                  // onRowAdd: (newData) =>
+                  //   new Promise((resolve, reject) => {
+                  //     setTimeout(() => {
+                  //       {
+                  //         /* const data = this.state.data;
+                  //         data.push(newData);
+                  //         this.setState({ data }, () => resolve()); */
+                  //       }
+                  //       resolve();
+                  //     }, 1000);
+                  //   }),
+                  // onRowUpdate: (newData, oldData) =>
+                  //   new Promise((resolve, reject) => {
+                  //     setTimeout(() => {
+                  //       {
+                  //         /* const data = this.state.data;
+                  //         const index = data.indexOf(oldData);
+                  //         data[index] = newData;
+                  //         this.setState({ data }, () => resolve()); */
+                  //       }
+                  //       resolve();
+                  //     }, 1000);
+                  //   }),
+                  // onRowDelete: (oldData) =>
+                  //   new Promise((resolve, reject) => {
+                  //     setTimeout(() => {
+                  //       {
+                  //         /* let data = this.state.data;
+                  //         const index = data.indexOf(oldData);
+                  //         data.splice(index, 1);
+                  //         this.setState({ data }, () => resolve()); */
+                  //       }
+                  //       resolve();
+                  //     }, 1000);
+                  //   }),
+                  //   onMultipleRowsUpdate: (multipleRowsEditChanges) =>
+                  //     new Promise((resolve, reject) => {
+                  //       setTimeout(() => {
+                  //         {
+                  //           const selectedRows = this.getCopyOfSelectedRows();
+                  //           const newData = this.state.data.map((_data) => {
+                  //             if (
+                  //               selectedRows.some((row) => row.id === _data.id)
+                  //             ) {
+                  //               Object.keys(multipleRowsEditChanges).forEach(
+                  //                 (key) => {
+                  //                   _data[key] = multipleRowsEditChanges[key];
+                  //                 }
+                  //               );
+                  //             }
+                  //             return _data;
+                  //           });
+                  //           this.setState({ data: newData }, () => resolve());
+                  //         }
+                  //         resolve();
+                  //       }, 1000);
+                  //     }),
                   // }}
                   localization={{
                     body: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "material-table",
-  "version": "1.68.0",
+  "version": "1.68.1",
   "description": "Datatable for React based on https://material-ui.com/api/table/ with additional features",
   "main": "dist/index.js",
   "types": "types/index.d.ts",

--- a/src/components/m-table-body.js
+++ b/src/components/m-table-body.js
@@ -109,6 +109,7 @@ class MTableBody extends React.Component {
             onMultipleEditRowsChanged={this.props.onMultipleEditRowsChanged}
             isEditMultipleRowsFlow={this.props.isEditMultipleRowsFlow}
             multipleRowsEditChanges={this.props.multipleRowsEditChanges}
+            scrollWidth={this.props.scrollWidth}
           />
         );
       } else {
@@ -145,6 +146,7 @@ class MTableBody extends React.Component {
             cellEditable={this.props.cellEditable}
             onCellEditStarted={this.props.onCellEditStarted}
             onCellEditFinished={this.props.onCellEditFinished}
+            scrollWidth={this.props.scrollWidth}
           />
         );
       }
@@ -185,6 +187,7 @@ class MTableBody extends React.Component {
         onCellEditStarted={this.props.onCellEditStarted}
         onCellEditFinished={this.props.onCellEditFinished}
         onBulkEditRowChanged={this.props.onBulkEditRowChanged}
+        scrollWidth={this.props.scrollWidth}
       />
     ));
   }
@@ -232,6 +235,7 @@ class MTableBody extends React.Component {
             filterCellStyle={this.props.options.filterCellStyle}
             filterRowStyle={this.props.options.filterRowStyle}
             hideFilterIcons={this.props.options.hideFilterIcons}
+            scrollWidth={this.props.scrollWidth}
           />
         )}
         {this.props.showAddRow &&
@@ -258,6 +262,7 @@ class MTableBody extends React.Component {
               onEditingCanceled={this.props.onEditingCanceled}
               onEditingApproved={this.props.onEditingApproved}
               getFieldValue={this.props.getFieldValue}
+              scrollWidth={this.props.scrollWidth}
             />
           )}
 
@@ -288,6 +293,7 @@ class MTableBody extends React.Component {
             onEditingCanceled={this.props.onEditingCanceled}
             onEditingApproved={this.props.onEditingApproved}
             getFieldValue={this.props.getFieldValue}
+            scrollWidth={this.props.scrollWidth}
           />
         )}
         {this.renderEmpty(emptyRowCount, renderData)}
@@ -329,6 +335,7 @@ MTableBody.propTypes = {
   renderData: PropTypes.array,
   initialFormData: PropTypes.object,
   selection: PropTypes.bool.isRequired,
+  scrollWidth: PropTypes.number.isRequired,
   showAddRow: PropTypes.bool,
   treeDataMaxLevel: PropTypes.number,
   localization: PropTypes.object,

--- a/src/components/m-table-body.js
+++ b/src/components/m-table-body.js
@@ -74,6 +74,11 @@ class MTableBody extends React.Component {
     }
   }
 
+  getMode = (data) => {
+    const { bulkEditOpen, isEditMultipleRowsFlow } = this.props
+    return bulkEditOpen ? "bulk" : isEditMultipleRowsFlow? "multiple-edit" : data.tableData.editing
+  }
+
   renderUngroupedRows(renderData) {
     return renderData.map((data, index) => {
       if (data.tableData.editing || this.props.bulkEditOpen) {
@@ -93,7 +98,7 @@ class MTableBody extends React.Component {
                 .dateTimePickerLocalization,
             }}
             key={"row-" + data.tableData.id}
-            mode={this.props.bulkEditOpen ? "bulk" : data.tableData.editing}
+            mode={this.getMode(data)}
             options={this.props.options}
             isTreeData={this.props.isTreeData}
             detailPanel={this.props.detailPanel}
@@ -101,6 +106,9 @@ class MTableBody extends React.Component {
             onEditingApproved={this.props.onEditingApproved}
             getFieldValue={this.props.getFieldValue}
             onBulkEditRowChanged={this.props.onBulkEditRowChanged}
+            onMultipleEditRowsChanged={this.props.onMultipleEditRowsChanged}
+            isEditMultipleRowsFlow={this.props.isEditMultipleRowsFlow}
+            multipleRowsEditChanges={this.props.multipleRowsEditChanges}
           />
         );
       } else {
@@ -337,6 +345,9 @@ MTableBody.propTypes = {
   onCellEditFinished: PropTypes.func,
   bulkEditOpen: PropTypes.bool,
   onBulkEditRowChanged: PropTypes.func,
+  onMultipleEditRowsChanged: PropTypes.func,
+  isEditMultipleRowsFlow: PropTypes.bool,
+  multipleRowsEditChanges: PropTypes.object,
 };
 
 export default MTableBody;

--- a/src/components/m-table-body.js
+++ b/src/components/m-table-body.js
@@ -75,9 +75,13 @@ class MTableBody extends React.Component {
   }
 
   getMode = (data) => {
-    const { bulkEditOpen, isEditMultipleRowsFlow } = this.props
-    return bulkEditOpen ? "bulk" : isEditMultipleRowsFlow? "multiple-edit" : data.tableData.editing
-  }
+    const { bulkEditOpen, isEditMultipleRowsFlow } = this.props;
+    return bulkEditOpen
+      ? "bulk"
+      : isEditMultipleRowsFlow
+      ? "multiple-edit"
+      : data.tableData.editing;
+  };
 
   renderUngroupedRows(renderData) {
     return renderData.map((data, index) => {

--- a/src/components/m-table-edit-field.js
+++ b/src/components/m-table-edit-field.js
@@ -24,6 +24,9 @@ class MTableEditField extends React.Component {
       onRowDataChange,
       errorState,
       onBulkEditRowChanged,
+      onMultipleEditRowsChanged,
+      isEditMultipleRowsFlow,
+      multipleRowsEditChanges,
       ...props
     } = this.props;
     return props;

--- a/src/components/m-table-edit-row.js
+++ b/src/components/m-table-edit-row.js
@@ -117,6 +117,7 @@ export default class MTableEditRow extends React.Component {
                 break;
             }
           }
+          const { isEditMultipleRowsFlow, multipleRowsEditChanges, onMultipleEditRowsChanged } = this.props;
           return (
             <TableCell
               size={size}
@@ -129,7 +130,8 @@ export default class MTableEditRow extends React.Component {
               <EditComponent
                 key={columnDef.tableData.id}
                 columnDef={cellProps}
-                value={value}
+                value={isEditMultipleRowsFlow & multipleRowsEditChanges[columnDef.field] ?
+                  multipleRowsEditChanges[columnDef.field] : value}
                 error={!error.isValid}
                 helperText={error.helperText}
                 locale={this.props.localization.dateTimePickerLocalization}
@@ -141,6 +143,9 @@ export default class MTableEditRow extends React.Component {
                   this.setState({ data }, () => {
                     if (this.props.onBulkEditRowChanged) {
                       this.props.onBulkEditRowChanged(this.props.data, data);
+                    }
+                    if (isEditMultipleRowsFlow && onMultipleEditRowsChanged) {
+                      onMultipleEditRowsChanged(columnDef.field, value);
                     }
                   });
                 }}
@@ -170,7 +175,7 @@ export default class MTableEditRow extends React.Component {
   };
 
   renderActions() {
-    if (this.props.mode === "bulk") {
+    if (this.props.mode === "bulk" || this.props.mode === 'multiple-edit') {
       return <TableCell padding="none" key="key-actions-column" />;
     }
 
@@ -261,7 +266,8 @@ export default class MTableEditRow extends React.Component {
     if (
       this.props.mode === "add" ||
       this.props.mode === "update" ||
-      this.props.mode === "bulk"
+      this.props.mode === "bulk" ||
+      this.props.mode === "multiple-edit"
     ) {
       columns = this.renderColumns();
     } else {
@@ -360,6 +366,9 @@ export default class MTableEditRow extends React.Component {
       actions,
       errorState,
       onBulkEditRowChanged,
+      onMultipleEditRowsChanged,
+      isEditMultipleRowsFlow,
+      multipleRowsEditChanges,
       ...rowProps
     } = this.props;
 
@@ -387,7 +396,8 @@ MTableEditRow.defaultProps = {
     cancelTooltip: "Cancel",
     deleteText: "Are you sure you want to delete this row?",
   },
-  onBulkEditRowChanged: () => {},
+  onBulkEditRowChanged: () => { },
+  onMultipleEditRowsChanged: () => { },
 };
 
 MTableEditRow.propTypes = {
@@ -410,4 +420,7 @@ MTableEditRow.propTypes = {
   getFieldValue: PropTypes.func,
   errorState: PropTypes.oneOfType([PropTypes.object, PropTypes.bool]),
   onBulkEditRowChanged: PropTypes.func,
+  onMultipleEditRowsChanged: PropTypes.func,
+  isEditMultipleRowsFlow: PropTypes.bool,
+  multipleRowsEditChanges: PropTypes.object,
 };

--- a/src/components/m-table-edit-row.js
+++ b/src/components/m-table-edit-row.js
@@ -130,8 +130,8 @@ export default class MTableEditRow extends React.Component {
               <EditComponent
                 key={columnDef.tableData.id}
                 columnDef={cellProps}
-                value={isEditMultipleRowsFlow & multipleRowsEditChanges[columnDef.field] ?
-                  multipleRowsEditChanges[columnDef.field] : value}
+                value={isEditMultipleRowsFlow & typeof multipleRowsEditChanges[columnDef.field] !== 'undefined' ?
+                   multipleRowsEditChanges[columnDef.field] : value}
                 error={!error.isValid}
                 helperText={error.helperText}
                 locale={this.props.localization.dateTimePickerLocalization}

--- a/src/components/m-table-header.js
+++ b/src/components/m-table-header.js
@@ -147,7 +147,7 @@ export class MTableHeader extends React.Component {
         className={this.props.classes.header}
         style={{ ...this.props.headerStyle, width: selectionWidth }}
       >
-        {this.props.showSelectAllCheckbox && (
+        {this.props.showSelectAllCheckbox && !this.props.isEditMultipleRowsFlow && (
           <Checkbox
             indeterminate={
               this.props.selectedCount > 0 &&
@@ -280,6 +280,7 @@ MTableHeader.propTypes = {
   draggable: PropTypes.bool,
   thirdSortClick: PropTypes.bool,
   tooltip: PropTypes.string,
+  isEditMultipleRowsFlow: PropTypes.bool
 };
 
 export const styles = (theme) => ({

--- a/src/default-props.js
+++ b/src/default-props.js
@@ -269,7 +269,7 @@ export const defaultProps = {
       bulkEditCancel: "Discard all changes",
       updateMultipleRowsTooltip: "Edit selected rows",
       saveMultipleRowsEditingTooltip: "Save selected rows changes",
-      cancelMultipleRowsEditingTooltip: "Discard all changes"
+      cancelMultipleRowsEditingTooltip: "Discard all changes",
     },
   },
   style: {},

--- a/src/default-props.js
+++ b/src/default-props.js
@@ -258,6 +258,9 @@ export const defaultProps = {
       bulkEditTooltip: "Edit All",
       bulkEditApprove: "Save all changes",
       bulkEditCancel: "Discard all changes",
+      updateMultipleRowsTooltip: "Edit selected rows",
+      saveMultipleRowsEditingTooltip: "Save selected rows changes",
+      cancelMultipleRowsEditingTooltip: "Discard all changes"
     },
   },
   style: {},

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -330,22 +330,8 @@ export default class MaterialTable extends React.Component {
           hidden: !this.dataManager.isEditMultipleRowsFlow,
           onClick: () => {
             this.setState({ isLoading: true }, () => {
-              const newData = this.dataManager
-                .getRenderState()
-                .data.map((_data) => {
-                  if (_data.tableData.checked) {
-                    Object.keys(
-                      this.dataManager.multipleRowsEditChanges
-                    ).forEach((key) => {
-                      _data[key] = this.dataManager.multipleRowsEditChanges[
-                        key
-                      ];
-                    });
-                  }
-                  return _data;
-                });
               calculatedProps.editable
-                .onMultipleRowsUpdate(newData)
+                .onMultipleRowsUpdate(this.dataManager.multipleRowsEditChanges)
                 .then((result) => {
                   this.dataManager.changeMultipleRowsEditing();
                   this.setState({

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -309,7 +309,9 @@ export default class MaterialTable extends React.Component {
         });
       }
       if (calculatedProps.editable.onMultipleRowsUpdate) {
-        const hasSelectedRows = this.dataManager.getRenderState().data.some(d => d.tableData.checked);
+        const hasSelectedRows = this.dataManager
+          .getRenderState()
+          .data.some((d) => d.tableData.checked);
         calculatedProps.actions.push({
           icon: calculatedProps.icons.Edit,
           tooltip: localization.updateMultipleRowsTooltip,
@@ -328,25 +330,32 @@ export default class MaterialTable extends React.Component {
           hidden: !this.dataManager.isEditMultipleRowsFlow,
           onClick: () => {
             this.setState({ isLoading: true }, () => {
-              const newData = this.dataManager.getRenderState().data.map(_data => {
-                if (_data.tableData.checked) {
-                  Object.keys(this.dataManager.multipleRowsEditChanges).forEach(key => {
-                    _data[key] = this.dataManager.multipleRowsEditChanges[key];
-                  })
-                }
-                return _data;
-              });
-              calculatedProps.editable.onMultipleRowsUpdate(newData)
-                .then(result => {
+              const newData = this.dataManager
+                .getRenderState()
+                .data.map((_data) => {
+                  if (_data.tableData.checked) {
+                    Object.keys(
+                      this.dataManager.multipleRowsEditChanges
+                    ).forEach((key) => {
+                      _data[key] = this.dataManager.multipleRowsEditChanges[
+                        key
+                      ];
+                    });
+                  }
+                  return _data;
+                });
+              calculatedProps.editable
+                .onMultipleRowsUpdate(newData)
+                .then((result) => {
                   this.dataManager.changeMultipleRowsEditing();
                   this.setState({
                     ...this.dataManager.getRenderState(),
                     isLoading: false,
                   });
-                  this.dataManager.resetMultipleRowsChanges()
-                })
-            })
-          }
+                  this.dataManager.resetMultipleRowsChanges();
+                });
+            });
+          },
         });
 
         calculatedProps.actions.push({
@@ -356,7 +365,7 @@ export default class MaterialTable extends React.Component {
           hidden: !this.dataManager.isEditMultipleRowsFlow,
           onClick: () => {
             this.dataManager.changeMultipleRowsEditing();
-            this.dataManager.resetMultipleRowsChanges()
+            this.dataManager.resetMultipleRowsChanges();
             this.setState(this.dataManager.getRenderState());
           },
         });
@@ -949,7 +958,11 @@ export default class MaterialTable extends React.Component {
         onRowClick={this.props.onRowClick}
         showAddRow={this.state.showAddRow}
         hasAnyEditingRow={
-          !!(this.state.lastEditingRow || this.state.showAddRow || this.dataManager.isEditMultipleRowsFlow)
+          !!(
+            this.state.lastEditingRow ||
+            this.state.showAddRow ||
+            this.dataManager.isEditMultipleRowsFlow
+          )
         }
         hasDetailPanel={!!props.detailPanel}
         treeDataMaxLevel={this.state.treeDataMaxLevel}

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -772,6 +772,11 @@ export default class MaterialTable extends React.Component {
     this.setState(this.dataManager.getRenderState());
   };
 
+  onColumnResized = (id, additionalWidth) => {
+    this.dataManager.onColumnResized(id, additionalWidth);
+    this.setState(this.dataManager.getRenderState());
+  };
+
   renderFooter() {
     const props = this.getProps();
     if (props.options.paging) {
@@ -912,6 +917,8 @@ export default class MaterialTable extends React.Component {
           treeDataMaxLevel={this.state.treeDataMaxLevel}
           options={props.options}
           isEditMultipleRowsFlow={this.dataManager.isEditMultipleRowsFlow}
+          onColumnResized={this.onColumnResized}
+          scrollWidth={this.state.width}
         />
       )}
       <props.components.Body
@@ -957,6 +964,7 @@ export default class MaterialTable extends React.Component {
         }}
         isEditMultipleRowsFlow={this.dataManager.isEditMultipleRowsFlow}
         multipleRowsEditChanges={this.dataManager.multipleRowsEditChanges}
+        scrollWidth={this.state.width}
       />
     </Table>
   );

--- a/src/utils/data-manager.js
+++ b/src/utils/data-manager.js
@@ -73,17 +73,21 @@ export default class DataManager {
         filterValue: columnDef.defaultFilter,
         groupOrder: columnDef.defaultGroupOrder,
         groupSort: columnDef.defaultGroupSort || "asc",
-        width: columnDef.width,
+        width:
+          typeof columnDef.width === "number"
+            ? columnDef.width + "px"
+            : columnDef.width,
+        initialWidth:
+          typeof columnDef.width === "number"
+            ? columnDef.width + "px"
+            : columnDef.width,
+        additionalWidth: 0,
         ...columnDef.tableData,
         id: index,
       };
 
-      if (columnDef.width !== undefined) {
-        if (typeof columnDef.width === "number") {
-          usedWidth.push(columnDef.width + "px");
-        } else {
-          usedWidth.push(columnDef.width);
-        }
+      if (columnDef.tableData.width !== undefined) {
+        usedWidth.push(columnDef.tableData.width);
       }
 
       return columnDef;
@@ -91,7 +95,7 @@ export default class DataManager {
 
     usedWidth = "(" + usedWidth.join(" + ") + ")";
     undefinedWidthColumns.forEach((columnDef) => {
-      columnDef.tableData.width = `calc((100% - ${usedWidth}) / ${undefinedWidthColumns.length})`;
+      columnDef.tableData.width = columnDef.tableData.initialWidth = `calc((100% - ${usedWidth}) / ${undefinedWidthColumns.length})`;
     });
   }
 
@@ -439,6 +443,28 @@ export default class DataManager {
 
   resetMultipleRowsChanges = () => {
     this.multipleRowsEditChanges = {};
+  }
+
+  onColumnResized(id, additionalWidth) {
+    const column = this.columns.find((c) => c.tableData.id === id);
+    if (!column) return;
+
+    const nextColumn = this.columns.find((c) => c.tableData.id === id + 1);
+    if (!nextColumn) return;
+
+    // console.log("S i: " + column.tableData.initialWidth);
+    // console.log("S a: " + column.tableData.additionalWidth);
+    // console.log("S w: " + column.tableData.width);
+
+    column.tableData.additionalWidth = additionalWidth;
+    column.tableData.width = `calc(${column.tableData.initialWidth} + ${column.tableData.additionalWidth}px)`;
+
+    // nextColumn.tableData.additionalWidth = -1 * additionalWidth;
+    // nextColumn.tableData.width = `calc(${nextColumn.tableData.initialWidth} + ${nextColumn.tableData.additionalWidth}px)`;
+
+    // console.log("F i: " + column.tableData.initialWidth);
+    // console.log("F a: " + column.tableData.additionalWidth);
+    // console.log("F w: " + column.tableData.width);
   }
 
   expandTreeForNodes = (data) => {

--- a/src/utils/data-manager.js
+++ b/src/utils/data-manager.js
@@ -22,6 +22,8 @@ export default class DataManager {
   defaultExpanded = false;
   bulkEditOpen = false;
   bulkEditChangedRows = {};
+  isEditMultipleRowsFlow = false;
+  multipleRowsEditChanges = {};
 
   data = [];
   columns = [];
@@ -43,7 +45,7 @@ export default class DataManager {
 
   rootGroupsIndex = {};
 
-  constructor() {}
+  constructor() { }
 
   setData(data) {
     this.selectedCount = 0;
@@ -207,6 +209,19 @@ export default class DataManager {
     } else if (this.lastEditingRow) {
       this.lastEditingRow.tableData.editing = undefined;
       this.lastEditingRow = undefined;
+    }
+  }
+
+  changeMultipleRowsEditing(mode = undefined) {
+    const hasSelectedRows = this.data.some(d => d.tableData.checked);
+    if (hasSelectedRows) {
+      this.isEditMultipleRowsFlow = mode ? true : false;
+      this.data.forEach((row) => {
+        if (row.tableData.checked) {
+          row.tableData.editing = mode;
+          row.tableData.checked = mode ? row.tableData.checked : false;
+        }
+      });
     }
   }
 
@@ -418,6 +433,14 @@ export default class DataManager {
     };
   };
 
+  onMultipleEditRowsChanged = (field, value) => {
+    this.multipleRowsEditChanges[field] = value;
+  }
+
+  resetMultipleRowsChanges = () => {
+    this.multipleRowsEditChanges = {};
+  }
+
   expandTreeForNodes = (data) => {
     data.forEach((row) => {
       let currentRow = row;
@@ -531,17 +554,17 @@ export default class DataManager {
       result = list.sort(
         this.orderDirection === "desc"
           ? (a, b) =>
-              this.sort(
-                this.getFieldValue(b, columnDef),
-                this.getFieldValue(a, columnDef),
-                columnDef.type
-              )
+            this.sort(
+              this.getFieldValue(b, columnDef),
+              this.getFieldValue(a, columnDef),
+              columnDef.type
+            )
           : (a, b) =>
-              this.sort(
-                this.getFieldValue(a, columnDef),
-                this.getFieldValue(b, columnDef),
-                columnDef.type
-              )
+            this.sort(
+              this.getFieldValue(a, columnDef),
+              this.getFieldValue(b, columnDef),
+              columnDef.type
+            )
       );
     }
 


### PR DESCRIPTION
## Description

This feature will allow to update fields of selected rows (a group of rows) in parallel, for instance:
if you have a group of rows that you want to update a new value to the field "Name" in all of the rows,
with this feature, you can do this easily without changing the same field for each row, again, and again, you only have to do this once.

## Impacted Areas in Application

List general components of the application that this PR will affect:
 - m-table-toolbar
 - m-table-edit-row
 - m-table-header

## Additional Notes

1. Select the rows that you want to update, then click on "Edit selected rows" button at the top right corner.
![Screen Shot 2020-08-26 at 3 45 51 PM](https://user-images.githubusercontent.com/53995839/91305155-48841780-e7b3-11ea-9d11-925406c0099d.png)

2. Edit some of the fields, and the relevant fields of other selected rows will update in parallel.
![Screen Shot 2020-08-26 at 3 43 19 PM](https://user-images.githubusercontent.com/53995839/91305451-bfb9ab80-e7b3-11ea-9e3d-36667ff7b910.png)



