### PR TITLE
Add support for group counting

### DIFF
--- a/src/components/m-table-group-row.js
+++ b/src/components/m-table-group-row.js
@@ -114,7 +114,13 @@ export default class MTableGroupRow extends React.Component {
       title = React.cloneElement(title);
     }
 
-    let separator = this.props.options.groupRowSeparator || ": ";
+    const separator = this.props.options.groupRowSeparator || ": ";
+
+    const counter = this.props.groupData.data.length;
+
+    const conterText = this.props.options.showGroupCount ? `(${counter}) ` : "";
+
+    const groupText = `${conterText}${title}${separator}`;
 
     return (
       <>
@@ -138,10 +144,7 @@ export default class MTableGroupRow extends React.Component {
             >
               <this.props.icons.DetailPanel />
             </IconButton>
-            <b>
-              {title}
-              {separator}
-            </b>
+            <b>{groupText}</b>
           </this.props.components.Cell>
         </TableRow>
         {detail}

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -58,6 +58,7 @@ export const propTypes = {
       filterPlaceholder: PropTypes.string,
       filterComponent: PropTypes.oneOfType([PropTypes.element, PropTypes.func]),
       grouping: PropTypes.bool,
+      showGroupCount: PropTypes.bool,
       headerStyle: PropTypes.object,
       hidden: PropTypes.bool,
       hideFilterIcon: PropTypes.bool,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -169,6 +169,7 @@ export interface Column<RowData extends object> {
   filterPlaceholder?: string;
   filterCellStyle?: React.CSSProperties;
   grouping?: boolean;
+  showGroupCount?: boolean;
   groupTitle?: string | ((groupData: any) => any) | React.ReactNode;
   headerStyle?: React.CSSProperties;
   hidden?: boolean;


### PR DESCRIPTION
## Related Issue

Fixes #1210, Fixes #329

## Description

This PR adds the possibility to show the count of the current group. Can be enabled with `showGroupCount` in options.
![image](https://user-images.githubusercontent.com/17567991/94813269-13916300-03f8-11eb-9f43-f555b89f5da5.png)


## Impacted Areas in Application

List general components of the application that this PR will affect:

\* Types
\* PropTypes
*\ MTableGroupRow