### PR TITLE
feature: change tooltip after click for certain action

### DIFF
--- a/src/components/m-table-action.js
+++ b/src/components/m-table-action.js
@@ -4,9 +4,17 @@ import PropTypes from "prop-types";
 import Icon from "@material-ui/core/Icon";
 import IconButton from "@material-ui/core/IconButton";
 import Tooltip from "@material-ui/core/Tooltip";
+import ClickAwayListener from "@material-ui/core/ClickAwayListener";
 /* eslint-enable no-unused-vars */
 
 class MTableAction extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      tooltip: this.props.action.tooltip,
+    };
+  }
+
   render() {
     let action = this.props.action;
 
@@ -30,9 +38,21 @@ class MTableAction extends React.Component {
 
     const disabled = action.disabled || this.props.disabled;
 
+    const tooltip = this.state.tooltip ? this.state.tooltip : action.tooltip;
+
+    const handleTooltipClose = () => {
+      setTooltipMessage(action.tooltip);
+    };
+
+    const setTooltipMessage = (tooltipMessage) => {
+      this.setState({ tooltip: tooltipMessage });
+    };
+
     const handleOnClick = (event) => {
       if (action.onClick) {
         action.onClick(event, this.props.data);
+        if (action.tooltipAfterClick)
+          setTooltipMessage(action.tooltipAfterClick);
         event.stopPropagation();
       }
     };
@@ -57,15 +77,19 @@ class MTableAction extends React.Component {
       </IconButton>
     );
 
-    if (action.tooltip) {
+    if (tooltip) {
       // fix for issue #1049
       // https://github.com/mbrn/material-table/issues/1049
       return disabled ? (
-        <Tooltip title={action.tooltip}>
+        <Tooltip title={tooltip}>
           <span>{button}</span>
         </Tooltip>
       ) : (
-        <Tooltip title={action.tooltip}>{button}</Tooltip>
+        <ClickAwayListener onClickAway={handleTooltipClose}>
+          <Tooltip onClose={handleTooltipClose} title={tooltip}>
+            {button}
+          </Tooltip>
+        </ClickAwayListener>
       );
     } else {
       return button;


### PR DESCRIPTION
## Related Issue

Related Github issue `#2569`

## Description

Change the tooltip of an action after the click. Some table action could need tooltip message change, such as **Copy** action could need the tooltip changed to **Copied** after the click.

## How will it work

put **tooltipAfterClick** key-value pair in action object.

`actions={[
                    {
                      icon: 'copy',
                      tooltip: 'Copy',
                      tooltipAfterClick: "Copied",
                      onClick: (event, rowData) => {}
                    }
                  ]}`

\*

## Additional Notes

This could be done by overriding the MTableAction component. Although providing this as default functionality could be helpful in the future.
