### PR TITLE
fix: prevent empty rows when filtering by 'date' and 'datetime'

### DIFF
--- a/src/utils/data-manager.js
+++ b/src/utils/data-manager.js
@@ -701,7 +701,7 @@ export default class DataManager {
                   return currentDateToCompare === selectedDateToCompare;
                 }
 
-                return true;
+                return false;
               });
             } else if (type === "time") {
               this.filteredData = this.filteredData.filter((row) => {


### PR DESCRIPTION
Еmpty lines appear when filtering by "date" and "datetime".
![image](https://user-images.githubusercontent.com/11224761/100535777-faa50280-322c-11eb-88f5-cbcf582a8f98.png)

