### PR TITLE
adding es6 Symbol & polyfill to inputed component data

### DIFF
--- a/src/components/m-table-body-row.js
+++ b/src/components/m-table-body-row.js
@@ -8,6 +8,7 @@ import Tooltip from "@material-ui/core/Tooltip";
 import PropTypes from "prop-types";
 import * as React from "react";
 import * as CommonValues from "../utils/common-values";
+const tableData = CommonValues.tableData;
 /* eslint-enable no-unused-vars */
 
 export default class MTableBodyRow extends React.Component {
@@ -16,16 +17,16 @@ export default class MTableBodyRow extends React.Component {
     const mapArr = this.props.columns
       .filter(
         (columnDef) =>
-          !columnDef.hidden && !(columnDef.tableData.groupOrder > -1)
+          !columnDef.hidden && !(columnDef[tableData].groupOrder > -1)
       )
-      .sort((a, b) => a.tableData.columnOrder - b.tableData.columnOrder)
+      .sort((a, b) => a[tableData].columnOrder - b[tableData].columnOrder)
       .map((columnDef, index) => {
         const value = this.props.getFieldValue(this.props.data, columnDef);
 
         if (
-          this.props.data.tableData.editCellList &&
-          this.props.data.tableData.editCellList.find(
-            (c) => c.tableData.id === columnDef.tableData.id
+          this.props.data[tableData].editCellList &&
+          this.props.data[tableData].editCellList.find(
+            (c) => c[tableData].id === columnDef[tableData].id
           )
         ) {
           return (
@@ -37,9 +38,9 @@ export default class MTableBodyRow extends React.Component {
               size={size}
               key={
                 "cell-" +
-                this.props.data.tableData.id +
+                this.props.data[tableData].id +
                 "-" +
-                columnDef.tableData.id
+                columnDef[tableData].id
               }
               rowData={this.props.data}
               cellEditable={this.props.cellEditable}
@@ -60,9 +61,9 @@ export default class MTableBodyRow extends React.Component {
               value={value}
               key={
                 "cell-" +
-                this.props.data.tableData.id +
+                this.props.data[tableData].id +
                 "-" +
-                columnDef.tableData.id
+                columnDef[tableData].id
               }
               rowData={this.props.data}
               cellEditable={
@@ -136,9 +137,9 @@ export default class MTableBodyRow extends React.Component {
       >
         <Checkbox
           size={size}
-          checked={this.props.data.tableData.checked === true}
+          checked={this.props.data[tableData].checked === true}
           onClick={(e) => e.stopPropagation()}
-          value={this.props.data.tableData.id.toString()}
+          value={this.props.data[tableData].id.toString()}
           onChange={(event) =>
             this.props.onRowSelected(event, this.props.path, this.props.data)
           }
@@ -179,7 +180,7 @@ export default class MTableBodyRow extends React.Component {
             style={{
               transition: "all ease 200ms",
               ...this.rotateIconStyle(
-                this.props.data.tableData.showDetailPanel
+                this.props.data[tableData].showDetailPanel
               ),
             }}
             onClick={(event) => {
@@ -211,8 +212,9 @@ export default class MTableBodyRow extends React.Component {
               }
 
               const isOpen =
-                (this.props.data.tableData.showDetailPanel || "").toString() ===
-                panel.render.toString();
+                (
+                  this.props.data[tableData].showDetailPanel || ""
+                ).toString() === panel.render.toString();
 
               let iconButton = <this.props.icons.DetailPanel />;
               let animation = true;
@@ -280,8 +282,8 @@ export default class MTableBodyRow extends React.Component {
   renderTreeDataColumn() {
     const size = CommonValues.elementSize(this.props);
     if (
-      this.props.data.tableData.childRows &&
-      this.props.data.tableData.childRows.length > 0
+      this.props.data[tableData].childRows &&
+      this.props.data[tableData].childRows.length > 0
     ) {
       return (
         <TableCell
@@ -295,7 +297,9 @@ export default class MTableBodyRow extends React.Component {
             style={{
               transition: "all ease 200ms",
               marginLeft: this.props.level * 9,
-              ...this.rotateIconStyle(this.props.data.tableData.isTreeExpanded),
+              ...this.rotateIconStyle(
+                this.props.data[tableData].isTreeExpanded
+              ),
             }}
             onClick={(event) => {
               this.props.onTreeExpandChanged(this.props.path, this.props.data);
@@ -386,7 +390,7 @@ export default class MTableBodyRow extends React.Component {
     }
 
     this.props.columns
-      .filter((columnDef) => columnDef.tableData.groupOrder > -1)
+      .filter((columnDef) => columnDef[tableData].groupOrder > -1)
       .forEach((columnDef) => {
         renderColumns.splice(
           0,
@@ -394,7 +398,7 @@ export default class MTableBodyRow extends React.Component {
           <TableCell
             size={size}
             padding="none"
-            key={"key-group-cell" + columnDef.tableData.id}
+            key={"key-group-cell" + columnDef[tableData].id}
           />
         );
       });
@@ -450,8 +454,8 @@ export default class MTableBodyRow extends React.Component {
         >
           {renderColumns}
         </TableRow>
-        {this.props.data.tableData &&
-          this.props.data.tableData.showDetailPanel && (
+        {this.props.data[tableData] &&
+          this.props.data[tableData].showDetailPanel && (
             <TableRow
             // selected={this.props.index % 2 === 0}
             >
@@ -460,14 +464,14 @@ export default class MTableBodyRow extends React.Component {
                 colSpan={renderColumns.length}
                 padding="none"
               >
-                {this.props.data.tableData.showDetailPanel(this.props.data)}
+                {this.props.data[tableData].showDetailPanel(this.props.data)}
               </TableCell>
             </TableRow>
           )}
-        {this.props.data.tableData.childRows &&
-          this.props.data.tableData.isTreeExpanded &&
-          this.props.data.tableData.childRows.map((data, index) => {
-            if (data.tableData.editing) {
+        {this.props.data[tableData].childRows &&
+          this.props.data[tableData].isTreeExpanded &&
+          this.props.data[tableData].childRows.map((data, index) => {
+            if (data[tableData].editing) {
               return (
                 <this.props.components.EditRow
                   columns={this.props.columns.filter((columnDef) => {
@@ -479,7 +483,7 @@ export default class MTableBodyRow extends React.Component {
                   localization={this.props.localization}
                   getFieldValue={this.props.getFieldValue}
                   key={index}
-                  mode={data.tableData.editing}
+                  mode={data[tableData].editing}
                   options={this.props.options}
                   isTreeData={this.props.isTreeData}
                   detailPanel={this.props.detailPanel}

--- a/src/components/m-table-body.js
+++ b/src/components/m-table-body.js
@@ -4,6 +4,7 @@ import TableCell from "@material-ui/core/TableCell";
 import TableRow from "@material-ui/core/TableRow";
 import PropTypes from "prop-types";
 import * as React from "react";
+import { tableData } from "../utils/common-values";
 /* eslint-enable no-unused-vars */
 
 class MTableBody extends React.Component {
@@ -76,7 +77,7 @@ class MTableBody extends React.Component {
 
   renderUngroupedRows(renderData) {
     return renderData.map((data, index) => {
-      if (data.tableData.editing || this.props.bulkEditOpen) {
+      if (data[tableData].editing || this.props.bulkEditOpen) {
         return (
           <this.props.components.EditRow
             columns={this.props.columns.filter((columnDef) => {
@@ -92,8 +93,8 @@ class MTableBody extends React.Component {
               dateTimePickerLocalization: this.props.localization
                 .dateTimePickerLocalization,
             }}
-            key={"row-" + data.tableData.id}
-            mode={this.props.bulkEditOpen ? "bulk" : data.tableData.editing}
+            key={"row-" + data[tableData].id}
+            mode={this.props.bulkEditOpen ? "bulk" : data[tableData].editing}
             options={this.props.options}
             isTreeData={this.props.isTreeData}
             detailPanel={this.props.detailPanel}
@@ -112,7 +113,7 @@ class MTableBody extends React.Component {
             data={data}
             index={index}
             errorState={this.props.errorState}
-            key={"row-" + data.tableData.id}
+            key={"row-" + data[tableData].id}
             level={0}
             options={this.props.options}
             localization={{
@@ -187,9 +188,9 @@ class MTableBody extends React.Component {
   render() {
     let renderData = this.props.renderData;
     const groups = this.props.columns
-      .filter((col) => col.tableData.groupOrder > -1)
+      .filter((col) => col[tableData].groupOrder > -1)
       .sort(
-        (col1, col2) => col1.tableData.groupOrder - col2.tableData.groupOrder
+        (col1, col2) => col1[tableData].groupOrder - col2[tableData].groupOrder
       );
 
     let emptyRowCount = 0;

--- a/src/components/m-table-cell.js
+++ b/src/components/m-table-cell.js
@@ -4,7 +4,7 @@ import TableCell from "@material-ui/core/TableCell";
 import PropTypes from "prop-types";
 import parseISO from "date-fns/parseISO";
 import * as CommonValues from "../utils/common-values";
-
+const tableData = CommonValues.tableData;
 /* eslint-enable no-unused-vars */
 
 /* eslint-disable no-useless-escape */
@@ -118,7 +118,7 @@ export default class MTableCell extends React.Component {
 
   getStyle = () => {
     const width = CommonValues.reducePercentsInCalc(
-      this.props.columnDef.tableData.width,
+      this.props.columnDef[tableData].width,
       this.props.scrollWidth
     );
 

--- a/src/components/m-table-edit-cell.js
+++ b/src/components/m-table-edit-cell.js
@@ -6,6 +6,8 @@ import CircularProgress from "@material-ui/core/CircularProgress";
 import { fade } from "@material-ui/core/styles/colorManipulator";
 import withTheme from "@material-ui/core/styles/withTheme";
 import { MTable } from "..";
+import { tableData } from "../utils/common-values";
+
 /* eslint-enable no-unused-vars */
 
 class MTableEditCell extends React.Component {
@@ -22,7 +24,7 @@ class MTableEditCell extends React.Component {
     let cellStyle = {
       boxShadow: "2px 0px 15px rgba(125,147,178,.25)",
       color: "inherit",
-      width: this.props.columnDef.tableData.width,
+      width: this.props.columnDef[tableData].width,
       boxSizing: "border-box",
       fontSize: "inherit",
       fontFamily: "inherit",

--- a/src/components/m-table-edit-row.js
+++ b/src/components/m-table-edit-row.js
@@ -6,6 +6,7 @@ import PropTypes from "prop-types";
 import * as React from "react";
 import { byString, setByString } from "../utils";
 import * as CommonValues from "../utils/common-values";
+const tableData = CommonValues.tableData;
 /* eslint-enable no-unused-vars */
 
 export default class MTableEditRow extends React.Component {
@@ -33,9 +34,9 @@ export default class MTableEditRow extends React.Component {
     const mapArr = this.props.columns
       .filter(
         (columnDef) =>
-          !columnDef.hidden && !(columnDef.tableData.groupOrder > -1)
+          !columnDef.hidden && !(columnDef[tableData].groupOrder > -1)
       )
-      .sort((a, b) => a.tableData.columnOrder - b.tableData.columnOrder)
+      .sort((a, b) => a[tableData].columnOrder - b[tableData].columnOrder)
       .map((columnDef, index) => {
         const value =
           typeof this.state.data[columnDef.field] !== "undefined"
@@ -93,7 +94,7 @@ export default class MTableEditRow extends React.Component {
               icons={this.props.icons}
               columnDef={columnDef}
               value={readonlyValue}
-              key={columnDef.tableData.id}
+              key={columnDef[tableData].id}
               rowData={this.props.data}
               style={getCellStyle(columnDef, value)}
             />
@@ -120,14 +121,14 @@ export default class MTableEditRow extends React.Component {
           return (
             <TableCell
               size={size}
-              key={columnDef.tableData.id}
+              key={columnDef[tableData].id}
               align={
                 ["numeric"].indexOf(columnDef.type) !== -1 ? "right" : "left"
               }
               style={getCellStyle(columnDef, value)}
             >
               <EditComponent
-                key={columnDef.tableData.id}
+                key={columnDef[tableData].id}
                 columnDef={cellProps}
                 value={value}
                 error={!error.isValid}
@@ -161,7 +162,7 @@ export default class MTableEditRow extends React.Component {
 
   handleSave = () => {
     const newData = this.state.data;
-    delete newData.tableData;
+    delete newData[tableData];
     this.props.onEditingApproved(
       this.props.mode,
       this.state.data,
@@ -267,7 +268,7 @@ export default class MTableEditRow extends React.Component {
     } else {
       const colSpan = this.props.columns.filter(
         (columnDef) =>
-          !columnDef.hidden && !(columnDef.tableData.groupOrder > -1)
+          !columnDef.hidden && !(columnDef[tableData].groupOrder > -1)
       ).length;
       columns = [
         <TableCell
@@ -330,14 +331,14 @@ export default class MTableEditRow extends React.Component {
     }
 
     this.props.columns
-      .filter((columnDef) => columnDef.tableData.groupOrder > -1)
+      .filter((columnDef) => columnDef[tableData].groupOrder > -1)
       .forEach((columnDef) => {
         columns.splice(
           0,
           0,
           <TableCell
             padding="none"
-            key={"key-group-cell" + columnDef.tableData.id}
+            key={"key-group-cell" + columnDef[tableData].id}
           />
         );
       });

--- a/src/components/m-table-filter-row.js
+++ b/src/components/m-table-filter-row.js
@@ -15,6 +15,7 @@ import InputAdornment from "@material-ui/core/InputAdornment";
 import Icon from "@material-ui/core/Icon";
 import Tooltip from "@material-ui/core/Tooltip";
 import DateFnsUtils from "@date-io/date-fns";
+import { tableData } from "../utils/common-values";
 import {
   MuiPickersUtilsProvider,
   TimePicker,
@@ -45,17 +46,17 @@ class MTableFilterRow extends React.Component {
 
   LookupFilter = ({ columnDef }) => {
     const [selectedFilter, setSelectedFilter] = React.useState(
-      columnDef.tableData.filterValue || []
+      columnDef[tableData].filterValue || []
     );
 
     React.useEffect(() => {
-      setSelectedFilter(columnDef.tableData.filterValue || []);
-    }, [columnDef.tableData.filterValue]);
+      setSelectedFilter(columnDef[tableData].filterValue || []);
+    }, [columnDef[tableData].filterValue]);
 
     return (
       <FormControl style={{ width: "100%" }}>
         <InputLabel
-          htmlFor={"select-multiple-checkbox" + columnDef.tableData.id}
+          htmlFor={"select-multiple-checkbox" + columnDef[tableData].id}
           style={{ marginTop: -16 }}
         >
           {this.getLocalizedFilterPlaceHolder(columnDef)}
@@ -66,7 +67,7 @@ class MTableFilterRow extends React.Component {
           onClose={() => {
             if (columnDef.filterOnItemSelect !== true)
               this.props.onFilterChanged(
-                columnDef.tableData.id,
+                columnDef[tableData].id,
                 selectedFilter
               );
           }}
@@ -74,12 +75,12 @@ class MTableFilterRow extends React.Component {
             setSelectedFilter(event.target.value);
             if (columnDef.filterOnItemSelect === true)
               this.props.onFilterChanged(
-                columnDef.tableData.id,
+                columnDef[tableData].id,
                 event.target.value
               );
           }}
           input={
-            <Input id={"select-multiple-checkbox" + columnDef.tableData.id} />
+            <Input id={"select-multiple-checkbox" + columnDef[tableData].id} />
           }
           renderValue={(selecteds) =>
             selecteds.map((selected) => columnDef.lookup[selected]).join(", ")
@@ -106,17 +107,17 @@ class MTableFilterRow extends React.Component {
 
   renderBooleanFilter = (columnDef) => (
     <Checkbox
-      indeterminate={columnDef.tableData.filterValue === undefined}
-      checked={columnDef.tableData.filterValue === "checked"}
+      indeterminate={columnDef[tableData].filterValue === undefined}
+      checked={columnDef[tableData].filterValue === "checked"}
       onChange={() => {
         let val;
-        if (columnDef.tableData.filterValue === undefined) {
+        if (columnDef[tableData].filterValue === undefined) {
           val = "checked";
-        } else if (columnDef.tableData.filterValue === "checked") {
+        } else if (columnDef[tableData].filterValue === "checked") {
           val = "unchecked";
         }
 
-        this.props.onFilterChanged(columnDef.tableData.id, val);
+        this.props.onFilterChanged(columnDef[tableData].id, val);
       }}
     />
   );
@@ -128,11 +129,11 @@ class MTableFilterRow extends React.Component {
       <TextField
         style={columnDef.type === "numeric" ? { float: "right" } : {}}
         type={columnDef.type === "numeric" ? "number" : "search"}
-        value={columnDef.tableData.filterValue || ""}
+        value={columnDef[tableData].filterValue || ""}
         placeholder={this.getLocalizedFilterPlaceHolder(columnDef)}
         onChange={(event) => {
           this.props.onFilterChanged(
-            columnDef.tableData.id,
+            columnDef[tableData].id,
             event.target.value
           );
         }}
@@ -156,9 +157,9 @@ class MTableFilterRow extends React.Component {
 
   renderDateTypeFilter = (columnDef) => {
     const onDateInputChange = (date) =>
-      this.props.onFilterChanged(columnDef.tableData.id, date);
+      this.props.onFilterChanged(columnDef[tableData].id, date);
     const pickerProps = {
-      value: columnDef.tableData.filterValue || null,
+      value: columnDef[tableData].filterValue || null,
       onChange: onDateInputChange,
       placeholder: this.getLocalizedFilterPlaceHolder(columnDef),
       clearable: true,
@@ -206,12 +207,12 @@ class MTableFilterRow extends React.Component {
     const columns = this.props.columns
       .filter(
         (columnDef) =>
-          !columnDef.hidden && !(columnDef.tableData.groupOrder > -1)
+          !columnDef.hidden && !(columnDef[tableData].groupOrder > -1)
       )
-      .sort((a, b) => a.tableData.columnOrder - b.tableData.columnOrder)
+      .sort((a, b) => a[tableData].columnOrder - b[tableData].columnOrder)
       .map((columnDef) => (
         <TableCell
-          key={columnDef.tableData.id}
+          key={columnDef[tableData].id}
           style={{
             ...this.props.filterCellStyle,
             ...columnDef.filterCellStyle,
@@ -264,14 +265,14 @@ class MTableFilterRow extends React.Component {
     }
 
     this.props.columns
-      .filter((columnDef) => columnDef.tableData.groupOrder > -1)
+      .filter((columnDef) => columnDef[tableData].groupOrder > -1)
       .forEach((columnDef) => {
         columns.splice(
           0,
           0,
           <TableCell
             padding="checkbox"
-            key={"key-group-filter" + columnDef.tableData.id}
+            key={"key-group-filter" + columnDef[tableData].id}
           />
         );
       });

--- a/src/components/m-table-group-row.js
+++ b/src/components/m-table-group-row.js
@@ -4,6 +4,7 @@ import TableRow from "@material-ui/core/TableRow";
 import IconButton from "@material-ui/core/IconButton";
 import PropTypes from "prop-types";
 import * as React from "react";
+import { tableData } from "../utils/common-values";
 /* eslint-enable no-unused-vars */
 
 export default class MTableGroupRow extends React.Component {
@@ -54,7 +55,7 @@ export default class MTableGroupRow extends React.Component {
         ));
       } else {
         detail = this.props.groupData.data.map((rowData, index) => {
-          if (rowData.tableData.editing) {
+          if (rowData[tableData].editing) {
             return (
               <this.props.components.EditRow
                 columns={this.props.columns}
@@ -64,7 +65,7 @@ export default class MTableGroupRow extends React.Component {
                 path={[...this.props.path, index]}
                 localization={this.props.localization}
                 key={index}
-                mode={rowData.tableData.editing}
+                mode={rowData[tableData].editing}
                 options={this.props.options}
                 isTreeData={this.props.isTreeData}
                 detailPanel={this.props.detailPanel}

--- a/src/components/m-table-groupbar.js
+++ b/src/components/m-table-groupbar.js
@@ -5,6 +5,7 @@ import Typography from "@material-ui/core/Typography";
 import PropTypes from "prop-types";
 import * as React from "react";
 import { Droppable, Draggable } from "react-beautiful-dnd";
+import { tableData } from "../utils/common-values";
 /* eslint-enable no-unused-vars */
 
 class MTableGroupbar extends React.Component {
@@ -58,8 +59,8 @@ class MTableGroupbar extends React.Component {
               {this.props.groupColumns.map((columnDef, index) => {
                 return (
                   <Draggable
-                    key={columnDef.tableData.id}
-                    draggableId={columnDef.tableData.id.toString()}
+                    key={columnDef[tableData].id}
+                    draggableId={columnDef[tableData].id.toString()}
                     index={index}
                   >
                     {(provided, snapshot) => (
@@ -82,12 +83,12 @@ class MTableGroupbar extends React.Component {
                               <div style={{ float: "left" }}>
                                 {columnDef.title}
                               </div>
-                              {columnDef.tableData.groupSort && (
+                              {columnDef[tableData].groupSort && (
                                 <this.props.icons.SortArrow
                                   style={{
                                     transition: "300ms ease all",
                                     transform:
-                                      columnDef.tableData.groupSort === "asc"
+                                      columnDef[tableData].groupSort === "asc"
                                         ? "rotate(-180deg)"
                                         : "none",
                                     fontSize: 18,

--- a/src/components/m-table-header.js
+++ b/src/components/m-table-header.js
@@ -11,7 +11,7 @@ import { Draggable } from "react-beautiful-dnd";
 import { Tooltip } from "@material-ui/core";
 import * as CommonValues from "../utils/common-values";
 import equal from "fast-deep-equal";
-
+const tableData = CommonValues.tableData;
 /* eslint-enable no-unused-vars */
 
 export class MTableHeader extends React.Component {
@@ -40,7 +40,7 @@ export class MTableHeader extends React.Component {
 
   handleMouseDown = (e, columnDef) => {
     this.setState({
-      lastAdditionalWidth: columnDef.tableData.additionalWidth,
+      lastAdditionalWidth: columnDef[tableData].additionalWidth,
       lastX: e.clientX,
       resizingColumnDef: columnDef,
     });
@@ -60,10 +60,11 @@ export class MTableHeader extends React.Component {
     );
 
     if (
-      this.state.resizingColumnDef.tableData.additionalWidth !== additionalWidth
+      this.state.resizingColumnDef[tableData].additionalWidth !==
+      additionalWidth
     ) {
       this.props.onColumnResized(
-        this.state.resizingColumnDef.tableData.id,
+        this.state.resizingColumnDef[tableData].id,
         additionalWidth
       );
     }
@@ -75,7 +76,7 @@ export class MTableHeader extends React.Component {
 
   getCellStyle = (columnDef) => {
     const width = CommonValues.reducePercentsInCalc(
-      columnDef.tableData.width,
+      columnDef[tableData].width,
       this.props.scrollWidth
     );
 
@@ -105,17 +106,17 @@ export class MTableHeader extends React.Component {
     const mapArr = this.props.columns
       .filter(
         (columnDef) =>
-          !columnDef.hidden && !(columnDef.tableData.groupOrder > -1)
+          !columnDef.hidden && !(columnDef[tableData].groupOrder > -1)
       )
-      .sort((a, b) => a.tableData.columnOrder - b.tableData.columnOrder)
+      .sort((a, b) => a[tableData].columnOrder - b[tableData].columnOrder)
       .map((columnDef, index) => {
         let content = columnDef.title;
 
         if (this.props.draggable) {
           content = (
             <Draggable
-              key={columnDef.tableData.id}
-              draggableId={columnDef.tableData.id.toString()}
+              key={columnDef[tableData].id}
+              draggableId={columnDef[tableData].id.toString()}
               index={index}
             >
               {(provided, snapshot) => (
@@ -135,11 +136,11 @@ export class MTableHeader extends React.Component {
           content = (
             <TableSortLabel
               IconComponent={this.props.icons.SortArrow}
-              active={this.props.orderBy === columnDef.tableData.id}
+              active={this.props.orderBy === columnDef[tableData].id}
               direction={this.props.orderDirection || "asc"}
               onClick={() => {
                 const orderDirection =
-                  columnDef.tableData.id !== this.props.orderBy
+                  columnDef[tableData].id !== this.props.orderBy
                     ? "asc"
                     : this.props.orderDirection === "asc"
                     ? "desc"
@@ -153,7 +154,7 @@ export class MTableHeader extends React.Component {
                     ? "asc"
                     : "desc";
                 this.props.onOrderChange(
-                  columnDef.tableData.id,
+                  columnDef[tableData].id,
                   orderDirection
                 );
               }}
@@ -185,8 +186,8 @@ export class MTableHeader extends React.Component {
                   cursor: "col-resize",
                   color:
                     this.state.resizingColumnDef &&
-                    this.state.resizingColumnDef.tableData.id ===
-                      columnDef.tableData.id
+                    this.state.resizingColumnDef[tableData].id ===
+                      columnDef[tableData].id
                       ? this.props.theme.palette.primary.main
                       : "inherit",
                 }}
@@ -204,7 +205,7 @@ export class MTableHeader extends React.Component {
             : "left";
         return (
           <TableCell
-            key={columnDef.tableData.id}
+            key={columnDef[tableData].id}
             align={cellAlignment}
             className={this.props.classes.header}
             style={this.getCellStyle(columnDef)}
@@ -329,14 +330,14 @@ export class MTableHeader extends React.Component {
     }
 
     this.props.columns
-      .filter((columnDef) => columnDef.tableData.groupOrder > -1)
+      .filter((columnDef) => columnDef[tableData].groupOrder > -1)
       .forEach((columnDef) => {
         headers.splice(
           0,
           0,
           <TableCell
             padding="checkbox"
-            key={"key-group-header" + columnDef.tableData.id}
+            key={"key-group-header" + columnDef[tableData].id}
             className={this.props.classes.header}
           />
         );

--- a/src/components/m-table-toolbar.js
+++ b/src/components/m-table-toolbar.js
@@ -16,6 +16,7 @@ import { CsvBuilder } from "filefy";
 import PropTypes, { oneOf } from "prop-types";
 import "jspdf-autotable";
 import * as React from "react";
+import { tableData } from "../utils/common-values";
 const jsPDF = typeof window !== "undefined" ? require("jspdf").jsPDF : null;
 /* eslint-enable no-unused-vars */
 
@@ -43,7 +44,7 @@ export class MTableToolbar extends React.Component {
           columnDef.field
       )
       .sort((a, b) =>
-        a.tableData.columnOrder > b.tableData.columnOrder ? 1 : -1
+        a[tableData].columnOrder > b[tableData].columnOrder ? 1 : -1
       );
     const data = (this.props.exportAllData
       ? this.props.data
@@ -212,16 +213,16 @@ export class MTableToolbar extends React.Component {
               {this.props.columns.map((col) => {
                 if (!col.hidden || col.hiddenByColumnsButton) {
                   return (
-                    <li key={col.tableData.id}>
+                    <li key={col[tableData].id}>
                       <MenuItem
                         className={classes.formControlLabel}
                         component="label"
-                        htmlFor={`column-toggle-${col.tableData.id}`}
+                        htmlFor={`column-toggle-${col[tableData].id}`}
                         disabled={col.removable === false}
                       >
                         <Checkbox
                           checked={!col.hidden}
-                          id={`column-toggle-${col.tableData.id}`}
+                          id={`column-toggle-${col[tableData].id}`}
                           onChange={() =>
                             this.props.onColumnsChanged(col, !col.hidden)
                           }

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -12,7 +12,7 @@ import { debounce } from "debounce";
 import equal from "fast-deep-equal";
 import { withStyles } from "@material-ui/core";
 import * as CommonValues from "./utils/common-values";
-
+const tableData = CommonValues.tableData;
 /* eslint-enable no-unused-vars */
 
 export default class MaterialTable extends React.Component {
@@ -31,14 +31,14 @@ export default class MaterialTable extends React.Component {
       ...renderState,
       query: {
         filters: renderState.columns
-          .filter((a) => a.tableData.filterValue)
+          .filter((a) => a[tableData].filterValue)
           .map((a) => ({
             column: a,
             operator: "=",
-            value: a.tableData.filterValue,
+            value: a[tableData].filterValue,
           })),
         orderBy: renderState.columns.find(
-          (a) => a.tableData.id === renderState.orderBy
+          (a) => a[tableData].id === renderState.orderBy
         ),
         orderDirection: renderState.orderDirection,
         page: 0,
@@ -123,7 +123,7 @@ export default class MaterialTable extends React.Component {
   cleanColumns(columns) {
     return columns.map((col) => {
       const colClone = { ...col };
-      delete colClone.tableData;
+      delete colClone[tableData];
       return colClone;
     });
   }
@@ -335,7 +335,7 @@ export default class MaterialTable extends React.Component {
   };
 
   onChangeGroupOrder = (groupedColumn) => {
-    this.dataManager.changeGroupOrder(groupedColumn.tableData.id);
+    this.dataManager.changeGroupOrder(groupedColumn[tableData].id);
     this.setState(this.dataManager.getRenderState());
   };
 
@@ -347,7 +347,7 @@ export default class MaterialTable extends React.Component {
       const query = { ...this.state.query };
       query.page = 0;
       query.orderBy = this.state.columns.find(
-        (a) => a.tableData.id === newOrderBy
+        (a) => a[tableData].id === newOrderBy
       );
       query.orderDirection = orderDirection;
       this.onQueryChange(query, () => {
@@ -431,7 +431,7 @@ export default class MaterialTable extends React.Component {
     const result = {
       combine: null,
       destination: { droppableId: "headers", index: 0 },
-      draggableId: groupedColumn.tableData.id,
+      draggableId: groupedColumn[tableData].id,
       mode: "FLUID",
       reason: "DROP",
       source: { index, droppableId: "groups" },
@@ -633,7 +633,7 @@ export default class MaterialTable extends React.Component {
 
       const findSelecteds = (list) => {
         list.forEach((row) => {
-          if (row.tableData.checked) {
+          if (row[tableData].checked) {
             selectedRows.push(row);
           }
         });
@@ -668,11 +668,11 @@ export default class MaterialTable extends React.Component {
       const query = { ...this.state.query };
       query.page = 0;
       query.filters = this.state.columns
-        .filter((a) => a.tableData.filterValue)
+        .filter((a) => a[tableData].filterValue)
         .map((a) => ({
           column: a,
           operator: "=",
-          value: a.tableData.filterValue,
+          value: a[tableData].filterValue,
         }));
 
       this.onQueryChange(query);
@@ -680,11 +680,11 @@ export default class MaterialTable extends React.Component {
       this.setState(this.dataManager.getRenderState(), () => {
         if (this.props.onFilterChange) {
           const appliedFilters = this.state.columns
-            .filter((a) => a.tableData.filterValue)
+            .filter((a) => a[tableData].filterValue)
             .map((a) => ({
               column: a,
               operator: "=",
-              value: a.tableData.filterValue,
+              value: a[tableData].filterValue,
             }));
           this.props.onFilterChange(appliedFilters);
         }
@@ -696,7 +696,7 @@ export default class MaterialTable extends React.Component {
     this.dataManager.changeTreeExpand(path);
     this.setState(this.dataManager.getRenderState(), () => {
       this.props.onTreeExpandChange &&
-        this.props.onTreeExpandChange(data, data.tableData.isTreeExpanded);
+        this.props.onTreeExpandChange(data, data[tableData].isTreeExpanded);
     });
   };
 
@@ -838,7 +838,7 @@ export default class MaterialTable extends React.Component {
             props.parentChildData
               ? this.state.treefiedDataLength
               : this.state.columns.filter(
-                  (col) => col.tableData.groupOrder > -1
+                  (col) => col[tableData].groupOrder > -1
                 ).length > 0
               ? this.state.groupedDataLength
               : this.state.data.length
@@ -942,11 +942,11 @@ export default class MaterialTable extends React.Component {
     for (let i = 0; i < Math.abs(count) && i < props.columns.length; i++) {
       const colDef =
         props.columns[count >= 0 ? i : props.columns.length - 1 - i];
-      if (colDef.tableData) {
-        if (typeof colDef.tableData.width === "number") {
-          result.push(colDef.tableData.width + "px");
+      if (colDef[tableData]) {
+        if (typeof colDef[tableData].width === "number") {
+          result.push(colDef[tableData].width + "px");
         } else {
-          result.push(colDef.tableData.width);
+          result.push(colDef[tableData].width);
         }
       }
     }
@@ -976,7 +976,7 @@ export default class MaterialTable extends React.Component {
               selectedRows={
                 this.state.selectedCount > 0
                   ? this.state.originalData.filter((a) => {
-                      return a.tableData.checked;
+                      return a[tableData].checked;
                     })
                   : []
               }
@@ -1019,10 +1019,10 @@ export default class MaterialTable extends React.Component {
                 ...props.localization.grouping,
               }}
               groupColumns={this.state.columns
-                .filter((col) => col.tableData.groupOrder > -1)
+                .filter((col) => col[tableData].groupOrder > -1)
                 .sort(
                   (col1, col2) =>
-                    col1.tableData.groupOrder - col2.tableData.groupOrder
+                    col1[tableData].groupOrder - col2[tableData].groupOrder
                 )}
               onSortChanged={this.onChangeGroupOrder}
               onGroupRemoved={this.onGroupRemoved}

--- a/src/utils/common-values.js
+++ b/src/utils/common-values.js
@@ -1,3 +1,5 @@
+export const tableData = Symbol("tableData");
+
 export const elementSize = (props) =>
   props.options.padding === "default" ? "medium" : "small";
 export const baseIconSize = (props) =>

--- a/src/utils/data-manager.js
+++ b/src/utils/data-manager.js
@@ -1,5 +1,6 @@
 import formatDate from "date-fns/format";
 import { byString } from "./";
+import { tableData } from "./common-values";
 
 export default class DataManager {
   applyFilters = false;
@@ -49,8 +50,8 @@ export default class DataManager {
     this.selectedCount = 0;
 
     this.data = data.map((row, index) => {
-      row.tableData = { ...row.tableData, id: index };
-      if (row.tableData.checked) {
+      row[tableData] = { ...row[tableData], id: index };
+      if (row[tableData].checked) {
         this.selectedCount++;
       }
       return row;
@@ -64,9 +65,8 @@ export default class DataManager {
       (c) => c.width === undefined && !c.hidden
     );
     let usedWidth = ["0px"];
-
     this.columns = columns.map((columnDef, index) => {
-      columnDef.tableData = {
+      columnDef[tableData] = {
         columnOrder: index,
         filterValue: columnDef.defaultFilter,
         groupOrder: columnDef.defaultGroupOrder,
@@ -80,12 +80,15 @@ export default class DataManager {
             ? columnDef.width + "px"
             : columnDef.width,
         additionalWidth: 0,
-        ...columnDef.tableData,
+        ...columnDef[tableData],
         id: index,
       };
 
-      if (columnDef.tableData.width !== undefined) {
-        usedWidth.push(columnDef.tableData.width);
+      if (
+        columnDef[tableData] !== undefined &&
+        columnDef[tableData].width !== undefined
+      ) {
+        usedWidth.push(columnDef[tableData].width);
       }
 
       return columnDef;
@@ -93,7 +96,9 @@ export default class DataManager {
 
     usedWidth = "(" + usedWidth.join(" + ") + ")";
     undefinedWidthColumns.forEach((columnDef) => {
-      columnDef.tableData.width = columnDef.tableData.initialWidth = `calc((100% - ${usedWidth}) / ${undefinedWidthColumns.length})`;
+      columnDef[tableData].width = columnDef[
+        tableData
+      ].initialWidth = `calc((100% - ${usedWidth}) / ${undefinedWidthColumns.length})`;
     });
   }
 
@@ -136,20 +141,20 @@ export default class DataManager {
   }
 
   changeFilterValue(columnId, value) {
-    this.columns[columnId].tableData.filterValue = value;
+    this.columns[columnId][tableData].filterValue = value;
     this.filtered = false;
   }
 
   changeRowSelected(checked, path) {
     const rowData = this.findDataByPath(this.sortedData, path);
-    rowData.tableData.checked = checked;
+    rowData[tableData].checked = checked;
     this.selectedCount = this.selectedCount + (checked ? 1 : -1);
 
     const checkChildRows = (rowData) => {
-      if (rowData.tableData.childRows) {
-        rowData.tableData.childRows.forEach((childRow) => {
-          if (childRow.tableData.checked !== checked) {
-            childRow.tableData.checked = checked;
+      if (rowData[tableData].childRows) {
+        rowData[tableData].childRows.forEach((childRow) => {
+          if (childRow[tableData].checked !== checked) {
+            childRow[tableData].checked = checked;
             this.selectedCount = this.selectedCount + (checked ? 1 : -1);
           }
           checkChildRows(childRow);
@@ -166,11 +171,12 @@ export default class DataManager {
     const rowData = this.findDataByPath(this.sortedData, path);
 
     if (
-      (rowData.tableData.showDetailPanel || "").toString() === render.toString()
+      (rowData[tableData].showDetailPanel || "").toString() ===
+      render.toString()
     ) {
-      rowData.tableData.showDetailPanel = undefined;
+      rowData[tableData].showDetailPanel = undefined;
     } else {
-      rowData.tableData.showDetailPanel = render;
+      rowData[tableData].showDetailPanel = render;
     }
 
     if (
@@ -178,7 +184,7 @@ export default class DataManager {
       this.lastDetailPanelRow &&
       this.lastDetailPanelRow != rowData
     ) {
-      this.lastDetailPanelRow.tableData.showDetailPanel = undefined;
+      this.lastDetailPanelRow[tableData].showDetailPanel = undefined;
     }
 
     this.lastDetailPanelRow = rowData;
@@ -197,10 +203,10 @@ export default class DataManager {
 
   changeRowEditing(rowData, mode) {
     if (rowData) {
-      rowData.tableData.editing = mode;
+      rowData[tableData].editing = mode;
 
       if (this.lastEditingRow && this.lastEditingRow != rowData) {
-        this.lastEditingRow.tableData.editing = undefined;
+        this.lastEditingRow[tableData].editing = undefined;
       }
 
       if (mode) {
@@ -209,7 +215,7 @@ export default class DataManager {
         this.lastEditingRow = undefined;
       }
     } else if (this.lastEditingRow) {
-      this.lastEditingRow.tableData.editing = undefined;
+      this.lastEditingRow[tableData].editing = undefined;
       this.lastEditingRow = undefined;
     }
   }
@@ -227,7 +233,7 @@ export default class DataManager {
             setCheck(element.groups);
           } else {
             element.data.forEach((d) => {
-              d.tableData.checked = d.tableData.disabled ? false : checked;
+              d[tableData].checked = d[tableData].disabled ? false : checked;
               selectedCount++;
             });
           }
@@ -237,7 +243,7 @@ export default class DataManager {
       setCheck(this.groupedData);
     } else {
       this.searchedData.map((row) => {
-        row.tableData.checked = row.tableData.disabled ? false : checked;
+        row[tableData].checked = row[tableData].disabled ? false : checked;
         return row;
       });
       selectedCount = this.searchedData.length;
@@ -255,12 +261,12 @@ export default class DataManager {
   }
 
   changeGroupOrder(columnId) {
-    const column = this.columns.find((c) => c.tableData.id === columnId);
+    const column = this.columns.find((c) => c[tableData].id === columnId);
 
-    if (column.tableData.groupSort === "asc") {
-      column.tableData.groupSort = "desc";
+    if (column[tableData].groupSort === "asc") {
+      column[tableData].groupSort = "desc";
     } else {
-      column.tableData.groupSort = "asc";
+      column[tableData].groupSort = "asc";
     }
 
     this.sorted = false;
@@ -273,7 +279,7 @@ export default class DataManager {
 
   changeTreeExpand(path) {
     const rowData = this.findDataByPath(this.sortedData, path);
-    rowData.tableData.isTreeExpanded = !rowData.tableData.isTreeExpanded;
+    rowData[tableData].isTreeExpanded = !rowData[tableData].isTreeExpanded;
   }
 
   changeDetailPanelType(type) {
@@ -284,9 +290,9 @@ export default class DataManager {
     let start = 0;
 
     let groups = this.columns
-      .filter((col) => col.tableData.groupOrder > -1)
+      .filter((col) => col[tableData].groupOrder > -1)
       .sort(
-        (col1, col2) => col1.tableData.groupOrder - col2.tableData.groupOrder
+        (col1, col2) => col1[tableData].groupOrder - col2[tableData].groupOrder
       );
 
     if (
@@ -312,7 +318,7 @@ export default class DataManager {
       result.source.droppableId === "headers"
     ) {
       const newGroup = this.columns.find(
-        (c) => c.tableData.id == result.draggableId
+        (c) => c[tableData].id == result.draggableId
       );
 
       if (newGroup.grouping === false || !newGroup.field) {
@@ -325,9 +331,9 @@ export default class DataManager {
       result.source.droppableId === "groups"
     ) {
       const removeGroup = this.columns.find(
-        (c) => c.tableData.id == result.draggableId
+        (c) => c[tableData].id == result.draggableId
       );
-      removeGroup.tableData.groupOrder = undefined;
+      removeGroup[tableData].groupOrder = undefined;
       groups.splice(result.source.index, 1);
     } else if (
       result.destination.droppableId === "headers" &&
@@ -338,8 +344,8 @@ export default class DataManager {
 
       // get the effective start and end considering hidden columns
       const sorted = this.columns
-        .sort((a, b) => a.tableData.columnOrder - b.tableData.columnOrder)
-        .filter((column) => column.tableData.groupOrder === undefined);
+        .sort((a, b) => a[tableData].columnOrder - b[tableData].columnOrder)
+        .filter((column) => column[tableData].groupOrder === undefined);
       let numHiddenBeforeStart = 0;
       let numVisibleBeforeStart = 0;
       for (
@@ -378,7 +384,7 @@ export default class DataManager {
       }
 
       for (let i = 0; i < colsToMov.length; i++) {
-        colsToMov[i].tableData.columnOrder = effectiveStart + i;
+        colsToMov[i][tableData].columnOrder = effectiveStart + i;
       }
 
       return;
@@ -387,26 +393,26 @@ export default class DataManager {
     }
 
     for (let i = 0; i < groups.length; i++) {
-      groups[i].tableData.groupOrder = start + i;
+      groups[i][tableData].groupOrder = start + i;
     }
 
     this.sorted = this.grouped = false;
   }
 
   startCellEditable = (rowData, columnDef) => {
-    rowData.tableData.editCellList = [
-      ...(rowData.tableData.editCellList || []),
+    rowData[tableData].editCellList = [
+      ...(rowData[tableData].editCellList || []),
       columnDef,
     ];
   };
 
   finishCellEditable = (rowData, columnDef) => {
-    if (rowData.tableData.editCellList) {
-      var index = rowData.tableData.editCellList.findIndex(
-        (c) => c.tableData.id === columnDef.tableData.id
+    if (rowData[tableData].editCellList) {
+      var index = rowData[tableData].editCellList.findIndex(
+        (c) => c[tableData].id === columnDef[tableData].id
       );
       if (index !== -1) {
-        rowData.tableData.editCellList.splice(index, 1);
+        rowData[tableData].editCellList.splice(index, 1);
       }
     }
   };
@@ -416,32 +422,34 @@ export default class DataManager {
   };
 
   onBulkEditRowChanged = (oldData, newData) => {
-    this.bulkEditChangedRows[oldData.tableData.id] = {
+    this.bulkEditChangedRows[oldData[tableData].id] = {
       oldData,
       newData,
     };
   };
 
   onColumnResized(id, additionalWidth) {
-    const column = this.columns.find((c) => c.tableData.id === id);
+    const column = this.columns.find((c) => c[tableData].id === id);
     if (!column) return;
 
-    const nextColumn = this.columns.find((c) => c.tableData.id === id + 1);
+    const nextColumn = this.columns.find((c) => c[tableData].id === id + 1);
     if (!nextColumn) return;
 
-    // console.log("S i: " + column.tableData.initialWidth);
-    // console.log("S a: " + column.tableData.additionalWidth);
-    // console.log("S w: " + column.tableData.width);
+    // console.log("S i: " + column[tableData].initialWidth);
+    // console.log("S a: " + column[tableData].additionalWidth);
+    // console.log("S w: " + column[tableData].width);
 
-    column.tableData.additionalWidth = additionalWidth;
-    column.tableData.width = `calc(${column.tableData.initialWidth} + ${column.tableData.additionalWidth}px)`;
+    column[tableData].additionalWidth = additionalWidth;
+    column[
+      tableData
+    ].width = `calc(${column[tableData].initialWidth} + ${column[tableData].additionalWidth}px)`;
 
-    // nextColumn.tableData.additionalWidth = -1 * additionalWidth;
-    // nextColumn.tableData.width = `calc(${nextColumn.tableData.initialWidth} + ${nextColumn.tableData.additionalWidth}px)`;
+    // nextColumn[tableData].additionalWidth = -1 * additionalWidth;
+    // nextColumn[tableData].width = `calc(${nextColumn[tableData].initialWidth} + ${nextColumn[tableData].additionalWidth}px)`;
 
-    // console.log("F i: " + column.tableData.initialWidth);
-    // console.log("F a: " + column.tableData.additionalWidth);
-    // console.log("F w: " + column.tableData.width);
+    // console.log("F i: " + column[tableData].initialWidth);
+    // console.log("F a: " + column[tableData].additionalWidth);
+    // console.log("F w: " + column[tableData].width);
   }
 
   expandTreeForNodes = (data) => {
@@ -450,7 +458,7 @@ export default class DataManager {
       while (this.parentFunc(currentRow, this.data)) {
         let parent = this.parentFunc(currentRow, this.data);
         if (parent) {
-          parent.tableData.isTreeExpanded = true;
+          parent[tableData].isTreeExpanded = true;
         }
         currentRow = parent;
       }
@@ -463,9 +471,9 @@ export default class DataManager {
         (result, current) => {
           return (
             result &&
-            result.tableData &&
-            result.tableData.childRows &&
-            result.tableData.childRows[current]
+            result[tableData] &&
+            result[tableData].childRows &&
+            result[tableData].childRows[current]
           );
         },
         { tableData: { childRows: renderData } }
@@ -523,7 +531,7 @@ export default class DataManager {
 
     if (this.parentFunc) {
       dataType = "tree";
-    } else if (this.columns.find((a) => a.tableData.groupOrder > -1)) {
+    } else if (this.columns.find((a) => a[tableData].groupOrder > -1)) {
       dataType = "group";
     }
 
@@ -544,7 +552,9 @@ export default class DataManager {
   }
 
   sortList(list) {
-    const columnDef = this.columns.find((_) => _.tableData.id === this.orderBy);
+    const columnDef = this.columns.find(
+      (_) => _[tableData].id === this.orderBy
+    );
     let result = list;
 
     if (columnDef.customSort) {
@@ -628,7 +638,7 @@ export default class DataManager {
 
     if (this.applyFilters) {
       this.columns
-        .filter((columnDef) => columnDef.tableData.filterValue)
+        .filter((columnDef) => columnDef[tableData].filterValue)
         .forEach((columnDef) => {
           const { lookup, type, tableData } = columnDef;
           if (columnDef.customFilterAndSearch) {
@@ -780,9 +790,9 @@ export default class DataManager {
     const tmpData = [...this.searchedData];
 
     const groups = this.columns
-      .filter((col) => col.tableData.groupOrder > -1)
+      .filter((col) => col[tableData].groupOrder > -1)
       .sort(
-        (col1, col2) => col1.tableData.groupOrder - col2.tableData.groupOrder
+        (col1, col2) => col1[tableData].groupOrder - col2[tableData].groupOrder
       );
 
     const subData = tmpData.reduce(
@@ -838,7 +848,7 @@ export default class DataManager {
 
   treefyData() {
     this.sorted = this.paged = false;
-    this.data.forEach((a) => (a.tableData.childRows = null));
+    this.data.forEach((a) => (a[tableData].childRows = null));
     this.treefiedData = [];
     this.treefiedDataLength = 0;
     this.treeDataMaxLevel = 0;
@@ -846,10 +856,10 @@ export default class DataManager {
     // if filter or search is enabled, collapse the tree
     if (
       this.searchText ||
-      this.columns.some((columnDef) => columnDef.tableData.filterValue)
+      this.columns.some((columnDef) => columnDef[tableData].filterValue)
     ) {
       this.data.forEach((row) => {
-        row.tableData.isTreeExpanded = false;
+        row[tableData].isTreeExpanded = false;
       });
 
       // expand the tree for all nodes present after filtering and searching
@@ -857,30 +867,30 @@ export default class DataManager {
     }
 
     const addRow = (rowData) => {
-      rowData.tableData.markedForTreeRemove = false;
+      rowData[tableData].markedForTreeRemove = false;
       let parent = this.parentFunc(rowData, this.data);
       if (parent) {
-        parent.tableData.childRows = parent.tableData.childRows || [];
-        if (!parent.tableData.childRows.includes(rowData)) {
-          parent.tableData.childRows.push(rowData);
+        parent[tableData].childRows = parent[tableData].childRows || [];
+        if (!parent[tableData].childRows.includes(rowData)) {
+          parent[tableData].childRows.push(rowData);
           this.treefiedDataLength++;
         }
 
         addRow(parent);
 
-        rowData.tableData.path = [
-          ...parent.tableData.path,
-          parent.tableData.childRows.length - 1,
+        rowData[tableData].path = [
+          ...parent[tableData].path,
+          parent[tableData].childRows.length - 1,
         ];
         this.treeDataMaxLevel = Math.max(
           this.treeDataMaxLevel,
-          rowData.tableData.path.length
+          rowData[tableData].path.length
         );
       } else {
         if (!this.treefiedData.includes(rowData)) {
           this.treefiedData.push(rowData);
           this.treefiedDataLength++;
-          rowData.tableData.path = [this.treefiedData.length - 1];
+          rowData[tableData].path = [this.treefiedData.length - 1];
         }
       }
     };
@@ -891,39 +901,39 @@ export default class DataManager {
     });
     const markForTreeRemove = (rowData) => {
       let pointer = this.treefiedData;
-      rowData.tableData.path.forEach((pathPart) => {
-        if (pointer.tableData && pointer.tableData.childRows) {
-          pointer = pointer.tableData.childRows;
+      rowData[tableData].path.forEach((pathPart) => {
+        if (pointer[tableData] && pointer[tableData].childRows) {
+          pointer = pointer[tableData].childRows;
         }
         pointer = pointer[pathPart];
       });
-      pointer.tableData.markedForTreeRemove = true;
+      pointer[tableData].markedForTreeRemove = true;
     };
 
     const traverseChildrenAndUnmark = (rowData) => {
-      if (rowData.tableData.childRows) {
-        rowData.tableData.childRows.forEach((row) => {
+      if (rowData[tableData].childRows) {
+        rowData[tableData].childRows.forEach((row) => {
           traverseChildrenAndUnmark(row);
         });
       }
-      rowData.tableData.markedForTreeRemove = false;
+      rowData[tableData].markedForTreeRemove = false;
     };
 
     // for all data rows, restore initial expand if no search term is available and remove items that shouldn't be there
     this.data.forEach((rowData) => {
       if (
         !this.searchText &&
-        !this.columns.some((columnDef) => columnDef.tableData.filterValue)
+        !this.columns.some((columnDef) => columnDef[tableData].filterValue)
       ) {
-        if (rowData.tableData.isTreeExpanded === undefined) {
+        if (rowData[tableData].isTreeExpanded === undefined) {
           var isExpanded =
             typeof this.defaultExpanded === "boolean"
               ? this.defaultExpanded
               : this.defaultExpanded(rowData);
-          rowData.tableData.isTreeExpanded = isExpanded;
+          rowData[tableData].isTreeExpanded = isExpanded;
         }
       }
-      const hasSearchMatchedChildren = rowData.tableData.isTreeExpanded;
+      const hasSearchMatchedChildren = rowData[tableData].isTreeExpanded;
 
       if (!hasSearchMatchedChildren && this.searchedData.indexOf(rowData) < 0) {
         markForTreeRemove(rowData);
@@ -940,10 +950,10 @@ export default class DataManager {
     const traverseTreeAndDeleteMarked = (rowDataArray) => {
       for (var i = rowDataArray.length - 1; i >= 0; i--) {
         const item = rowDataArray[i];
-        if (item.tableData.childRows) {
-          traverseTreeAndDeleteMarked(item.tableData.childRows);
+        if (item[tableData].childRows) {
+          traverseTreeAndDeleteMarked(item[tableData].childRows);
         }
-        if (item.tableData.markedForTreeRemove) rowDataArray.splice(i, 1);
+        if (item[tableData].markedForTreeRemove) rowDataArray.splice(i, 1);
       }
     };
 
@@ -958,21 +968,22 @@ export default class DataManager {
       this.sortedData = [...this.groupedData];
 
       const groups = this.columns
-        .filter((col) => col.tableData.groupOrder > -1)
+        .filter((col) => col[tableData].groupOrder > -1)
         .sort(
-          (col1, col2) => col1.tableData.groupOrder - col2.tableData.groupOrder
+          (col1, col2) =>
+            col1[tableData].groupOrder - col2[tableData].groupOrder
         );
 
       const sortGroups = (list, columnDef) => {
         if (columnDef.customSort) {
           return list.sort(
-            columnDef.tableData.groupSort === "desc"
+            columnDef[tableData].groupSort === "desc"
               ? (a, b) => columnDef.customSort(b.value, a.value, "group")
               : (a, b) => columnDef.customSort(a.value, b.value, "group")
           );
         } else {
           return list.sort(
-            columnDef.tableData.groupSort === "desc"
+            columnDef[tableData].groupSort === "desc"
               ? (a, b) => this.sort(b.value, a.value, columnDef.type)
               : (a, b) => this.sort(a.value, b.value, columnDef.type)
           );
@@ -1003,11 +1014,11 @@ export default class DataManager {
 
         const sortTree = (list) => {
           list.forEach((item) => {
-            if (item.tableData.childRows) {
-              item.tableData.childRows = this.sortList(
-                item.tableData.childRows
+            if (item[tableData].childRows) {
+              item[tableData].childRows = this.sortList(
+                item[tableData].childRows
               );
-              sortTree(item.tableData.childRows);
+              sortTree(item[tableData].childRows);
             }
           });
         };

--- a/src/utils/polyfill/index.js
+++ b/src/utils/polyfill/index.js
@@ -2,3 +2,7 @@
 if (!Array.prototype.find) {
   require("./array.find");
 }
+
+if (typeof Symbol !== "function") {
+  require("./symbol");
+}

--- a/src/utils/polyfill/symbol.js
+++ b/src/utils/polyfill/symbol.js
@@ -1,0 +1,638 @@
+/*!
+ * Symbol-ES6 v0.1.2
+ * ES6 Symbol polyfill in pure ES5.
+ *
+ * @license Copyright (c) 2017-2018 Rousan Ali, MIT License
+ *
+ * Codebase: https://github.com/rousan/symbol-es6
+ * Date: 28th Jan, 2018
+ */
+
+(function (global, factory) {
+  "use strict";
+
+  if (typeof module === "object" && typeof module.exports === "object") {
+    // For the environment like NodeJS, CommonJS etc where module or
+    // module.exports objects are available
+    module.exports = factory(global);
+  } else {
+    // For browser context, where global object is window
+    factory(global);
+  }
+
+  /* window is for browser environment and global is for NodeJS environment */
+})(typeof window !== "undefined" ? window : global, function (global) {
+  "use strict";
+
+  var defineProperty = Object.defineProperty;
+
+  var defineProperties = Object.defineProperties;
+
+  var symbolHiddenCounter = 0;
+
+  var globalSymbolRegistry = [];
+
+  var slice = Array.prototype.slice;
+
+  var ES6 = typeof global.ES6 === "object" ? global.ES6 : (global.ES6 = {});
+
+  var isArray = Array.isArray;
+
+  var objectToString = Object.prototype.toString;
+
+  var push = Array.prototype.push;
+
+  var emptyFunction = function () {};
+
+  var simpleFunction = function (arg) {
+    return arg;
+  };
+
+  var isCallable = function (fn) {
+    return typeof fn === "function";
+  };
+
+  var isConstructor = function (fn) {
+    return isCallable(fn);
+  };
+
+  var Iterator = function () {};
+
+  var ArrayIterator = function ArrayIterator(array, flag) {
+    this._array = array;
+    this._flag = flag;
+    this._nextIndex = 0;
+  };
+
+  var StringIterator = function StringIterator(string, flag) {
+    this._string = string;
+    this._flag = flag;
+    this._nextIndex = 0;
+  };
+
+  var isES6Running = function () {
+    return false; /* Now 'false' for testing purpose */
+  };
+
+  var isObject = function (value) {
+    return (
+      value !== null &&
+      (typeof value === "object" || typeof value === "function")
+    );
+  };
+
+  var es6FunctionPrototypeHasInstanceSymbol = function (instance) {
+    if (typeof this !== "function") return false;
+    return instance instanceof this;
+  };
+
+  var es6InstanceOfOperator = function (object, constructor) {
+    if (!isObject(constructor))
+      throw new TypeError("Right-hand side of 'instanceof' is not an object");
+
+    var hasInstanceSymbolProp = constructor[Symbol.hasInstance];
+    if (typeof hasInstanceSymbolProp === "undefined") {
+      return object instanceof constructor;
+    } else if (typeof hasInstanceSymbolProp !== "function") {
+      throw new TypeError(typeof hasInstanceSymbolProp + " is not a function");
+    } else {
+      return hasInstanceSymbolProp.call(constructor, object);
+    }
+  };
+
+  // Generates name for a symbol instance and this name will be used as
+  // property key for property symbols internally.
+  var generateSymbolName = function (id) {
+    return "@@_____" + id + "_____";
+  };
+
+  // Generates id for next Symbol instance
+  var getNextSymbolId = function () {
+    return symbolHiddenCounter++;
+  };
+
+  var setupSymbolInternals = function (symbol, desc) {
+    defineProperties(symbol, {
+      _description: {
+        value: desc,
+      },
+      _isSymbol: {
+        value: true,
+      },
+      _id: {
+        value: getNextSymbolId(),
+      },
+    });
+    return symbol;
+  };
+
+  var checkSymbolInternals = function (symbol) {
+    return (
+      symbol._isSymbol === true &&
+      typeof symbol._id === "number" &&
+      typeof symbol._description === "string"
+    );
+  };
+
+  var isSymbol = function (symbol) {
+    return symbol instanceof Symbol && checkSymbolInternals(symbol);
+  };
+
+  var symbolFor = function (key) {
+    key = String(key);
+    var registryLength = globalSymbolRegistry.length,
+      record,
+      i = 0;
+
+    for (; i < registryLength; ++i) {
+      record = globalSymbolRegistry[i];
+      if (record.key === key) return record.symbol;
+    }
+
+    record = {
+      key: key,
+      symbol: Symbol(key),
+    };
+    globalSymbolRegistry.push(record);
+    return record.symbol;
+  };
+
+  var symbolKeyFor = function (symbol) {
+    if (!ES6.isSymbol(symbol))
+      throw new TypeError(String(symbol) + " is not a symbol");
+    var registryLength = globalSymbolRegistry.length,
+      record,
+      i = 0;
+
+    for (; i < registryLength; ++i) {
+      record = globalSymbolRegistry[i];
+      if (record.symbol === symbol) return record.key;
+    }
+  };
+
+  /* It affects array1 and appends array2 at the end of array1 */
+  var appendArray = function (array1, array2) {
+    // Returns immediately if these are not array or not array-like objects
+    if (
+      !(
+        typeof array1.length === "number" &&
+        array1.length >= 0 &&
+        typeof array2.length === "number" &&
+        array2.length >= 0
+      )
+    )
+      return;
+    var length1 = Math.floor(array1.length),
+      length2 = Math.floor(array2.length),
+      i = 0;
+
+    array1.length = length1 + length2;
+    for (; i < length2; ++i)
+      if (array2.hasOwnProperty(i)) array1[length1 + i] = array2[i];
+  };
+
+  var es6ObjectPrototypeToString = function toString() {
+    if (this === undefined || this === null) return objectToString.call(this);
+    // Add support for @@toStringTag symbol
+    if (typeof this[Symbol.toStringTag] === "string")
+      return "[object " + this[Symbol.toStringTag] + "]";
+    else return objectToString.call(this);
+  };
+
+  var es6ArrayPrototypeConcat = function concat() {
+    if (this === undefined || this === null)
+      throw new TypeError("Array.prototype.concat called on null or undefined");
+
+    // Boxing 'this' value to wrapper object
+    var self = Object(this),
+      targets = slice.call(arguments),
+      outputs = []; // Later it may affected by Symbol
+
+    targets.unshift(self);
+
+    targets.forEach(function (target) {
+      // If target is primitive then just push
+      if (!isObject(target)) outputs.push(target);
+      // Here Symbol.isConcatSpreadable support is added
+      else if (typeof target[Symbol.isConcatSpreadable] !== "undefined") {
+        if (target[Symbol.isConcatSpreadable]) {
+          appendArray(outputs, target);
+        } else {
+          outputs.push(target);
+        }
+      } else if (isArray(target)) {
+        appendArray(outputs, target);
+      } else {
+        outputs.push(target);
+      }
+    });
+    return outputs;
+  };
+
+  var es6ForOfLoop = function (iterable, callback, thisArg) {
+    callback = typeof callback !== "function" ? emptyFunction : callback;
+    if (typeof iterable[Symbol.iterator] !== "function")
+      throw new TypeError("Iterable[Symbol.iterator] is not a function");
+    var iterator = iterable[Symbol.iterator](),
+      iterationResult;
+    if (typeof iterator.next !== "function")
+      throw new TypeError(".iterator.next is not a function");
+    while (true) {
+      iterationResult = iterator.next();
+      if (!isObject(iterationResult))
+        throw new TypeError(
+          "Iterator result " + iterationResult + " is not an object"
+        );
+      if (iterationResult.done) break;
+      callback.call(thisArg, iterationResult.value);
+    }
+  };
+
+  // Provides simple inheritance functionality
+  var simpleInheritance = function (child, parent) {
+    if (typeof child !== "function" || typeof parent !== "function")
+      throw new TypeError("Child and Parent must be function type");
+
+    child.prototype = Object.create(parent.prototype);
+    child.prototype.constructor = child;
+  };
+
+  // Behaves as Symbol function in ES6, take description and returns an unique object,
+  // but in ES6 this function returns 'symbol' primitive typed value.
+  // Its type is 'object' not 'symbol'.
+  // There is no wrapping in this case i.e. Object(sym) = sym.
+  var Symbol = function Symbol(desc) {
+    desc = typeof desc === "undefined" ? "" : String(desc);
+
+    if (this instanceof Symbol)
+      throw new TypeError("Symbol is not a constructor");
+
+    return setupSymbolInternals(Object.create(Symbol.prototype), desc);
+  };
+
+  defineProperties(Symbol, {
+    for: {
+      value: symbolFor,
+      writable: true,
+      configurable: true,
+    },
+
+    keyFor: {
+      value: symbolKeyFor,
+      writable: true,
+      configurable: true,
+    },
+
+    hasInstance: {
+      value: Symbol("Symbol.hasInstance"),
+    },
+
+    isConcatSpreadable: {
+      value: Symbol("Symbol.isConcatSpreadable"),
+    },
+
+    iterator: {
+      value: Symbol("Symbol.iterator"),
+    },
+
+    toStringTag: {
+      value: Symbol("Symbol.toStringTag"),
+    },
+  });
+
+  // In ES6, this function returns like 'Symbol(<desc>)', but in this case
+  // this function returns the symbol's internal name to work properly.
+  Symbol.prototype.toString = function () {
+    return generateSymbolName(this._id);
+  };
+
+  // Returns itself but in ES6 It returns 'symbol' typed value.
+  Symbol.prototype.valueOf = function () {
+    return this;
+  };
+
+  // Make Iterator like iterable
+  defineProperty(Iterator.prototype, Symbol.iterator.toString(), {
+    value: function () {
+      return this;
+    },
+    writable: true,
+    configurable: true,
+  });
+
+  simpleInheritance(ArrayIterator, Iterator);
+
+  simpleInheritance(StringIterator, Iterator);
+
+  defineProperty(ArrayIterator.prototype, Symbol.toStringTag.toString(), {
+    value: "Array Iterator",
+    configurable: true,
+  });
+
+  defineProperty(StringIterator.prototype, Symbol.toStringTag.toString(), {
+    value: "String Iterator",
+    configurable: true,
+  });
+
+  // This iterator works on any Array or TypedArray or array-like objects
+  ArrayIterator.prototype.next = function next() {
+    if (!(this instanceof ArrayIterator))
+      throw new TypeError(
+        "Method Array Iterator.prototype.next called on incompatible receiver " +
+          String(this)
+      );
+
+    var self = this,
+      nextValue;
+
+    if (self._nextIndex === -1) {
+      return {
+        done: true,
+        value: undefined,
+      };
+    }
+
+    if (!(typeof self._array.length === "number" && self._array.length >= 0)) {
+      self._nextIndex = -1;
+      return {
+        done: true,
+        value: undefined,
+      };
+    }
+
+    // _flag = 1 for [index, value]
+    // _flag = 2 for [value]
+    // _flag = 3 for [index]
+    if (self._nextIndex < Math.floor(self._array.length)) {
+      if (self._flag === 1)
+        nextValue = [self._nextIndex, self._array[self._nextIndex]];
+      else if (self._flag === 2) nextValue = self._array[self._nextIndex];
+      else if (self._flag === 3) nextValue = self._nextIndex;
+      self._nextIndex++;
+      return {
+        done: false,
+        value: nextValue,
+      };
+    } else {
+      self._nextIndex = -1;
+      return {
+        done: true,
+        value: undefined,
+      };
+    }
+  };
+
+  StringIterator.prototype.next = function next() {
+    if (!(this instanceof StringIterator))
+      throw new TypeError(
+        "Method String Iterator.prototype.next called on incompatible receiver " +
+          String(this)
+      );
+
+    var self = this,
+      stringObject = new String(this._string),
+      nextValue;
+
+    if (self._nextIndex === -1) {
+      return {
+        done: true,
+        value: undefined,
+      };
+    }
+
+    if (self._nextIndex < stringObject.length) {
+      nextValue = stringObject[self._nextIndex];
+      self._nextIndex++;
+      return {
+        done: false,
+        value: nextValue,
+      };
+    } else {
+      self._nextIndex = -1;
+      return {
+        done: true,
+        value: undefined,
+      };
+    }
+  };
+
+  var es6ArrayPrototypeIteratorSymbol = function values() {
+    if (this === undefined || this === null)
+      throw new TypeError("Cannot convert undefined or null to object");
+
+    var self = Object(this);
+    return new ArrayIterator(self, 2);
+  };
+
+  var es6StringPrototypeIteratorSymbol = function values() {
+    if (this === undefined || this === null)
+      throw new TypeError(
+        "String.prototype[Symbol.iterator] called on null or undefined"
+      );
+    return new StringIterator(String(this), 0);
+  };
+
+  var es6ArrayPrototypeEntries = function entries() {
+    if (this === undefined || this === null)
+      throw new TypeError("Cannot convert undefined or null to object");
+
+    var self = Object(this);
+    return new ArrayIterator(self, 1);
+  };
+
+  var es6ArrayPrototypeKeys = function keys() {
+    if (this === undefined || this === null)
+      throw new TypeError("Cannot convert undefined or null to object");
+    var self = Object(this);
+    return new ArrayIterator(self, 3);
+  };
+
+  var SpreadOperatorImpl = function (target, thisArg) {
+    this._target = target;
+    this._values = [];
+    this._thisArg = thisArg;
+  };
+  // All the arguments must be iterable
+  SpreadOperatorImpl.prototype.spread = function () {
+    var self = this;
+    slice.call(arguments).forEach(function (iterable) {
+      ES6.forOf(iterable, function (value) {
+        self._values.push(value);
+      });
+    });
+    return self;
+  };
+
+  SpreadOperatorImpl.prototype.add = function () {
+    var self = this;
+    slice.call(arguments).forEach(function (value) {
+      self._values.push(value);
+    });
+    return self;
+  };
+
+  SpreadOperatorImpl.prototype.call = function (thisArg) {
+    if (typeof this._target !== "function")
+      throw new TypeError("Target is not a function");
+    thisArg = arguments.length <= 0 ? this._thisArg : thisArg;
+    return this._target.apply(thisArg, this._values);
+  };
+
+  SpreadOperatorImpl.prototype.new = function () {
+    if (typeof this._target !== "function")
+      throw new TypeError("Target is not a constructor");
+
+    var temp, returnValue;
+    temp = Object.create(this._target.prototype);
+    returnValue = this._target.apply(temp, this._values);
+    return isObject(returnValue) ? returnValue : temp;
+  };
+
+  // Affects the target array
+  SpreadOperatorImpl.prototype.array = function () {
+    if (!isArray(this._target)) throw new TypeError("Target is not a array");
+    push.apply(this._target, this._values);
+    return this._target;
+  };
+
+  // Target must be Array or function
+  var es6SpreadOperator = function spreadOperator(target, thisArg) {
+    if (!(typeof target === "function" || isArray(target)))
+      throw new TypeError(
+        "Spread operator only supports on array and function objects at this moment"
+      );
+    return new SpreadOperatorImpl(target, thisArg);
+  };
+
+  var es6ArrayFrom = function from(arrayLike, mapFn, thisArg) {
+    var constructor,
+      i = 0,
+      length,
+      outputs;
+    // Use the generic constructor
+    constructor = !isConstructor(this) ? Array : this;
+    if (arrayLike === undefined || arrayLike === null)
+      throw new TypeError("Cannot convert undefined or null to object");
+
+    arrayLike = Object(arrayLike);
+    if (mapFn === undefined) mapFn = simpleFunction;
+    else if (!isCallable(mapFn))
+      throw new TypeError(mapFn + " is not a function");
+
+    if (typeof arrayLike[Symbol.iterator] === "undefined") {
+      if (!(typeof arrayLike.length === "number" && arrayLike.length >= 0)) {
+        outputs = new constructor(0);
+        outputs.length = 0;
+        return outputs;
+      }
+      length = Math.floor(arrayLike.length);
+      outputs = new constructor(length);
+      outputs.length = length;
+      for (; i < length; ++i) outputs[i] = mapFn.call(thisArg, arrayLike[i]);
+    } else {
+      outputs = new constructor();
+      outputs.length = 0;
+      ES6.forOf(arrayLike, function (value) {
+        outputs.length++;
+        outputs[outputs.length - 1] = mapFn.call(thisArg, value);
+      });
+    }
+    return outputs;
+  };
+
+  // Export ES6 APIs and add all the patches to support Symbol in ES5
+  // If the running environment already supports ES6 then no patches will be applied,
+  if (isES6Running()) return ES6;
+  else {
+    // Some ES6 APIs can't be implemented in pure ES5, so this 'ES6' object provides
+    // some equivalent functionality of these features.
+    defineProperties(ES6, {
+      // Checks if a JS value is a symbol
+      // It can be used as equivalent api in ES6: typeof symbol === 'symbol'
+      isSymbol: {
+        value: isSymbol,
+        writable: true,
+        configurable: true,
+      },
+
+      // Native ES5 'instanceof' operator does not support @@hasInstance symbol,
+      // this method provides same functionality of ES6 'instanceof' operator.
+      instanceOf: {
+        value: es6InstanceOfOperator,
+        writable: true,
+        configurable: true,
+      },
+
+      // This method behaves exactly same as ES6 for...of loop.
+      forOf: {
+        value: es6ForOfLoop,
+        writable: true,
+        configurable: true,
+      },
+
+      // This method gives same functionality of the spread operator of ES6
+      // It works on only functions and arrays.
+      // Limitation: You can't create array like this [...iterable, , , , 33] by this method,
+      // to achieve this you have to do like this [...iterable, undefined, undefined, undefined, 33]
+      spreadOperator: {
+        value: es6SpreadOperator,
+        writable: true,
+        configurable: true,
+      },
+    });
+
+    defineProperty(global, "Symbol", {
+      value: Symbol,
+      writable: true,
+      configurable: true,
+    });
+
+    defineProperty(Function.prototype, Symbol.hasInstance.toString(), {
+      value: es6FunctionPrototypeHasInstanceSymbol,
+    });
+
+    defineProperty(Array.prototype, "concat", {
+      value: es6ArrayPrototypeConcat,
+      writable: true,
+      configurable: true,
+    });
+
+    defineProperty(Object.prototype, "toString", {
+      value: es6ObjectPrototypeToString,
+      writable: true,
+      configurable: true,
+    });
+
+    defineProperty(Array.prototype, Symbol.iterator.toString(), {
+      value: es6ArrayPrototypeIteratorSymbol,
+      writable: true,
+      configurable: true,
+    });
+
+    defineProperty(Array, "from", {
+      value: es6ArrayFrom,
+      writable: true,
+      configurable: true,
+    });
+
+    defineProperty(Array.prototype, "entries", {
+      value: es6ArrayPrototypeEntries,
+      writable: true,
+      configurable: true,
+    });
+
+    defineProperty(Array.prototype, "keys", {
+      value: es6ArrayPrototypeKeys,
+      writable: true,
+      configurable: true,
+    });
+
+    defineProperty(String.prototype, Symbol.iterator.toString(), {
+      value: es6StringPrototypeIteratorSymbol,
+      writable: true,
+      configurable: true,
+    });
+  }
+
+  return ES6;
+});


### PR DESCRIPTION
## Related Issue

#2286 
#666 

## Description

I've replaced all instance of row.tableData and column.tableData with row[tableData] and column[tableData], where tableData is now an ES6 Symbol exported from commonValues.

## Related PRs

None

## Impacted Areas in Application

data-manager

\*

## Additional Notes

Requires additional testing. There should also be a more modern polyfill for ES6 Symbols, so may want to replace here. There also appears to be a JSLint autofix rule somewhere that is breaking the layout of this new syntax, particularly on line 99 & 403 of data-manager when you commit.
