### PR TITLE
Fix for hiddenByColumnsButton property

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -429,6 +429,7 @@ class App extends Component {
         tooltip: "This is tooltip text",
         editPlaceholder: "This is placeholder",
         maxWidth: 50,
+        hidden: true,
       },
       {
         title: "Soyadı",
@@ -437,6 +438,8 @@ class App extends Component {
         tooltip: "This is tooltip text",
         editable: "never",
         resizable: false,
+        hidden: true,
+        hiddenByColumnsButton: true,
       },
       { title: "Evli", field: "isMarried" },
       {
@@ -504,6 +507,7 @@ class App extends Component {
                   //   },
                   // }}
                   options={{
+                    columnsButton: true,
                     tableLayout: "fixed",
                     columnResizable: true,
                     headerSelectionProps: {

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -82,7 +82,7 @@ export default class MaterialTable extends React.Component {
           : "";
     }
 
-    this.dataManager.setColumns(props.columns);
+    this.dataManager.setColumns(props.columns, isInit);
     this.dataManager.setDefaultExpanded(props.options.defaultExpanded);
     this.dataManager.changeRowEditing();
 

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -82,7 +82,7 @@ export default class MaterialTable extends React.Component {
           : "";
     }
 
-    this.dataManager.setColumns(props.columns, isInit);
+    this.dataManager.setColumns(props.columns);
     this.dataManager.setDefaultExpanded(props.options.defaultExpanded);
     this.dataManager.changeRowEditing();
 
@@ -328,7 +328,7 @@ export default class MaterialTable extends React.Component {
 
   onChangeColumnHidden = (column, hidden) => {
     this.dataManager.changeColumnHidden(column, hidden);
-    this.setState(this.dataManager.getRenderState(), () => {
+    this.setState(this.dataManager.getRenderState(true), () => {
       this.props.onChangeColumnHidden &&
         this.props.onChangeColumnHidden(column, hidden);
     });

--- a/src/utils/data-manager.js
+++ b/src/utils/data-manager.js
@@ -61,7 +61,7 @@ export default class DataManager {
 
   setColumns(columns) {
     const undefinedWidthColumns = columns.filter(
-      (c) => c.width === undefined && !c.hidden
+      (c) => c.width === undefined && (!c.hidden || c.hiddenByColumnsButton)
     );
     let usedWidth = ["0px"];
 

--- a/src/utils/data-manager.js
+++ b/src/utils/data-manager.js
@@ -59,9 +59,11 @@ export default class DataManager {
     this.filtered = false;
   }
 
-  setColumns(columns) {
+  setColumns(columns, isInit) {
     const undefinedWidthColumns = columns.filter(
-      (c) => c.width === undefined && (!c.hidden || c.hiddenByColumnsButton)
+      (c) =>
+        c.width === undefined &&
+        (!c.hidden || (isInit && c.hiddenByColumnsButton))
     );
     let usedWidth = ["0px"];
 

--- a/src/utils/data-manager.js
+++ b/src/utils/data-manager.js
@@ -59,11 +59,9 @@ export default class DataManager {
     this.filtered = false;
   }
 
-  setColumns(columns, isInit) {
+  setColumns(columns) {
     const undefinedWidthColumns = columns.filter(
-      (c) =>
-        c.width === undefined &&
-        (!c.hidden || (isInit && c.hiddenByColumnsButton))
+      (c) => c.width === undefined && !c.hidden
     );
     let usedWidth = ["0px"];
 
@@ -576,7 +574,7 @@ export default class DataManager {
     return result;
   }
 
-  getRenderState = () => {
+  getRenderState = (resetColsWidth) => {
     if (this.filtered === false) {
       this.filterData();
     }
@@ -599,6 +597,20 @@ export default class DataManager {
 
     if (this.paged === false) {
       this.pageData();
+    }
+
+    if (resetColsWidth) {
+      this.setColumns(
+        this.columns.map((col) => ({
+          ...col,
+          width: undefined,
+          tableData: {
+            ...col.tableData,
+            initialWidth: undefined,
+            width: undefined,
+          },
+        }))
+      );
     }
 
     return {


### PR DESCRIPTION
## Related Issue

#2414 

## Description

Column width was not calculated for columns hidden. This included columns with hiddenByColumnsButton, which can be made visible by user using columnsButton. As a result of missing width, table was crashing.

Approach to resolution is to reset all table columns' width to "undefined" and call setColumns to recalculate columns width when "onChangeColumnHidden" is called.

## Related PRs

N/A

## Impacted Areas in Application

List general components of the application that this PR will affect:

* data-manager

## Additional Notes

