### PR TITLE
Fix expanded multi-level grouping collapsing on row selection

### DIFF
--- a/src/utils/data-manager.js
+++ b/src/utils/data-manager.js
@@ -983,11 +983,20 @@ export default class DataManager {
 
       this.sortedData = sortGroups(this.sortedData, groups[0]);
 
+      const getGroupsIndex = (groups) =>
+        groups.reduce((result, group) => {
+          result[group.value] = groups.findIndex(
+            (g) => g.value === group.value
+          );
+          return result;
+        }, {});
+
       const sortGroupData = (list, level) => {
         list.forEach((element) => {
           if (element.groups.length > 0) {
             const column = groups[level];
             element.groups = sortGroups(element.groups, column);
+            element.groupsIndex = getGroupsIndex(element.groups);
             sortGroupData(element.groups, level + 1);
           } else {
             if (this.orderBy >= 0 && this.orderDirection) {


### PR DESCRIPTION
## Related Issue

#2258 and the already closed #2249 

## Description
The groupsIndex did get messed up while sorting. This leads to the wrong groups being collapsed/expanded on subsequent `getRenderState()` calls. The fix is reindexing the groups after sorting.


## Impacted Areas in Application
- DataManager


## Additional Notes
What a hell of a class :D
Also is the level supposed to start at 1 here?
https://github.com/mbrn/material-table/blob/b7474ca0f5497f04ff3a3d50e709d86de7c639b0/src/utils/data-manager.js#L1000
On a glance 0 seems to make more sense. 

Awesome project 💯 
