### PR TITLE
Fix browser freeze-up due to unbounded column sizing calculations.

### DIFF
--- a/src/utils/data-manager.js
+++ b/src/utils/data-manager.js
@@ -60,35 +60,38 @@ export default class DataManager {
   }
 
   setColumns(columns) {
-    const undefinedWidthColumns = columns.filter((c) =>
-      c.width === undefined && c.columnDef
-        ? c.columnDef.tableData.width === undefined
-        : true && !c.hidden
-    );
+    const undefinedWidthColumns = columns.filter((c) => {
+      if (c.hidden) {
+        // Hidden column
+        return false;
+      }
+      if (c.columnDef && columnDef.tableData && columnDef.tableData.width) {
+        // tableData.width already calculated
+        return false;
+      }
+      // Calculate width if no value provided
+      return c.width === undefined;
+    });
     let usedWidth = ["0px"];
 
     this.columns = columns.map((columnDef, index) => {
+      const width = typeof columnDef.width === "number" ? columnDef.width + "px" : columnDef.width;
+
+      if (width && columnDef.tableData && columnDef.tableData.width !== undefined) {
+        usedWidth.push(width);
+      }
+
       columnDef.tableData = {
         columnOrder: index,
         filterValue: columnDef.defaultFilter,
         groupOrder: columnDef.defaultGroupOrder,
         groupSort: columnDef.defaultGroupSort || "asc",
-        width:
-          typeof columnDef.width === "number"
-            ? columnDef.width + "px"
-            : columnDef.width,
-        initialWidth:
-          typeof columnDef.width === "number"
-            ? columnDef.width + "px"
-            : columnDef.width,
+        width,
+        initialWidth: width,
         additionalWidth: 0,
         ...columnDef.tableData,
         id: index,
       };
-
-      if (columnDef.tableData.width !== undefined) {
-        usedWidth.push(columnDef.tableData.width);
-      }
 
       return columnDef;
     });

--- a/src/utils/data-manager.js
+++ b/src/utils/data-manager.js
@@ -65,7 +65,7 @@ export default class DataManager {
         // Hidden column
         return false;
       }
-      if (c.columnDef && columnDef.tableData && columnDef.tableData.width) {
+      if (c.columnDef && c.columnDef.tableData && c.columnDef.tableData.width) {
         // tableData.width already calculated
         return false;
       }


### PR DESCRIPTION
## Related Issue

#2451 Material Table freezes Browser

## Description

This PR fixes the bug that causes the width calculations to grow every time `setColumns()` is called. This occurs frequently and causes the value to grow unbounded, eventually freezing the browser.

The check on `columnDef.tableData.width` occurs in the wrong order, after `tableData.width` is set. That causes it to always add to `usedWidth`, the root cause of the unbounded growth.
https://github.com/mbrn/material-table/blob/master/src/utils/data-manager.js#L89

The filter code, while compact, is terse and difficult to reason about. It's worth expanding out to improve maintainability. There's no real impact on performance. The ternary is just syntactic sugar.
https://github.com/mbrn/material-table/blob/master/src/utils/data-manager.js#L63


## Impacted Areas in Application

List general components of the application that this PR will affect:

data-manager.js

## Additional Notes

This may be related to #2685 #2650 #2643 #2581 #2514 #2486 #2451
