### PR TITLE
Sort render values in lookup filter

### DIFF
--- a/src/components/m-table-filter-row.js
+++ b/src/components/m-table-filter-row.js
@@ -82,8 +82,10 @@ class MTableFilterRow extends React.Component {
             <Input id={"select-multiple-checkbox" + columnDef.tableData.id} />
           }
           renderValue={(selecteds) =>
-            selecteds.map((selected) => columnDef.lookup[selected]).join(", ")
-          }
+            selecteds
+              .map((selected) => columnDef.lookup[selected])
+              .sort((a, b) => a.localeCompare(b))
+              .join(", ")          }
           MenuProps={MenuProps}
           style={{ marginTop: 0 }}
         >

--- a/src/components/m-table-filter-row.js
+++ b/src/components/m-table-filter-row.js
@@ -85,7 +85,8 @@ class MTableFilterRow extends React.Component {
             selecteds
               .map((selected) => columnDef.lookup[selected])
               .sort((a, b) => a.localeCompare(b))
-              .join(", ")          }
+              .join(", ")
+          }
           MenuProps={MenuProps}
           style={{ marginTop: 0 }}
         >


### PR DESCRIPTION
## Related Issue

N/A

## Description

Depending on the sequence of lookup filter selection by user, render values are not always displayed in the same order. This PR just adds sorting to render values.

## Related PRs

N/A.

## Impacted Areas in Application

List general components of the application that this PR will affect:

* m-table-filter-row

