### PR TITLE
Fixes bug with deeply nested tree data

### DIFF
--- a/src/utils/data-manager.js
+++ b/src/utils/data-manager.js
@@ -834,21 +834,25 @@ export default class DataManager {
       let parent = this.parentFunc(rowData, this.data);
       if (parent) {
         parent.tableData.childRows = parent.tableData.childRows || [];
+	let addIndex = undefined;
         if (!parent.tableData.childRows.includes(rowData)) {
           parent.tableData.childRows.push(rowData);
+	  addIndex = parent.tableData.childRows.length - 1;
           this.treefiedDataLength++;
         }
 
         addRow(parent);
 
-        rowData.tableData.path = [
-          ...parent.tableData.path,
-          parent.tableData.childRows.length - 1,
-        ];
-        this.treeDataMaxLevel = Math.max(
-          this.treeDataMaxLevel,
-          rowData.tableData.path.length
-        );
+	if (addIndex !== undefined) {
+          rowData.tableData.path = [
+            ...parent.tableData.path,
+            addIndex,
+          ];
+	  this.treeDataMaxLevel = Math.max(
+            this.treeDataMaxLevel,
+            rowData.tableData.path.length
+          );
+	}
       } else {
         if (!this.treefiedData.includes(rowData)) {
           this.treefiedData.push(rowData);

--- a/src/utils/data-manager.js
+++ b/src/utils/data-manager.js
@@ -834,25 +834,25 @@ export default class DataManager {
       let parent = this.parentFunc(rowData, this.data);
       if (parent) {
         parent.tableData.childRows = parent.tableData.childRows || [];
-	let addIndex = undefined;
+        let addIndex = undefined;
         if (!parent.tableData.childRows.includes(rowData)) {
           parent.tableData.childRows.push(rowData);
-	  addIndex = parent.tableData.childRows.length - 1;
+          addIndex = parent.tableData.childRows.length - 1;
           this.treefiedDataLength++;
         }
 
         addRow(parent);
 
-	if (addIndex !== undefined) {
+        if (addIndex !== undefined) {
           rowData.tableData.path = [
             ...parent.tableData.path,
             addIndex,
           ];
-	  this.treeDataMaxLevel = Math.max(
+          this.treeDataMaxLevel = Math.max(
             this.treeDataMaxLevel,
             rowData.tableData.path.length
           );
-	}
+        }
       } else {
         if (!this.treefiedData.includes(rowData)) {
           this.treefiedData.push(rowData);


### PR DESCRIPTION
## Related Issue

Issue that this PR fixes is described below:

## Description

When a row is inserted before its parents in a table with tree data, all levels of parents are added and the correct path data is written to each row's `tableData` correctly at first. However, when parents are then added later, the path data gets written to again, but with incorrect data this time (see below for minimum working example), which causes problems when the path data is consulted during search or filter.

This PR fixes the bug by only writing the path data the first time, when it is correct. If `addRow` is called again later and the parent already has the child row, the path data is known to be correct from when the child was added and is not overwritten with an incomplete path.

## Related PRs

No related PRs.

## Impacted Areas in Application

List general components of the application that this PR will affect:

Fixes searching and filtering on tables with tree data

## Additional Notes

Bug is very easy to reproduce:

1. Go to https://material-table.com/#/docs/features/tree-data
2. Paste in the following code into the "Basic Tree Data Example" (note how the row "g" has been added and the data is not given in order)
```js
function BasicTreeData() {
  return (
    <MaterialTable
      title="Basic Tree Data Preview"
      data={[
        {
          id: 7,
          name: 'g',
          surname: 'Baran',
          birthYear: 1987,
          birthCity: 34,
          sex: 'Female',
          type: 'child',
          parentId: 3,
        },
        {
          id: 5,
          name: 'e',
          surname: 'Baran',
          birthYear: 1987,
          birthCity: 34,
          sex: 'Female',
          type: 'child',
        },
        {
          id: 1,
          name: 'a',
          surname: 'Baran',
          birthYear: 1987,
          birthCity: 63,
          sex: 'Male',
          type: 'adult',
        },
        {
          id: 2,
          name: 'b',
          surname: 'Baran',
          birthYear: 1987,
          birthCity: 34,
          sex: 'Female',
          type: 'adult',
          parentId: 1,
        },
        {
          id: 3,
          name: 'c',
          surname: 'Baran',
          birthYear: 1987,
          birthCity: 34,
          sex: 'Female',
          type: 'child',
          parentId: 1,
        },
        {
          id: 4,
          name: 'd',
          surname: 'Baran',
          birthYear: 1987,
          birthCity: 34,
          sex: 'Female',
          type: 'child',
          parentId: 3,
        },
        {
          id: 6,
          name: 'f',
          surname: 'Baran',
          birthYear: 1987,
          birthCity: 34,
          sex: 'Female',
          type: 'child',
          parentId: 5,
        },
      ]}
      columns={[
        { title: 'Adı', field: 'name' },
        { title: 'Soyadı', field: 'surname' },
        { title: 'Cinsiyet', field: 'sex' },
        { title: 'Tipi', field: 'type', removable: false },
        { title: 'Doğum Yılı', field: 'birthYear', type: 'numeric' },
        {
          title: 'Doğum Yeri',
          field: 'birthCity',
          lookup: { 34: 'İstanbul', 63: 'Şanlıurfa' },
        },
      ]}
      parentChildData={(row, rows) => rows.find(a => a.id === row.parentId)}
      options={{
        selection: true,
      }}
    />
  )
}
```
3. Try searching for "g" in the search bar of the table and notice how all rows get folded and are now frozen in that state

Expected behavior would be that the "g" row is shown with all of its parents, but this does not happen because when the row was being added, its path property ended up with bad data as described above.

Trying the above example with the code in this PR does produce the expected behavior.