### PR TITLE
[Feature] Add feature to hide actions based on a function with rowDat…

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -487,7 +487,13 @@ class App extends Component {
                       icon: "save",
                       tooltip: "Save",
                       onClick: (E, rowData) => alert(rowData.name),
-                      hidden: (rowData) => rowData.name !== "A1",
+                      hidden: (rowData) => {
+                        if (rowData instanceof Array) {
+                          return !!rowData.find((data) => data.name === "A2");
+                        } else {
+                          return rowData.name === "A2";
+                        }
+                      },
                     },
                     {
                       icon: "home",
@@ -529,7 +535,7 @@ class App extends Component {
                     headerSelectionProps: {
                       color: "primary",
                     },
-                    selection: false,
+                    selection: true,
                     selectionProps: (rowData) => {
                       rowData.tableData.disabled = rowData.name === "A1";
 

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -482,6 +482,26 @@ class App extends Component {
               <Grid item xs={12}>
                 {this.state.selectedRows && this.state.selectedRows.length}
                 <MaterialTable
+                  actions={[
+                    {
+                      icon: "save",
+                      tooltip: "Save",
+                      onClick: (E, rowData) => alert(rowData.name),
+                      hidden: (rowData) => rowData.name !== "A1",
+                    },
+                    {
+                      icon: "home",
+                      tooltip: "Home",
+                      onClick: (E, rowData) => alert(rowData.name),
+                      hidden: false,
+                    },
+                    {
+                      icon: "remove",
+                      tooltip: "Remove",
+                      onClick: (E, rowData) => alert(rowData.name),
+                      hidden: true,
+                    },
+                  ]}
                   tableRef={this.tableRef}
                   columns={this.state.columns}
                   data={this.state.data}

--- a/src/components/m-table-action.js
+++ b/src/components/m-table-action.js
@@ -24,7 +24,9 @@ class MTableAction extends React.Component {
       }
     }
 
-    if (action.hidden) {
+    if (typeof action.hidden === "function" && action.hidden(this.props.data)) {
+      return null;
+    } else if (typeof action.hidden === "boolean" && action.hidden) {
       return null;
     }
 

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -28,7 +28,7 @@ export const propTypes = {
         onClick: PropTypes.func.isRequired,
         iconProps: PropTypes.object,
         disabled: PropTypes.bool,
-        hidden: PropTypes.bool,
+        hidden: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
       }),
     ])
   ),

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -114,7 +114,7 @@ export interface Action<RowData extends object> {
   tooltip?: string;
   onClick: (event: any, data: RowData | RowData[]) => void;
   iconProps?: IconProps;
-  hidden?: boolean;
+  hidden?: boolean | ((data: RowData | RowData[]) => boolean);
 }
 
 export interface EditComponentProps<RowData extends object> {


### PR DESCRIPTION
…a attributes

## Related Issue

#2483

## Description

Add feature to hide actions with a function in adittion to a simple boolean.

## Related PRs

N/A

## Impacted Areas in Application

List general components of the application that this PR will affect:

- MTableAction

## Additional Notes

I would like to help more this library so I liked to add this feature, it could be added also with "disabled" property. Btw, I wish you could accept it and release the functionality so I could update to the last version.

Also I don't know why the "Prettier CLI" failed, if you could explain that to it would be nice, thanks