### PR TITLE
Change the reset of the order direction for remote data

### DIFF
--- a/src/components/m-table-toolbar.js
+++ b/src/components/m-table-toolbar.js
@@ -256,12 +256,14 @@ export class MTableToolbar extends React.Component {
               open={Boolean(this.state.exportButtonAnchorEl)}
               onClose={() => this.setState({ exportButtonAnchorEl: null })}
             >
-              {(this.props.exportButton === true || this.props.exportButton.csv ) && (
+              {(this.props.exportButton === true ||
+                this.props.exportButton.csv) && (
                 <MenuItem key="export-csv" onClick={this.exportCsv}>
                   {localization.exportCSVName}
                 </MenuItem>
               )}
-              {(this.props.exportButton === true || this.props.exportButton.pdf ) && (
+              {(this.props.exportButton === true ||
+                this.props.exportButton.pdf) && (
                 <MenuItem key="export-pdf" onClick={this.exportPdf}>
                   {localization.exportPDFName}
                 </MenuItem>
@@ -423,7 +425,10 @@ MTableToolbar.propTypes = {
   renderData: PropTypes.array,
   data: PropTypes.array,
   exportAllData: PropTypes.bool,
-  exportButton: PropTypes.oneOfType([PropTypes.bool, PropTypes.shape({ csv: PropTypes.bool, pdf: PropTypes.bool })]),
+  exportButton: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.shape({ csv: PropTypes.bool, pdf: PropTypes.bool }),
+  ]),
   exportDelimiter: PropTypes.string,
   exportFileName: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
   exportCsv: PropTypes.func,

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -101,6 +101,7 @@ export default class MaterialTable extends React.Component {
     const shouldReorder =
       isInit ||
       (defaultSortColumnIndex !== this.dataManager.orderBy &&
+        !this.isRemoteData() &&
         defaultSortDirection !== this.dataManager.orderDirection);
     shouldReorder &&
       this.dataManager.changeOrder(


### PR DESCRIPTION
## Related Issue

Fixes #2177 Fixes #2187

## Description
This prevents the reset of the order for remote data to prevent out-of-sync sorting directions between the query and the current sorting of data-manager.

## Related PRs

#2330

## Impacted Areas in Application
* Material-Table

