### PR TITLE
add aria-label to 'x' clear button

### DIFF
--- a/src/components/m-table-action.js
+++ b/src/components/m-table-action.js
@@ -50,6 +50,7 @@ class MTableAction extends React.Component {
       <IconButton
         size={this.props.size}
         color="inherit"
+        aria-label="Clear"
         disabled={disabled}
         onClick={handleOnClick}
       >


### PR DESCRIPTION
## Related Issue

#1884 

## Description

Add aria-label of 'clear' to the 'x' icon button in search field. Screen reader now announces button as 'clear'. Now conforms to WCAG 2.5.3 accessibility guideline.

## Impacted Areas in Application

m-tables-actions.js

