### PR TITLE
chore: replace classnames by clsx

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
   "dependencies": {
     "@date-io/date-fns": "1.1.0",
     "@material-ui/pickers": "3.2.2",
-    "classnames": "2.2.6",
+    "clsx": "1.1.1",
     "date-fns": "2.0.0-alpha.27",
     "debounce": "1.2.0",
     "fast-deep-equal": "2.0.1",

--- a/src/components/m-table-toolbar.js
+++ b/src/components/m-table-toolbar.js
@@ -11,7 +11,7 @@ import Tooltip from "@material-ui/core/Tooltip";
 import Typography from "@material-ui/core/Typography";
 import withStyles from "@material-ui/core/styles/withStyles";
 import { lighten } from "@material-ui/core/styles/colorManipulator";
-import classNames from "classnames";
+import clsx from "clsx";
 import { CsvBuilder } from "filefy";
 import PropTypes, { oneOf } from "prop-types";
 import "jspdf-autotable";
@@ -354,7 +354,7 @@ export class MTableToolbar extends React.Component {
         : null;
     return (
       <Toolbar
-        className={classNames(classes.root, {
+        className={clsx(classes.root, {
           [classes.highlight]:
             this.props.showTextRowsSelected &&
             this.props.selectedRows &&


### PR DESCRIPTION
## Description

Replace `classnames` dependency by  [clsx](https://github.com/lukeed/clsx).

`@material-ui/core` use `clsx` internally and `classnames` isn't maintained for 2 years.

> A tiny (228B) utility for constructing className strings conditionally.
> Also serves as a faster & smaller drop-in replacement for the classnames module.

## Impacted Areas in Application

`MTableToolbar`