### PR TITLE
Bug/cell edit opens detail panel

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -438,7 +438,7 @@ class App extends Component {
         editable: "never",
         resizable: false,
       },
-      { title: "Evli", field: "isMarried", type: "boolean" },
+      { title: "Evli", field: "isMarried" },
       {
         title: "Cinsiyet",
         field: "sex",
@@ -489,22 +489,20 @@ class App extends Component {
                   onFilterChange={(appliedFilter) => {
                     console.log("selected Filters : ", appliedFilter);
                   }}
-                  onRowClick={(event, rowData, togglePanel) => togglePanel()}
-                  detailPanel={(rowData) => <div>hello world</div>}
-                  cellEditable={{
-                    cellStyle: {},
-                    onCellEditApproved: (
-                      newValue,
-                      oldValue,
-                      rowData,
-                      columnDef
-                    ) => {
-                      return new Promise((resolve, reject) => {
-                        console.log("newValue: " + newValue);
-                        setTimeout(resolve, 4000);
-                      });
-                    },
-                  }}
+                  // cellEditable={{
+                  //   cellStyle: {},
+                  //   onCellEditApproved: (
+                  //     newValue,
+                  //     oldValue,
+                  //     rowData,
+                  //     columnDef
+                  //   ) => {
+                  //     return new Promise((resolve, reject) => {
+                  //       console.log("newValue: " + newValue);
+                  //       setTimeout(resolve, 4000);
+                  //     });
+                  //   },
+                  // }}
                   options={{
                     tableLayout: "fixed",
                     columnResizable: true,

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -438,7 +438,7 @@ class App extends Component {
         editable: "never",
         resizable: false,
       },
-      { title: "Evli", field: "isMarried" },
+      { title: "Evli", field: "isMarried", type: "boolean" },
       {
         title: "Cinsiyet",
         field: "sex",
@@ -489,20 +489,22 @@ class App extends Component {
                   onFilterChange={(appliedFilter) => {
                     console.log("selected Filters : ", appliedFilter);
                   }}
-                  // cellEditable={{
-                  //   cellStyle: {},
-                  //   onCellEditApproved: (
-                  //     newValue,
-                  //     oldValue,
-                  //     rowData,
-                  //     columnDef
-                  //   ) => {
-                  //     return new Promise((resolve, reject) => {
-                  //       console.log("newValue: " + newValue);
-                  //       setTimeout(resolve, 4000);
-                  //     });
-                  //   },
-                  // }}
+                  onRowClick={(event, rowData, togglePanel) => togglePanel()}
+                  detailPanel={(rowData) => <div>hello world</div>}
+                  cellEditable={{
+                    cellStyle: {},
+                    onCellEditApproved: (
+                      newValue,
+                      oldValue,
+                      rowData,
+                      columnDef
+                    ) => {
+                      return new Promise((resolve, reject) => {
+                        console.log("newValue: " + newValue);
+                        setTimeout(resolve, 4000);
+                      });
+                    },
+                  }}
                   options={{
                     tableLayout: "fixed",
                     columnResizable: true,

--- a/src/components/m-table-edit-field.js
+++ b/src/components/m-table-edit-field.js
@@ -37,7 +37,10 @@ class MTableEditField extends React.Component {
         <Select
           {...props}
           value={this.props.value === undefined ? "" : this.props.value}
-          onChange={(event) => this.props.onChange(event.target.value)}
+          onChange={(event) => {
+            event.stopPropagation();
+            this.props.onChange(event.target.value);
+          }}
           style={{
             fontSize: 13,
           }}
@@ -63,20 +66,24 @@ class MTableEditField extends React.Component {
           <FormControlLabel
             label=""
             control={
-              <Checkbox
-                {...props}
-                value={String(this.props.value)}
-                checked={Boolean(this.props.value)}
-                onChange={(event) => this.props.onChange(event.target.checked)}
-                style={{
-                  padding: 0,
-                  width: 24,
-                  marginLeft: 9,
-                }}
-                inputProps={{
-                  "aria-label": this.props.columnDef.title,
-                }}
-              />
+              <div onClick={(event) => event.stopPropagation()}>
+                <Checkbox
+                  {...props}
+                  value={String(this.props.value)}
+                  checked={Boolean(this.props.value)}
+                  onChange={(event) =>
+                    this.props.onChange(event.target.checked)
+                  }
+                  style={{
+                    padding: 0,
+                    width: 24,
+                    marginLeft: 9,
+                  }}
+                  inputProps={{
+                    "aria-label": this.props.columnDef.title,
+                  }}
+                />
+              </div>
             }
           />
         </FormGroup>
@@ -93,42 +100,46 @@ class MTableEditField extends React.Component {
         : "dd.MM.yyyy";
     return (
       <MuiPickersUtilsProvider utils={DateFnsUtils} locale={this.props.locale}>
-        <DatePicker
-          {...this.getProps()}
-          format={dateFormat}
-          value={this.props.value || null}
-          onChange={this.props.onChange}
-          clearable
-          InputProps={{
-            style: {
-              fontSize: 13,
-            },
-          }}
-          inputProps={{
-            "aria-label": `${this.props.columnDef.title}: press space to edit`,
-          }}
-        />
+        <div onClick={(event) => event.stopPropagation()}>
+          <DatePicker
+            {...this.getProps()}
+            format={dateFormat}
+            value={this.props.value || null}
+            onChange={this.props.onChange}
+            clearable
+            InputProps={{
+              style: {
+                fontSize: 13,
+              },
+            }}
+            inputProps={{
+              "aria-label": `${this.props.columnDef.title}: press space to edit`,
+            }}
+          />
+        </div>
       </MuiPickersUtilsProvider>
     );
   }
   renderTimeField() {
     return (
       <MuiPickersUtilsProvider utils={DateFnsUtils} locale={this.props.locale}>
-        <TimePicker
-          {...this.getProps()}
-          format="HH:mm:ss"
-          value={this.props.value || null}
-          onChange={this.props.onChange}
-          clearable
-          InputProps={{
-            style: {
-              fontSize: 13,
-            },
-          }}
-          inputProps={{
-            "aria-label": `${this.props.columnDef.title}: press space to edit`,
-          }}
-        />
+        <div onClick={(event) => event.stopPropagation()}>
+          <TimePicker
+            {...this.getProps()}
+            format="HH:mm:ss"
+            value={this.props.value || null}
+            onChange={this.props.onChange}
+            clearable
+            InputProps={{
+              style: {
+                fontSize: 13,
+              },
+            }}
+            inputProps={{
+              "aria-label": `${this.props.columnDef.title}: press space to edit`,
+            }}
+          />
+        </div>
       </MuiPickersUtilsProvider>
     );
   }
@@ -136,21 +147,23 @@ class MTableEditField extends React.Component {
   renderDateTimeField() {
     return (
       <MuiPickersUtilsProvider utils={DateFnsUtils} locale={this.props.locale}>
-        <DateTimePicker
-          {...this.getProps()}
-          format="dd.MM.yyyy HH:mm:ss"
-          value={this.props.value || null}
-          onChange={this.props.onChange}
-          clearable
-          InputProps={{
-            style: {
-              fontSize: 13,
-            },
-          }}
-          inputProps={{
-            "aria-label": `${this.props.columnDef.title}: press space to edit`,
-          }}
-        />
+        <div onClick={(event) => event.stopPropagation()}>
+          <DateTimePicker
+            {...this.getProps()}
+            format="dd.MM.yyyy HH:mm:ss"
+            value={this.props.value || null}
+            onChange={this.props.onChange}
+            clearable
+            InputProps={{
+              style: {
+                fontSize: 13,
+              },
+            }}
+            inputProps={{
+              "aria-label": `${this.props.columnDef.title}: press space to edit`,
+            }}
+          />
+        </div>
       </MuiPickersUtilsProvider>
     );
   }
@@ -168,6 +181,7 @@ class MTableEditField extends React.Component {
           this.props.columnDef.editPlaceholder || this.props.columnDef.title
         }
         value={this.props.value === undefined ? "" : this.props.value}
+        onClick={(event) => event.stopPropagation()}
         onChange={(event) =>
           this.props.onChange(
             this.props.columnDef.type === "numeric"
@@ -197,6 +211,7 @@ class MTableEditField extends React.Component {
         style={{ float: "right" }}
         type="number"
         value={this.props.value === undefined ? "" : this.props.value}
+        onClick={(event) => event.stopPropagation()}
         onChange={(event) => {
           let value = event.target.valueAsNumber;
           if (!value && value !== 0) {


### PR DESCRIPTION
If you have enabled both individual cell edits and onRowClick, the onClick event bubbles up when editing a cell and the onRowClick is triggered.  In my case that meant the details tab for the row would be toggled open and closed while trying to edit the cell. 

## Description
I added click events with event.stopPropagation to the editField components when the element had an onClick handler. In the cases where onClick was not available, like with date selection, I simply wrapped the component in a div and added a onClick event to that. 
  
Simple words to describe the overall goals of the pull request's commits.
Stop the onRowClick from being fired when editing a individual cell.

## Related PRs

List related PRs against other branches:

## Impacted Areas in Application

List general components of the application that this PR will affect:


## Additional Notes

Love this library! My company jokes that I am slowly converting our whole app into a material table. 
