### PR TITLE
Upgrade jspdf to v2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "debounce": "^1.2.0",
     "fast-deep-equal": "2.0.1",
     "filefy": "0.1.10",
-    "jspdf": "2.0.0",
+    "jspdf": "2.1.0",
     "jspdf-autotable": "3.5.9",
     "prop-types": "^15.6.2",
     "react-beautiful-dnd": "^13.0.0",


### PR DESCRIPTION
## Related Issue

Fixes #2326

## Description

Update jspdf version to 2.1.0 fixing the warnings there.

## Related PRs

List related PRs against other branches:

| branch              | PR       |
| ------------------- | -------- |
| ollyrowe:upgrade-jspdf | #2311 |

## Impacted Areas in Application

List general components of the application that this PR will affect:

* The library setup
