### PR TITLE
disableInternalSorting flag for column and options

### DIFF
--- a/src/components/m-table-header.js
+++ b/src/components/m-table-header.js
@@ -352,6 +352,7 @@ export class MTableHeader extends React.Component {
 
 MTableHeader.defaultProps = {
   dataCount: 0,
+  disableInternalSorting: false,
   hasSelection: false,
   headerStyle: {},
   selectedCount: 0,
@@ -370,6 +371,7 @@ MTableHeader.defaultProps = {
 MTableHeader.propTypes = {
   columns: PropTypes.array.isRequired,
   dataCount: PropTypes.number,
+  disableInternalSorting: PropTypes.bool,
   hasDetailPanel: PropTypes.bool.isRequired,
   detailPanelColumnAlignment: PropTypes.string,
   hasSelection: PropTypes.bool,

--- a/src/default-props.js
+++ b/src/default-props.js
@@ -203,6 +203,7 @@ export const defaultProps = {
     columnsButton: false,
     detailPanelType: "multiple",
     debounceInterval: 200,
+    disableInternalSorting: false,
     doubleHorizontalScroll: false,
     emptyRowsWhenPaging: true,
     exportAllData: false,

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -84,6 +84,8 @@ export default class MaterialTable extends React.Component {
 
     this.dataManager.setColumns(props.columns);
     this.dataManager.setDefaultExpanded(props.options.defaultExpanded);
+    this.dataManager.disableInternalSorting =
+      props.options.disableInternalSorting;
     this.dataManager.changeRowEditing();
 
     if (this.isRemoteData(props)) {
@@ -858,6 +860,7 @@ export default class MaterialTable extends React.Component {
           onOrderChange={this.onChangeOrder}
           actionsHeaderIndex={props.options.actionsColumnIndex}
           sorting={props.options.sorting}
+          disableInternalSorting={props.options.disableInternalSorting}
           grouping={props.options.grouping}
           isTreeData={this.props.parentChildData !== undefined}
           draggable={props.options.draggable}

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -45,6 +45,7 @@ export const propTypes = {
       customSort: PropTypes.func,
       defaultFilter: PropTypes.any,
       defaultSort: PropTypes.oneOf(["asc", "desc"]),
+      disableInternalSorting: PropTypes.bool,
       editComponent: PropTypes.oneOfType([PropTypes.element, PropTypes.func]),
       emptyValue: PropTypes.oneOfType([
         PropTypes.string,
@@ -305,6 +306,7 @@ export const propTypes = {
     defaultExpanded: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
     debounceInterval: PropTypes.number,
     detailPanelType: PropTypes.oneOf(["single", "multiple"]),
+    disableInternalSorting: PropTypes.bool,
     doubleHorizontalScroll: PropTypes.bool,
     emptyRowsWhenPaging: PropTypes.bool,
     exportAllData: PropTypes.bool,

--- a/src/utils/data-manager.js
+++ b/src/utils/data-manager.js
@@ -7,6 +7,7 @@ export default class DataManager {
   applySort = false;
   currentPage = 0;
   detailPanelType = "multiple";
+  disableInternalSorting = false;
   lastDetailPanelRow = undefined;
   lastEditingRow = undefined;
   orderBy = -1;
@@ -545,6 +546,11 @@ export default class DataManager {
 
   sortList(list) {
     const columnDef = this.columns.find((_) => _.tableData.id === this.orderBy);
+
+    if (this.disableInternalSorting || columnDef.disableInternalSorting) {
+      return list;
+    }
+
     let result = list;
 
     if (columnDef.customSort) {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -166,6 +166,7 @@ export interface Column<RowData extends object> {
   defaultGroupSort?: "asc" | "desc";
   defaultSort?: "asc" | "desc";
   disableClick?: boolean;
+  disableInternalSorting?: boolean;
   editComponent?: (
     props: EditComponentProps<RowData>
   ) => React.ReactElement<any>;
@@ -302,6 +303,7 @@ export interface Options<RowData extends object> {
   defaultExpanded?: boolean | ((rowData: any) => boolean);
   debounceInterval?: number;
   detailPanelType?: "single" | "multiple";
+  disableInternalSorting?: boolean;
   doubleHorizontalScroll?: boolean;
   draggable?: boolean;
   emptyRowsWhenPaging?: boolean;


### PR DESCRIPTION
## Related Issue

N/A

## Description

The internal sorting conflicts with server pagination/sorting. Rendered items or computed values can loose position as a result of the `sortList` function. Current work around is to return nothing from `customSort` though this is not ideal. Request is to add `disableInternalSorting` flag to both `columns` and `options` that will still allow for column ordering, but not alter the data. 

## Related PRs

N/A

## Impacted Areas in Application

Sorting

