### PR TITLE
Add missing adornment icon on lookup filter

### DIFF
--- a/src/components/m-table-filter-row.js
+++ b/src/components/m-table-filter-row.js
@@ -12,7 +12,6 @@ import MenuItem from "@material-ui/core/MenuItem";
 import Checkbox from "@material-ui/core/Checkbox";
 import ListItemText from "@material-ui/core/ListItemText";
 import InputAdornment from "@material-ui/core/InputAdornment";
-import Icon from "@material-ui/core/Icon";
 import Tooltip from "@material-ui/core/Tooltip";
 import DateFnsUtils from "@date-io/date-fns";
 import {
@@ -44,6 +43,8 @@ class MTableFilterRow extends React.Component {
     "";
 
   LookupFilter = ({ columnDef }) => {
+    const localization = this.getLocalizationData();
+    const FilterIcon = this.props.icons.Filter;
     const [selectedFilter, setSelectedFilter] = React.useState(
       columnDef.tableData.filterValue || []
     );
@@ -79,7 +80,16 @@ class MTableFilterRow extends React.Component {
               );
           }}
           input={
-            <Input id={"select-multiple-checkbox" + columnDef.tableData.id} />
+            <Input
+              startAdornment={
+                <InputAdornment position="start">
+                  <Tooltip title={localization.filterTooltip}>
+                    <FilterIcon />
+                  </Tooltip>
+                </InputAdornment>
+              }
+              id={"select-multiple-checkbox" + columnDef.tableData.id}
+            />
           }
           renderValue={(selecteds) =>
             selecteds.map((selected) => columnDef.lookup[selected]).join(", ")


### PR DESCRIPTION
## Related Issue

N/A

## Description

Currently filter textfields have an input adornment icon, but select / lookup filters do not. This PR just adds the same adornment icon to select filters.

## Impacted Areas in Application

Filter row component

