### PR TITLE
Cell edit mode is now taking into account editComponent setting

### DIFF
--- a/src/components/m-table-edit-cell.js
+++ b/src/components/m-table-edit-cell.js
@@ -123,11 +123,13 @@ class MTableEditCell extends React.Component {
   }
 
   render() {
+    const EditComponent =
+      this.props.columnDef.editComponent || this.props.components.EditField;
     return (
       <TableCell size={this.props.size} style={this.getStyle()} padding="none">
         <div style={{ display: "flex", alignItems: "center" }}>
           <div style={{ flex: 1, marginRight: 4 }}>
-            <this.props.components.EditField
+            <EditComponent
               columnDef={this.props.columnDef}
               value={this.state.value}
               onChange={(value) => this.setState({ value })}


### PR DESCRIPTION
## Related Issue

Issue was not created

## Description

columnDef.editComponent was ignored in cell edit mode. Now its not. 

## Impacted Areas in Application
m-table-edit-cell.js

## Additional Notes

For cell to look correctly, editComponent should have style "width: 100%". However, users may like to develop some big custom editors. I think that correct width and appearance would better be handled on their side rather than we hardcode width,
