### PR TITLE
Add hide grouping DnD

### DIFF
--- a/src/default-props.js
+++ b/src/default-props.js
@@ -213,6 +213,7 @@ export const defaultProps = {
     header: true,
     headerSelectionProps: {},
     hideFilterIcons: false,
+    hideGroupingDnD: false,
     loadingType: "overlay",
     padding: "default",
     searchAutoFocus: false,

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -1011,7 +1011,7 @@ export default class MaterialTable extends React.Component {
               }}
             />
           )}
-          {props.options.grouping && (
+          {props.options.grouping && !props.options.hideGroupingDnD && (
             <props.components.Groupbar
               icons={props.icons}
               localization={{

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -61,6 +61,7 @@ export const propTypes = {
       headerStyle: PropTypes.object,
       hidden: PropTypes.bool,
       hideFilterIcon: PropTypes.bool,
+      hideGroupingDnD: PropTypes.bool,
       initialEditValue: PropTypes.any,
       lookup: PropTypes.object,
       editable: PropTypes.oneOfType([

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -188,6 +188,7 @@ export interface Column<RowData extends object> {
   hidden?: boolean;
   hiddenByColumnsButton?: boolean;
   hideFilterIcon?: boolean;
+  hideGroupingDnD?: boolean;
   initialEditValue?: any;
   lookup?: object;
   editPlaceholder?: string;
@@ -321,6 +322,7 @@ export interface Options<RowData extends object> {
   headerSelectionProps?: object;
   headerStyle?: React.CSSProperties;
   hideFilterIcons?: boolean;
+  hideGroupingDnD?: boolean;
   initialPage?: number;
   loadingType?: "overlay" | "linear";
   maxBodyHeight?: number | string;


### PR DESCRIPTION
## Related Issue

Fixed #2668 

## Description

This PR add a `hideGroupingDnD` prop to use `grouping` without DnD.
![image](https://user-images.githubusercontent.com/42630357/101903873-8896cb00-3be7-11eb-8e25-45d7f0c9c610.png)

Now, if you want to use the `grouping` feature without DnD, just simple add `hideGroupingDnD: true` into the options prop
```
options={{
      ...,
      hideGroupingDnD: false,
}}
```

## Impacted Areas in Application

List general components of the application that this PR will affect:

\* MaterialTable
\* PropTypes
\* DefaultProps

