### PR TITLE
Fix `inputProps` incorrectly nested under `InputProps`

### DIFF
--- a/src/components/m-table-edit-field.js
+++ b/src/components/m-table-edit-field.js
@@ -123,10 +123,10 @@ class MTableEditField extends React.Component {
           InputProps={{
             style: {
               fontSize: 13,
-            },
-            inputProps: {
-              "aria-label": `${this.props.columnDef.title}: press space to edit`,
-            },
+            }
+          }}
+          inputProps={{
+            "aria-label": `${this.props.columnDef.title}: press space to edit`,
           }}
         />
       </MuiPickersUtilsProvider>
@@ -145,10 +145,10 @@ class MTableEditField extends React.Component {
           InputProps={{
             style: {
               fontSize: 13,
-            },
-            inputProps: {
-              "aria-label": `${this.props.columnDef.title}: press space to edit`,
-            },
+            }
+          }}
+          inputProps={{
+            "aria-label": `${this.props.columnDef.title}: press space to edit`,
           }}
         />
       </MuiPickersUtilsProvider>
@@ -178,10 +178,10 @@ class MTableEditField extends React.Component {
         InputProps={{
           style: {
             fontSize: 13,
-          },
-          inputProps: {
-            "aria-label": this.props.columnDef.title,
-          },
+          }
+        }}
+        inputProps={{
+          "aria-label": this.props.columnDef.title,
         }}
       />
     );
@@ -204,12 +204,14 @@ class MTableEditField extends React.Component {
           }
           return this.props.onChange(value);
         }}
-        inputProps={{
+        InputProps={{
           style: {
             fontSize: 13,
             textAlign: "right",
-            "aria-label": this.props.columnDef.title,
-          },
+          }
+        }}
+        inputProps={{
+          "aria-label": this.props.columnDef.title,
         }}
         onKeyDown={this.props.onKeyDown}
         autoFocus={this.props.autoFocus}


### PR DESCRIPTION
## Description

In `MTableEditField`, some `material-ui` input components were being passed
`inputProps`, which are for passing attributes to the rendered `input` element,
inside `InputProps`, which are for passing props to the wrapped `material-ui`
`Input` component. This resulted in the `aria-label` for these components
(which was all that was being passed in `inputProps`) being incorrectly applied,
throwing a development error and failing to render the `aria-label` in the DOM.

## Impacted Areas in Application

List general components of the application that this PR will affect:
- `MTableEditField`
