### PR TITLE
Make rowId parameter in onFilterChanged optional

### DIFF
--- a/src/components/m-table-filter-row.js
+++ b/src/components/m-table-filter-row.js
@@ -101,7 +101,9 @@ class MTableFilterRow extends React.Component {
   renderFilterComponent = (columnDef) =>
     React.createElement(columnDef.filterComponent, {
       columnDef: columnDef,
-      onFilterChanged: this.props.onFilterChanged,
+      onFilterChanged: (rowId = columnDef.tableData.id, value) => {
+        this.props.onFilterChanged(rowId, value);
+      },
     });
 
   renderBooleanFilter = (columnDef) => (

--- a/src/components/m-table-filter-row.js
+++ b/src/components/m-table-filter-row.js
@@ -101,8 +101,8 @@ class MTableFilterRow extends React.Component {
   renderFilterComponent = (columnDef) =>
     React.createElement(columnDef.filterComponent, {
       columnDef: columnDef,
-      onFilterChanged: (rowId = columnDef.tableData.id, value) => {
-        this.props.onFilterChanged(rowId, value);
+      onFilterChanged: (columnId = columnDef.tableData.id, value) => {
+        this.props.onFilterChanged(columnId, value);
       },
     });
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -178,7 +178,8 @@ export interface Column<RowData extends object> {
   filtering?: boolean;
   filterComponent?: (props: {
     columnDef: Column<RowData>;
-    onFilterChanged: (rowId: string, value: any) => void;
+    onFilterChanged?(rowId: string, value: any): void;
+    onFilterChanged?(value: any): void;
   }) => React.ReactElement<any>;
   filterPlaceholder?: string;
   filterCellStyle?: React.CSSProperties;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -178,7 +178,7 @@ export interface Column<RowData extends object> {
   filtering?: boolean;
   filterComponent?: (props: {
     columnDef: Column<RowData>;
-    onFilterChanged?(rowId: string, value: any): void;
+    onFilterChanged?(columnId: string, value: any): void;
     onFilterChanged?(value: any): void;
   }) => React.ReactElement<any>;
   filterPlaceholder?: string;


### PR DESCRIPTION
## Related Issue

#1955
#1958

## Description

Currently `onFilterChanged` callback requires `rowId` parameter which is stored in `Column`'s private member `tableData`.

This PR doesn't remove it but makes it optional for backward compatibility.

## Related PRs

#1351

## Impacted Areas in Application

List general components of the application that this PR will affect:

* MTableFilterRow
