### PR TITLE
Add support for a summary row

### DIFF
--- a/src/components/index.js
+++ b/src/components/index.js
@@ -13,6 +13,7 @@ import MTableHeader from "./m-table-header";
 import MTablePagination from "./m-table-pagination";
 import MTableSteppedPagination from "./m-table-stepped-pagination";
 import MTableToolbar from "./m-table-toolbar";
+import { MTableSummaryRow } from "./m-table-summary-row";
 
 export {
   MTableAction,
@@ -30,4 +31,5 @@ export {
   MTablePagination,
   MTableSteppedPagination,
   MTableToolbar,
+  MTableSummaryRow,
 };

--- a/src/components/m-table-body.js
+++ b/src/components/m-table-body.js
@@ -197,13 +197,13 @@ class MTableBody extends React.Component {
       emptyRowCount = this.props.pageSize - renderData.length;
     }
 
+    const columns = this.props.columns.filter((columnDef) => !columnDef.hidden);
+
     return (
       <TableBody>
         {this.props.options.filtering && (
           <this.props.components.FilterRow
-            columns={this.props.columns.filter(
-              (columnDef) => !columnDef.hidden
-            )}
+            columns={columns}
             icons={this.props.icons}
             hasActions={
               this.props.actions.filter(
@@ -288,6 +288,12 @@ class MTableBody extends React.Component {
             scrollWidth={this.props.scrollWidth}
           />
         )}
+        <this.props.components.SummaryRow
+          currentData={renderData}
+          columns={columns}
+          data={this.props.data}
+          renderSummaryRow={this.props.renderSummaryRow}
+        />
         {this.renderEmpty(emptyRowCount, renderData)}
       </TableBody>
     );
@@ -297,6 +303,7 @@ class MTableBody extends React.Component {
 MTableBody.defaultProps = {
   actions: [],
   currentPage: 0,
+  data: [],
   pageSize: 5,
   renderData: [],
   selection: false,
@@ -309,6 +316,8 @@ MTableBody.defaultProps = {
 
 MTableBody.propTypes = {
   actions: PropTypes.array,
+  data: PropTypes.array,
+  renderSummaryRow: PropTypes.func,
   components: PropTypes.object.isRequired,
   columns: PropTypes.array.isRequired,
   currentPage: PropTypes.number,

--- a/src/components/m-table-edit-field.js
+++ b/src/components/m-table-edit-field.js
@@ -123,7 +123,7 @@ class MTableEditField extends React.Component {
           InputProps={{
             style: {
               fontSize: 13,
-            }
+            },
           }}
           inputProps={{
             "aria-label": `${this.props.columnDef.title}: press space to edit`,
@@ -145,7 +145,7 @@ class MTableEditField extends React.Component {
           InputProps={{
             style: {
               fontSize: 13,
-            }
+            },
           }}
           inputProps={{
             "aria-label": `${this.props.columnDef.title}: press space to edit`,
@@ -178,7 +178,7 @@ class MTableEditField extends React.Component {
         InputProps={{
           style: {
             fontSize: 13,
-          }
+          },
         }}
         inputProps={{
           "aria-label": this.props.columnDef.title,
@@ -208,7 +208,7 @@ class MTableEditField extends React.Component {
           style: {
             fontSize: 13,
             textAlign: "right",
-          }
+          },
         }}
         inputProps={{
           "aria-label": this.props.columnDef.title,

--- a/src/components/m-table-summary-row.js
+++ b/src/components/m-table-summary-row.js
@@ -8,11 +8,28 @@ function MTableSummaryRow({ data, columns, currentData, renderSummaryRow }) {
   }
   return (
     <TableRow>
-      {columns.map((column, index) => (
-        <TableCell key={index}>
-          {renderSummaryRow({ index, column, data, currentData, columns })}
-        </TableCell>
-      ))}
+      {columns.map((column, index) => {
+        const summaryColumn = renderSummaryRow({
+          index,
+          column,
+          data,
+          currentData,
+          columns,
+        });
+        let value = "";
+        let style = {};
+        if (summaryColumn && summaryColumn.value) {
+          value = summaryColumn.value;
+          style = summaryColumn.style;
+        } else {
+          value = summaryColumn;
+        }
+        return (
+          <TableCell key={index} style={style}>
+            {value}
+          </TableCell>
+        );
+      })}
     </TableRow>
   );
 }

--- a/src/components/m-table-summary-row.js
+++ b/src/components/m-table-summary-row.js
@@ -1,0 +1,27 @@
+import * as React from "react";
+import { TableRow, TableCell } from "@material-ui/core";
+import PropTypes from "prop-types";
+
+function MTableSummaryRow({ data, columns, currentData, renderSummaryRow }) {
+  if (!renderSummaryRow) {
+    return null;
+  }
+  return (
+    <TableRow>
+      {columns.map((column, index) => (
+        <TableCell key={index}>
+          {renderSummaryRow({ index, column, data, currentData, columns })}
+        </TableCell>
+      ))}
+    </TableRow>
+  );
+}
+
+MTableSummaryRow.propTypes = {
+  data: PropTypes.array,
+  currentData: PropTypes.array,
+  columns: PropTypes.array,
+  renderSummaryRow: PropTypes.func,
+};
+
+export { MTableSummaryRow };

--- a/src/default-props.js
+++ b/src/default-props.js
@@ -90,6 +90,7 @@ export const defaultProps = {
     Pagination: TablePagination,
     Row: MComponents.MTableBodyRow,
     Toolbar: MComponents.MTableToolbar,
+    SummaryRow: MComponents.MTableSummaryRow,
   },
   data: [],
   icons: {

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -873,6 +873,8 @@ export default class MaterialTable extends React.Component {
         components={props.components}
         icons={props.icons}
         renderData={this.state.renderData}
+        data={this.state.data}
+        renderSummaryRow={this.props.renderSummaryRow}
         currentPage={this.state.currentPage}
         initialFormData={props.initialFormData}
         pageSize={this.state.pageSize}

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -32,6 +32,7 @@ export const propTypes = {
       }),
     ])
   ),
+  renderSummaryRow: PropTypes.func,
   columns: PropTypes.arrayOf(
     PropTypes.shape({
       cellStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -39,6 +39,19 @@ export interface MaterialTableProps<RowData extends object> {
     isDeleteHidden?: (rowData: RowData) => boolean;
   };
   icons?: Icons;
+  renderSummaryRow?: ({
+    columns,
+    column,
+    index,
+    data,
+    currentData,
+  }: {
+    columns: Column<RowData>[];
+    column: Column<RowData>;
+    index: number;
+    data: RowData[];
+    currentData: RowData[];
+  }) => unknown;
   initialFormData?: object;
   isLoading?: boolean;
   title?: string | React.ReactElement<any>;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -51,7 +51,7 @@ export interface MaterialTableProps<RowData extends object> {
     index: number;
     data: RowData[];
     currentData: RowData[];
-  }) => unknown;
+  }) => { value: unknwon; style: CSSProperties } | unknown;
   initialFormData?: object;
   isLoading?: boolean;
   title?: string | React.ReactElement<any>;


### PR DESCRIPTION
## Related Issue

Fixes #1419, Fixes #2395, Fixes #27, Fixes #460

## Description

This PR adds the possibility to add a summary row by adding renderSummaryRow to the props:
![image](https://user-images.githubusercontent.com/17567991/94845606-39326280-0420-11eb-8747-53f24dc4c8d9.png)

```
 renderSummaryRow={({ data, index, columns }) => {
                    switch (index) {
                      case 0:
                        return `Total times used: ${data.length}`;
                      case columns.length - 1:
                        return `500`;
                      default:
                        return null;
                    }
                  }}
```
This can be extended to whatever the user needs per column. By skipping certain row indexes, a filter summary can also be achieved.

Additionally, an object with `{value: unknown, style: object}` can be returned to style this cell.
```
return { value: `500`, style: { fontWeight: 800, fontSize: 32 } };
```

## Impacted Areas in Application

List general components of the application that this PR will affect:

\* Table
\* PropTypes
\* Summary-Row
\* TableBody
