### PR TITLE
Options to customize IconButton and 'div' inside Actions column

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules
 package-lock.json
 yarn.lock
 .idea
+.history

--- a/src/components/m-table-action.js
+++ b/src/components/m-table-action.js
@@ -46,12 +46,15 @@ class MTableAction extends React.Component {
         <action.icon />
       );
 
+    const iconButtonProps = action.iconButtonProps || {};
+
     const button = (
       <IconButton
         size={this.props.size}
         color="inherit"
         disabled={disabled}
         onClick={handleOnClick}
+        {...iconButtonProps}
       >
         {icon}
       </IconButton>

--- a/src/components/m-table-body-row.js
+++ b/src/components/m-table-body-row.js
@@ -93,7 +93,9 @@ export default class MTableBodyRow extends React.Component {
           ...this.props.options.actionsCellStyle,
         }}
       >
-        <div style={{ display: "flex" }}>
+        <div
+          style={{ display: "flex", ...this.props.options.actionsCellDivStyle }}
+        >
           <this.props.components.Actions
             data={this.props.data}
             actions={actions}

--- a/src/components/m-table-pagination.js
+++ b/src/components/m-table-pagination.js
@@ -35,6 +35,7 @@ class MTablePaginationInner extends React.Component {
       rowsPerPage,
       theme,
       showFirstLastPageButtons,
+      iconButtonProps,
     } = this.props;
     const localization = {
       ...MTablePaginationInner.defaultProps.localization,
@@ -47,9 +48,10 @@ class MTablePaginationInner extends React.Component {
           <Tooltip title={localization.firstTooltip}>
             <span>
               <IconButton
+                {...iconButtonProps}
                 onClick={this.handleFirstPageButtonClick}
-                disabled={page === 0}
                 aria-label={localization.firstAriaLabel}
+                disabled={page === 0}
               >
                 {theme.direction === "rtl" ? (
                   <this.props.icons.LastPage />
@@ -63,6 +65,7 @@ class MTablePaginationInner extends React.Component {
         <Tooltip title={localization.previousTooltip}>
           <span>
             <IconButton
+              {...iconButtonProps}
               onClick={this.handleBackButtonClick}
               disabled={page === 0}
               aria-label={localization.previousAriaLabel}
@@ -103,6 +106,7 @@ class MTablePaginationInner extends React.Component {
         <Tooltip title={localization.nextTooltip}>
           <span>
             <IconButton
+              {...iconButtonProps}
               onClick={this.handleNextButtonClick}
               disabled={page >= Math.ceil(count / rowsPerPage) - 1}
               aria-label={localization.nextAriaLabel}
@@ -119,6 +123,7 @@ class MTablePaginationInner extends React.Component {
           <Tooltip title={localization.lastTooltip}>
             <span>
               <IconButton
+                {...iconButtonProps}
                 onClick={this.handleLastPageButtonClick}
                 disabled={page >= Math.ceil(count / rowsPerPage) - 1}
                 aria-label={localization.lastAriaLabel}
@@ -155,10 +160,12 @@ MTablePaginationInner.propTypes = {
   localization: PropTypes.object,
   theme: PropTypes.any,
   showFirstLastPageButtons: PropTypes.bool,
+  iconButtonProps: PropTypes.object,
 };
 
 MTablePaginationInner.defaultProps = {
   showFirstLastPageButtons: true,
+  iconButtonProps: {},
   localization: {
     firstTooltip: "First Page",
     previousTooltip: "Previous Page",

--- a/src/components/m-table-stepped-pagination.js
+++ b/src/components/m-table-stepped-pagination.js
@@ -68,6 +68,7 @@ class MTablePaginationInner extends React.Component {
       rowsPerPage,
       theme,
       showFirstLastPageButtons,
+      iconButtonProps,
     } = this.props;
 
     const localization = {
@@ -85,6 +86,7 @@ class MTablePaginationInner extends React.Component {
           <Tooltip title={localization.firstTooltip}>
             <span>
               <IconButton
+                {...iconButtonProps}
                 onClick={this.handleFirstPageButtonClick}
                 disabled={page === 0}
                 aria-label={localization.firstAriaLabel}
@@ -101,6 +103,7 @@ class MTablePaginationInner extends React.Component {
         <Tooltip title={localization.previousTooltip}>
           <span>
             <IconButton
+              {...iconButtonProps}
               onClick={this.handleBackButtonClick}
               disabled={page === 0}
               aria-label={localization.previousAriaLabel}
@@ -115,6 +118,7 @@ class MTablePaginationInner extends React.Component {
         <Tooltip title={localization.nextTooltip}>
           <span>
             <IconButton
+              {...iconButtonProps}
               onClick={this.handleNextButtonClick}
               disabled={page >= maxPages}
               aria-label={localization.nextAriaLabel}
@@ -127,6 +131,7 @@ class MTablePaginationInner extends React.Component {
           <Tooltip title={localization.lastTooltip}>
             <span>
               <IconButton
+                {...iconButtonProps}
                 onClick={this.handleLastPageButtonClick}
                 disabled={page >= Math.ceil(count / rowsPerPage) - 1}
                 aria-label={localization.lastAriaLabel}
@@ -162,10 +167,12 @@ MTablePaginationInner.propTypes = {
   localization: PropTypes.object,
   theme: PropTypes.any,
   showFirstLastPageButtons: PropTypes.bool,
+  iconButtonProps: PropTypes.object,
 };
 
 MTablePaginationInner.defaultProps = {
   showFirstLastPageButtons: true,
+  iconButtonProps: {},
   localization: {
     firstTooltip: "First Page",
     previousTooltip: "Previous Page",

--- a/src/default-props.js
+++ b/src/default-props.js
@@ -219,6 +219,7 @@ export const defaultProps = {
     paging: true,
     pageSize: 5,
     pageSizeOptions: [5, 10, 20],
+    paginationIconButtonProps: {},
     paginationType: "normal",
     paginationPosition: "bottom",
     showEmptyDataSourceMessage: true,

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -804,6 +804,7 @@ export default class MaterialTable extends React.Component {
                     .replace("{count}", row.count)
                 }
                 labelRowsPerPage={localization.labelRowsPerPage}
+                iconButtonProps={props.options.paginationIconButtonProps}
               />
             </TableRow>
           </TableFooter>

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -785,6 +785,7 @@ export default class MaterialTable extends React.Component {
                       showFirstLastPageButtons={
                         props.options.showFirstLastPageButtons
                       }
+                      iconButtonProps={props.options.paginationIconButtonProps}
                     />
                   ) : (
                     <MTableSteppedPagination
@@ -794,6 +795,7 @@ export default class MaterialTable extends React.Component {
                       showFirstLastPageButtons={
                         props.options.showFirstLastPageButtons
                       }
+                      iconButtonProps={props.options.paginationIconButtonProps}
                     />
                   )
                 }
@@ -804,7 +806,6 @@ export default class MaterialTable extends React.Component {
                     .replace("{count}", row.count)
                 }
                 labelRowsPerPage={localization.labelRowsPerPage}
-                iconButtonProps={props.options.paginationIconButtonProps}
               />
             </TableRow>
           </TableFooter>

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -336,6 +336,7 @@ export const propTypes = {
       "initial",
       "inherit",
     ]),
+    paginationIconButtonProps: PropTypes.object,
     padding: PropTypes.oneOf(["default", "dense"]),
     paging: PropTypes.bool,
     pageSize: PropTypes.number,

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -27,6 +27,7 @@ export const propTypes = {
         tooltip: PropTypes.string,
         onClick: PropTypes.func.isRequired,
         iconProps: PropTypes.object,
+        iconButtonProps: PropTypes.object,
         disabled: PropTypes.bool,
         hidden: PropTypes.bool,
       }),

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -298,6 +298,7 @@ export const propTypes = {
   title: PropTypes.oneOfType([PropTypes.element, PropTypes.string]),
   options: PropTypes.shape({
     actionsCellStyle: PropTypes.object,
+    actionsCellDivStyle: PropTypes.object,
     editCellStyle: PropTypes.object,
     detailPanelColumnStyle: PropTypes.object,
     actionsColumnIndex: PropTypes.number,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -295,6 +295,7 @@ export interface Icons {
 
 export interface Options<RowData extends object> {
   actionsCellStyle?: React.CSSProperties;
+  actionsCellDivStyle?: React.CSSProperties;
   detailPanelColumnStyle?: React.CSSProperties;
   editCellStyle?: React.CSSProperties;
   actionsColumnIndex?: number;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -329,6 +329,7 @@ export interface Options<RowData extends object> {
   maxBodyHeight?: number | string;
   minBodyHeight?: number | string;
   padding?: "default" | "dense";
+  paginationIconButtonProps?: IconButtonProps;
   paging?: boolean;
   grouping?: boolean;
   groupTitle?: (groupData: any) => any;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { IconProps } from "@material-ui/core/Icon";
+import { IconButtonProps } from "@material-ui/core/IconButton";
 import SvgIcon from "@material-ui/core/SvgIcon";
 import { string } from "prop-types";
 
@@ -113,6 +114,7 @@ export interface Action<RowData extends object> {
   position?: "auto" | "toolbar" | "toolbarOnSelect" | "row";
   tooltip?: string;
   onClick: (event: any, data: RowData | RowData[]) => void;
+  iconButtonProps?: IconButtonProps;
   iconProps?: IconProps;
   hidden?: boolean;
 }


### PR DESCRIPTION
## Related Issue

n/a

## Description

- Created `option.actionsCellDivStyle` to pass dynamically styles to hardcoded ` <div style={{ display: "flex" }}>` **between** `TableCell` and `components.Actions`.  I am using it to pass `justifyContent: 'flex-end'` to align my actions.

- Created `action.iconButtonProps`, with the definition of type of `@material-ui/core/IconButton`. I am using it to customize `IconButtons`.

- Created `option.paginationIconButtonProps`, with the definition of type of `@material-ui/core/IconButton`. I am using it to customize `IconButtons` of pagination with `size="small"`.

## Related PRs

n/a

## Impacted Areas in Application

List general components of the application that this PR will affect:

\* MTableAction
\* MTableBodyRow
\* MTablePagination
\* MTableSteppedPagination

