### PR TITLE
Prevent state update when table is unmounted (for remote data)

### DIFF
--- a/src/material-table.js
+++ b/src/material-table.js
@@ -582,6 +582,9 @@ export default class MaterialTable extends React.Component {
       this.props
         .data(query)
         .then((result) => {
+          // Before updating state, check table is still mounted
+          if (!this.tableContainerDiv.current) return;
+        
           query.totalCount = result.totalCount;
           query.page = result.page;
           this.dataManager.setData(result.data);
@@ -598,6 +601,9 @@ export default class MaterialTable extends React.Component {
           );
         })
         .catch((error) => {
+          // Before updating state, check table is still mounted
+          if (!this.tableContainerDiv.current) return;
+        
           const localization = {
             ...MaterialTable.defaultProps.localization,
             ...this.props.localization,


### PR DESCRIPTION
## Related Issue

Steps to reproduce:
- create a remote data function (calling API for data for instance)
- open page with Material-Table
- change page before remote data was fetched

Expected result:
- no console error

Actual result:
- Console error:
`
Warning: Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in the componentWillUnmount method.
`

## Description

Material Table should cancel state update on data promise resolution when material table component was unmounted between promise start and promise end.

## Related PRs

N/A

## Impacted Areas in Application

onQueryChange function

## Additional Notes

This is optional, feel free to follow your hearth and write here :)
