### PR TITLE
make input and output types consistent when editing rows

### DIFF
--- a/src/components/m-table-edit-row.js
+++ b/src/components/m-table-edit-row.js
@@ -13,9 +13,7 @@ export default class MTableEditRow extends React.Component {
     super(props);
 
     this.state = {
-      data: props.data
-        ? JSON.parse(JSON.stringify(props.data))
-        : this.createRowData(),
+      data: props.data ? props.data : this.createRowData(),
     };
   }
 


### PR DESCRIPTION
## Description

any non-primitive types in the rowData are stringified in edit row mode. This means that things like Dates become ISOStrings in the validate method. This inconsistency makes life difficult when when trying to use shared validators for models that are defined to use Date objects everywhere else in the app.

E.g.
`<MaterialTable data={[{ startDate: new Date() }]} columns={[{ field: "testCol", validate: (rowData) => // = {startDate: "2020-11-17T23:16:54.990Z" } }]} />
`

However after changing the value of the DatePicker in the edit row context it reverts back to Date object, so it seems that it's only when the row _becomes_ editable that it's flattened to an ISOString.

## Impacted Areas in Application

Row editing