### PR TITLE
Fix/hidden column visibility

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -424,6 +424,8 @@ class App extends Component {
     columns: [
       {
         title: "Adı",
+        hidden: true,
+        hiddenByColumnsButton: true,
         field: "name",
         filterPlaceholder: "Adı filter",
         tooltip: "This is tooltip text",
@@ -506,6 +508,7 @@ class App extends Component {
                   options={{
                     tableLayout: "fixed",
                     columnResizable: true,
+                    columnsButton: true,
                     headerSelectionProps: {
                       color: "primary",
                     },

--- a/src/components/m-table-toolbar.js
+++ b/src/components/m-table-toolbar.js
@@ -221,9 +221,7 @@ export class MTableToolbar extends React.Component {
                       <Checkbox
                         checked={!col.hidden}
                         id={`column-toggle-${col.tableData.id}`}
-                        onChange={() =>
-                          this.props.onColumnsChanged(col, !col.hidden)
-                        }
+                        onChange={() => this.props.onColumnsChanged(col)}
                       />
                       <span>{col.title}</span>
                     </MenuItem>
@@ -349,6 +347,7 @@ export class MTableToolbar extends React.Component {
         : this.props.showTitle
         ? this.props.title
         : null;
+
     return (
       <Toolbar
         className={classNames(classes.root, {

--- a/src/components/m-table-toolbar.js
+++ b/src/components/m-table-toolbar.js
@@ -210,28 +210,25 @@ export class MTableToolbar extends React.Component {
                 {localization.addRemoveColumns}
               </MenuItem>
               {this.props.columns.map((col) => {
-                if (!col.hidden || col.hiddenByColumnsButton) {
-                  return (
-                    <li key={col.tableData.id}>
-                      <MenuItem
-                        className={classes.formControlLabel}
-                        component="label"
-                        htmlFor={`column-toggle-${col.tableData.id}`}
-                        disabled={col.removable === false}
-                      >
-                        <Checkbox
-                          checked={!col.hidden}
-                          id={`column-toggle-${col.tableData.id}`}
-                          onChange={() =>
-                            this.props.onColumnsChanged(col, !col.hidden)
-                          }
-                        />
-                        <span>{col.title}</span>
-                      </MenuItem>
-                    </li>
-                  );
-                }
-                return null;
+                return (
+                  <li key={col.tableData.id}>
+                    <MenuItem
+                      className={classes.formControlLabel}
+                      component="label"
+                      htmlFor={`column-toggle-${col.tableData.id}`}
+                      disabled={col.removable === false}
+                    >
+                      <Checkbox
+                        checked={!col.hidden}
+                        id={`column-toggle-${col.tableData.id}`}
+                        onChange={() =>
+                          this.props.onColumnsChanged(col, !col.hidden)
+                        }
+                      />
+                      <span>{col.title}</span>
+                    </MenuItem>
+                  </li>
+                );
               })}
             </Menu>
           </span>

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -326,7 +326,8 @@ export default class MaterialTable extends React.Component {
     );
   };
 
-  onChangeColumnHidden = (column, hidden) => {
+  onChangeColumnHidden = (column) => {
+    const hidden = !column.hidden;
     this.dataManager.changeColumnHidden(column, hidden);
     this.setState(this.dataManager.getRenderState(), () => {
       this.props.onChangeColumnHidden &&

--- a/src/utils/data-manager.js
+++ b/src/utils/data-manager.js
@@ -268,6 +268,10 @@ export default class DataManager {
 
   changeColumnHidden(column, hidden) {
     column.hidden = hidden;
+    const nextColumns = this.columns.map((col) => {
+      return col.field === column.field ? { ...col, hidden } : col;
+    });
+    this.setColumns(nextColumns);
   }
 
   changeTreeExpand(path) {

--- a/src/utils/data-manager.js
+++ b/src/utils/data-manager.js
@@ -268,7 +268,6 @@ export default class DataManager {
 
   changeColumnHidden(column, hidden) {
     column.hidden = hidden;
-    column.hiddenByColumnsButton = hidden;
   }
 
   changeTreeExpand(path) {


### PR DESCRIPTION
## Related Issue

 #https://github.com/mbrn/material-table/issues/2414

## Description
Given a table column is initialized as `hidden=true` and the `hiddenByColumnsButton=false`
when the user clicks on the (unchecked) column in the columns menu
then the hidden column appears. 

## Impacted Areas in Application

* data-manager
* m-table-toolbar

## Additional Notes

This fix is still subject to this issue: https://github.com/mbrn/material-table/pull/2441
When you toggle the column visibility on and off, several times, it quickly crashes the main thread. 