### PR TITLE
Fixed row editing state loss on component update

### DIFF
--- a/src/material-table.js
+++ b/src/material-table.js
@@ -84,7 +84,7 @@ export default class MaterialTable extends React.Component {
 
     this.dataManager.setColumns(props.columns);
     this.dataManager.setDefaultExpanded(props.options.defaultExpanded);
-    this.dataManager.changeRowEditing();
+    isInit && this.dataManager.changeRowEditing();
 
     if (this.isRemoteData(props)) {
       this.dataManager.changeApplySearch(false);


### PR DESCRIPTION
## Related Issue

#2516 

## Description

Every time the material table component updates, the `setDataManagerFields` method is called and row editing state is reset. This PR resolves this issue. As a side effect, the #2516 issue is now also resolved.

## Related PRs

List related PRs against other branches: none

## Impacted Areas in Application

List general components of the application that this PR will affect:

`MaterialTable`