### PR TITLE
update equality library to support react components

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,13 +80,13 @@
     "classnames": "2.2.6",
     "date-fns": "2.0.0-alpha.27",
     "debounce": "1.2.0",
-    "fast-deep-equal": "2.0.1",
     "filefy": "0.1.10",
     "jspdf": "2.1.0",
     "jspdf-autotable": "3.5.9",
     "prop-types": "15.6.2",
     "react-beautiful-dnd": "13.0.0",
-    "react-double-scrollbar": "0.0.15"
+    "react-double-scrollbar": "0.0.15",
+    "react-fast-compare": "^3.2.0"
   },
   "peerDependencies": {
     "@date-io/core": "1.3.6",

--- a/src/components/m-table-header.js
+++ b/src/components/m-table-header.js
@@ -10,7 +10,7 @@ import withStyles from "@material-ui/core/styles/withStyles";
 import { Draggable } from "react-beautiful-dnd";
 import { Tooltip } from "@material-ui/core";
 import * as CommonValues from "../utils/common-values";
-import equal from "fast-deep-equal";
+import equal from "react-fast-compare";
 
 /* eslint-enable no-unused-vars */
 

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -9,7 +9,7 @@ import { MTablePagination, MTableSteppedPagination } from "./components";
 import { DragDropContext, Droppable } from "react-beautiful-dnd";
 import DataManager from "./utils/data-manager";
 import { debounce } from "debounce";
-import equal from "fast-deep-equal";
+import equal from "react-fast-compare";
 import { withStyles } from "@material-ui/core";
 import * as CommonValues from "./utils/common-values";
 


### PR DESCRIPTION
## Related Issue
#2230 
#2118 
## Description

issues linked are caused by passing react components to the 'render' function of the column, this can be fixed by changing the equality library library used to one which supports react components -- I suggest using https://github.com/FormidableLabs/react-fast-compare as it has near identical performance and explicitly states the difference between it and fast-deep-equal is that it supports react components.

## Impacted Areas in Application

* Column rendering 
