### PR TITLE
fix a bug when columns options hidden and hiddenByColumnsButton are set to true

### DIFF
--- a/src/utils/common-values.js
+++ b/src/utils/common-values.js
@@ -10,6 +10,7 @@ export const selectionMaxWidth = (props, maxTreeLevel) =>
   baseIconSize(props) + 9 * maxTreeLevel;
 
 export const reducePercentsInCalc = (calc, fullValue) => {
+  if(!calc) return `${fullValue}px`
   const captureGroups = calc.match(/(\d*)%/);
   if (captureGroups && captureGroups.length > 1) {
     const percentage = captureGroups[1];


### PR DESCRIPTION
## Related Issue
Fixes #2654 

## Description
Fixes a bug when columns options `hidden` and `hiddenByColumnsButton` are set to `true`.

The problem lies in the function `reducePercentsInCalc` when supplied with undefined or null value will throw an error.
I first tried using this approad `calc?.match` but got an error during compiling.
So in the end I choose the primitive approach 
```
if(!calc) return `${fullValue}px`
```

## Related PRs
#2518

## Impacted Areas in Application
List general components of the application that this PR will affect:
All that uses `reducePercentsInCalc` function.
\*

