### PR TITLE
Fix bug PR #2389

### DIFF
--- a/src/components/m-table-group-row.js
+++ b/src/components/m-table-group-row.js
@@ -35,6 +35,7 @@ export default class MTableGroupRow extends React.Component {
             groups={this.props.groups}
             icons={this.props.icons}
             level={this.props.level + 1}
+            localization: _this2.props.localization,
             path={[...this.props.path, index]}
             onGroupExpandChanged={this.props.onGroupExpandChanged}
             onRowSelected={this.props.onRowSelected}
@@ -86,6 +87,7 @@ export default class MTableGroupRow extends React.Component {
                 detailPanel={this.props.detailPanel}
                 getFieldValue={this.props.getFieldValue}
                 icons={this.props.icons}
+                localization: _this2.props.localization,
                 path={[...this.props.path, index]}
                 onRowSelected={this.props.onRowSelected}
                 onRowClick={this.props.onRowClick}


### PR DESCRIPTION
'saveTooltip' of undefined, localization undefined, MTableEditCell with group View pop error #2389

## Related Issue

Relate the Github issue with this PR using `#`

## Description

Add localization on 'material-table/dist/components/m-table-group-row.js'
at this.props.components.GroupRow
at this.props.components.Row

## Related PRs

List related PRs against other branches:

| branch              | PR       |
| ------------------- | -------- |
| other_pr_production | [link]() |
| other_pr_master     | [link]() |

## Impacted Areas in Application

List general components of the application that this PR will affect:

\*

## Additional Notes

This is optional, feel free to follow your hearth and write here :)
