### PR TITLE
Fix an error that makes the width value string very long.

### DIFF
--- a/src/utils/data-manager.js
+++ b/src/utils/data-manager.js
@@ -84,7 +84,10 @@ export default class DataManager {
         id: index,
       };
 
-      if (columnDef.width !== undefined) {
+      if (
+        !undefinedWidthColumns.includes(columnDef) &&
+        columnDef.tableData.width !== undefined
+      ) {
         usedWidth.push(columnDef.tableData.width);
       }
 

--- a/src/utils/data-manager.js
+++ b/src/utils/data-manager.js
@@ -84,7 +84,7 @@ export default class DataManager {
         id: index,
       };
 
-      if (columnDef.tableData.width !== undefined) {
+      if (columnDef.width !== undefined) {
         usedWidth.push(columnDef.tableData.width);
       }
 


### PR DESCRIPTION
## Related Issue

#2381 
#2433 (not sure)

## Description

`columnDef.tableData.width`may be defined even  if `columnDef.width` is undefined.
Because the calculated `tableData.width` added to each `column` object when the props updated or added.
This function produces a string value with a previously calculated value each time it is called, so the length increases proportionally to the power of the number of columns with has undefined width.
<img width="659" alt="스크린샷 2020-09-11 오전 2 03 40" src="https://user-images.githubusercontent.com/17980230/92768516-0c67ce00-f3d3-11ea-91aa-f2d9113476a5.png">




