### PR TITLE
Fix for hiddenByColumnsButton property

### DIFF
--- a/src/utils/data-manager.js
+++ b/src/utils/data-manager.js
@@ -269,6 +269,7 @@ export default class DataManager {
   changeColumnHidden(column, hidden) {
     column.hidden = hidden;
     column.hiddenByColumnsButton = hidden;
+    this.setColumns(this.columns);
   }
 
   changeTreeExpand(path) {


### PR DESCRIPTION
When columns' status is changed to hide or show, we should re-calculate columns width.

## Related Issue

#2414 

Steps to reproduce:
- for a column, set "hidden" and "hiddenByColumnsButton" to true. In options set property "columnsButton" to true
- display table and try to select the hidden column to show it

Actual result: 
- table crash

Expected result:
- table is displayed with new column

## Description

Root cause:
- reducePercentsInCalc expects calc to have a value, but width is undefined for hidden columns

Solution: 
- call setColumns to recalculate width in changeColumnHidden
## Related PRs

N/A

## Impacted Areas in Application

N/A


## Additional Notes

This is optional, feel free to follow your hearth and write here :)
