### PR TITLE
respect user styles over inherit width

### DIFF
--- a/src/components/m-table-header.js
+++ b/src/components/m-table-header.js
@@ -80,12 +80,12 @@ export class MTableHeader extends React.Component {
     );
 
     const style = {
-      ...this.props.headerStyle,
-      ...columnDef.headerStyle,
       boxSizing: "border-box",
       width,
       maxWidth: columnDef.maxWidth,
       minWidth: columnDef.minWidth,
+      ...this.props.headerStyle,
+      ...columnDef.headerStyle,
     };
 
     if (


### PR DESCRIPTION
## Related Issue

Fixes #2487

## Description

Custom cell width will be overridden with reducePercentsInCalc but should still be user settable.
This PR fixes that by reordering the overriding the order of spreading.