### PR TITLE
Update `pageSizeOptions` with correct definition

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -331,7 +331,7 @@ export interface Options<RowData extends object> {
   groupTitle?: (groupData: any) => any;
   overflowY?: "visible" | "hidden" | "scroll" | "auto" | "initial" | "inherit";
   pageSize?: number;
-  pageSizeOptions?: number[];
+  pageSizeOptions?: Array<number | { value: number; label: string }>;
   paginationType?: "normal" | "stepped";
   paginationPosition?: "bottom" | "top" | "both";
   rowStyle?:


### PR DESCRIPTION
## Description

Update `pageSizeOptions` with correct definition according to Material UI

Ref.: https://github.com/mui-org/material-ui/blob/next/packages/material-ui/src/TablePagination/TablePagination.d.ts#L119

It allows using labels in page size select e.g. "Show all" 

## Related PRs

List related PRs against other branches:

| branch              | PR       |
| ------------------- | -------- |
| other_pr_production | [link]() |
| other_pr_master     | [link]() |

## Impacted Areas in Application

List general components of the application that this PR will affect:

\*
