### PR TITLE
Update jspdf version to 2.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "debounce": "^1.2.0",
     "fast-deep-equal": "2.0.1",
     "filefy": "0.1.10",
-    "jspdf": "2.1.0",
+    "jspdf": "2.1.1",
     "jspdf-autotable": "3.5.9",
     "prop-types": "^15.6.2",
     "react-beautiful-dnd": "^13.0.0",


### PR DESCRIPTION
## Related Issue

Relate the Github issue with this PR using https://github.com/spotify/backstage/pull/2263 

## Description

Simple words to describe the overall goals of the pull request's commits.

## Additional Notes

jspdf fileSaver issue MrRio/jsPDF#2490. When the dependency configured to fetch directly from github, this caused an issue while running npm install in isolated environment, and the issue already been patched in jspdf, we just need to do an update here