### PR TITLE
[Typings] Add iconProps to DetailPanel interface

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -103,6 +103,7 @@ export interface DetailPanel<RowData extends object> {
   icon?: string | React.ComponentType<any>;
   openIcon?: string | React.ComponentType<any>;
   tooltip?: string;
+  iconProps?: IconProps;
   render: (rowData: RowData) => string | React.ReactNode;
 }
 


### PR DESCRIPTION
## Related issues
There are no currently open issues about this

## Description

Added a missing property type in the `DetailPanel` interface

## Impacted Areas in Application

\* index.d.ts