### PR TITLE
Add align to EditComponent from columnDef

### DIFF
--- a/src/components/m-table-edit-row.js
+++ b/src/components/m-table-edit-row.js
@@ -100,7 +100,12 @@ export default class MTableEditRow extends React.Component {
           );
         } else {
           const { editComponent, ...cellProps } = columnDef;
-          const cellAlignment = columnDef.align !== undefined ? columnDef.align : ['numeric', 'currency'].indexOf(columnDef.type) !== -1 ? "right" : "left";
+          const cellAlignment =
+            columnDef.align !== undefined
+              ? columnDef.align
+              : ["numeric", "currency"].indexOf(columnDef.type) !== -1
+              ? "right"
+              : "left";
           const EditComponent =
             editComponent || this.props.components.EditField;
           let error = { isValid: true, helperText: "" };

--- a/src/components/m-table-edit-row.js
+++ b/src/components/m-table-edit-row.js
@@ -100,6 +100,7 @@ export default class MTableEditRow extends React.Component {
           );
         } else {
           const { editComponent, ...cellProps } = columnDef;
+          const cellAlignment = columnDef.align !== undefined ? columnDef.align : ['numeric', 'currency'].indexOf(columnDef.type) !== -1 ? "right" : "left";
           const EditComponent =
             editComponent || this.props.components.EditField;
           let error = { isValid: true, helperText: "" };
@@ -121,9 +122,7 @@ export default class MTableEditRow extends React.Component {
             <TableCell
               size={size}
               key={columnDef.tableData.id}
-              align={
-                ["numeric"].indexOf(columnDef.type) !== -1 ? "right" : "left"
-              }
+              align={cellAlignment}
               style={getCellStyle(columnDef, value)}
             >
               <EditComponent


### PR DESCRIPTION
## Related Issue
#736
#1974

## Description

This enables the override in EditComponent of the cell align to match the available props from material-ui.


> By adding align to the column def, it will be passed down to the header and the cells for that column. It will override the default align which is either left or right for numeric values.
> 
> If not provided, the previously used alignment strategy will be the fallback.
> The types are updated as well with all possible options:
> 'center' |'inherit' | 'justify'|'left' |'right';

## Impacted Areas in Application
List general components of the application that this PR will affect:
- EditRow