### PR TITLE
add a position param for linear loading type

### DIFF
--- a/src/default-props.js
+++ b/src/default-props.js
@@ -214,6 +214,7 @@ export const defaultProps = {
     headerSelectionProps: {},
     hideFilterIcons: false,
     loadingType: "overlay",
+    linearPosition: "bottom",
     padding: "default",
     searchAutoFocus: false,
     paging: true,

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -1074,6 +1074,25 @@ export default class MaterialTable extends React.Component {
                         </div>
                       ) : null}
 
+                      {(this.state.isLoading || props.isLoading) &&
+                        props.options.loadingType === "linear" &&
+                        props.options.linearPosition === "top" && (
+                          <div style={{ position: "relative", width: "100%" }}>
+                            <div
+                              style={{
+                                position: "absolute",
+                                top: 0,
+                                left: 0,
+                                height: "100%",
+                                width: "100%",
+                                zIndex: 11,
+                              }}
+                            >
+                              <LinearProgress />
+                            </div>
+                          </div>
+                        )}
+
                       <div>{table}</div>
 
                       {this.state.width &&
@@ -1111,7 +1130,8 @@ export default class MaterialTable extends React.Component {
             </Droppable>
           </ScrollBar>
           {(this.state.isLoading || props.isLoading) &&
-            props.options.loadingType === "linear" && (
+            props.options.loadingType === "linear" &&
+            props.options.linearPosition === "bottom" && (
               <div style={{ position: "relative", width: "100%" }}>
                 <div
                   style={{

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -326,6 +326,7 @@ export const propTypes = {
     maxBodyHeight: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     minBodyHeight: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     loadingType: PropTypes.oneOf(["overlay", "linear"]),
+    linearPosition: PropTypes.oneOf(["top", "bottom"]),
     overflowY: PropTypes.oneOf([
       "visible",
       "hidden",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -323,6 +323,7 @@ export interface Options<RowData extends object> {
   hideFilterIcons?: boolean;
   initialPage?: number;
   loadingType?: "overlay" | "linear";
+  linearPosition?: "top" | "bottom";
   maxBodyHeight?: number | string;
   minBodyHeight?: number | string;
   padding?: "default" | "dense";


### PR DESCRIPTION
## Related Issue

#2582 

## Description

This PR adds a `linearPosition` field to position the LinearProgress component. Acceptable values are `bottom`(default) and `top`.

## Impacted Areas in Application

This PR should not affect any areas in this application, it simply adds a position control value for linear type loading.

## Additional Notes

This is what it looks like when the `linearPosition` is set to `top`. The loading is also set to absolute position to avoid the table jumping around at the start of the loading and the end of the loading.
![image](https://user-images.githubusercontent.com/15872787/99878978-20864200-2c44-11eb-984a-0b66fe0400de.png)

