### PR TITLE
Fixed #2427: Optional function for editable is now cheked if editable

### DIFF
--- a/src/components/m-table-body-row.js
+++ b/src/components/m-table-body-row.js
@@ -66,7 +66,7 @@ export default class MTableBodyRow extends React.Component {
               }
               rowData={this.props.data}
               cellEditable={
-                columnDef.editable !== "never" && !!this.props.cellEditable
+                ((typeof columnDef.editable !== "function" && columnDef.editable !== "never") || (typeof columnDef.editable === "function" && columnDef.editable(columnDef, this.props.data))) && !!this.props.cellEditable
               }
               onCellEditStarted={this.props.onCellEditStarted}
               scrollWidth={this.props.scrollWidth}

--- a/src/components/m-table-body-row.js
+++ b/src/components/m-table-body-row.js
@@ -66,7 +66,11 @@ export default class MTableBodyRow extends React.Component {
               }
               rowData={this.props.data}
               cellEditable={
-                ((typeof columnDef.editable !== "function" && columnDef.editable !== "never") || (typeof columnDef.editable === "function" && columnDef.editable(columnDef, this.props.data))) && !!this.props.cellEditable
+                ((typeof columnDef.editable !== "function" &&
+                  columnDef.editable !== "never") ||
+                  (typeof columnDef.editable === "function" &&
+                    columnDef.editable(columnDef, this.props.data))) &&
+                !!this.props.cellEditable
               }
               onCellEditStarted={this.props.onCellEditStarted}
               scrollWidth={this.props.scrollWidth}


### PR DESCRIPTION
Fixes #2427

## Description

The code was only checking if the editable field was 'never'.  It can also be a function and the result of that function should be used, if specified, to determine the state of the editable.
