### PR TITLE
fix: add types to exportPdf props

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -312,6 +312,7 @@ export interface Options<RowData extends object> {
     | string
     | ((columns: Column<RowData>, data: string[][]) => string);
   exportCsv?: (columns: any[], renderData: any[]) => void;
+  exportPdf?: (columns: any[], renderData: any[]) => void;
   filtering?: boolean;
   filterCellStyle?: React.CSSProperties;
   filterRowStyle?: React.CSSProperties;


### PR DESCRIPTION

## Description

```
No overload matches this call.
  Overload 1 of 2, '(props: Readonly<MaterialTableProps<CommissionsDetail>>): MaterialTable<CommissionsDetail>', gave the following error.
    Type '{ exportPdf: (columns: any, data: any) => void; exportCsv: (columns: any[], data: any[]) => void; exportAllData: true; exportDelimiter: string; exportButton: { csv: true; pdf: true; }; showTitle: false; ... 6 more ...; searchFieldStyle: { ...; }; }' is not assignable to type 'Options<CommissionsDetail>'.
      Object literal may only specify known properties, and 'exportPdf' does not exist in type 'Options<CommissionsDetail>'.
  Overload 2 of 2, '(props: MaterialTableProps<CommissionsDetail>, context?: any): MaterialTable<CommissionsDetail>', gave the following error.
    Type '{ exportPdf: (columns: any, data: any) => void; exportCsv: (columns: any[], data: any[]) => void; exportAllData: true; exportDelimiter: string; exportButton: { csv: true; pdf: true; }; showTitle: false; ... 6 more ...; searchFieldStyle: { ...; }; }' is not assignable to type 'Options<CommissionsDetail>'.
      Object literal may only specify known properties, and 'exportPdf' does not exist in type 'Options<CommissionsDetail>'.ts(2769)
index.d.ts(45, 3): The expected type comes from property 'options' which is declared here on type 'IntrinsicAttributes & IntrinsicClassAttributes<MaterialTable<CommissionsDetail>> & Readonly<...> & Readonly<...>'
index.d.ts(45, 3): The expected type comes from property 'options' which is declared here on type 'IntrinsicAttributes & IntrinsicClassAttributes<MaterialTable<CommissionsDetail>> & Readonly<...> & Readonly<...>'
```



## Impacted Areas in Application

We changed the file wheres option type, adding the missing type to the `exportPdf`.


