### PR TITLE
Fixed Bug : Pressing Enter While Editing Row Bypass Validations

### DIFF
--- a/src/components/m-table-edit-row.js
+++ b/src/components/m-table-edit-row.js
@@ -160,6 +160,9 @@ export default class MTableEditRow extends React.Component {
   }
 
   handleSave = () => {
+    if (!this.isValid()) {
+      return;
+    }
     const newData = this.state.data;
     delete newData.tableData;
     this.props.onEditingApproved(
@@ -169,17 +172,8 @@ export default class MTableEditRow extends React.Component {
     );
   };
 
-  renderActions() {
-    if (this.props.mode === "bulk") {
-      return <TableCell padding="none" key="key-actions-column" />;
-    }
-
-    const size = CommonValues.elementSize(this.props);
-    const localization = {
-      ...MTableEditRow.defaultProps.localization,
-      ...this.props.localization,
-    };
-    const isValid = this.props.columns.every((column) => {
+  isValid = () => {
+    return this.props.columns.every((column) => {
       if (column.validate) {
         const response = column.validate(this.state.data);
         switch (typeof response) {
@@ -194,6 +188,19 @@ export default class MTableEditRow extends React.Component {
         return true;
       }
     });
+  };
+
+  renderActions() {
+    if (this.props.mode === "bulk") {
+      return <TableCell padding="none" key="key-actions-column" />;
+    }
+
+    const size = CommonValues.elementSize(this.props);
+    const localization = {
+      ...MTableEditRow.defaultProps.localization,
+      ...this.props.localization,
+    };
+    const isValid = this.isValid();
     const actions = [
       {
         icon: this.props.icons.Check,


### PR DESCRIPTION
## Related Issue

#2270 

## Description

Previously when there is validations on any column, we can submit invalid data by pressing enter.  Validate functions are not triggered, new data is directly passing to `onEditingApproved` function.

I move the validation check logic on `renderActions` to a function. I reuse that function on `handleSave` function.

### Example Fail Case By Screenshots

1. Create a validation for a column like
`validate: ({ name }) => name?.trim().length > 3,`

2. As following screenshot `Save` button is disabled
![invalid-state](https://user-images.githubusercontent.com/8013228/92759978-f0473b00-f398-11ea-858e-5991c292e9ee.png)

3. But if we press enter invalid data will be submitted
![invalid-data-saved](https://user-images.githubusercontent.com/8013228/92760044-005f1a80-f399-11ea-94e5-ba7977c62674.png)

4. After our table has invalid data, we can't delete it also
![invalid-data-cannot-be-deleted](https://user-images.githubusercontent.com/8013228/92760052-035a0b00-f399-11ea-9e5f-6a30adb0ed4c.png)

## Impacted Areas in Application

m-table-edit-row.js