### PR TITLE
Update Filter types (operator add string)

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -73,7 +73,7 @@ export interface MaterialTableProps<RowData extends object> {
 
 export interface Filter<RowData extends object> {
   column: Column<RowData>;
-  operator: "=";
+  operator: "=" | string;
   value: any;
 }
 export interface ErrorState {


### PR DESCRIPTION
## Description

I created a dashboard scaffold ```bunadmin``` with ```material-table``` https://github.com/bunred/bunadmin

Custom operators are required for filtering functions, so the type of `operator` needs to be updated.
