### PR TITLE
Remove Accents in searchs

### DIFF
--- a/src/utils/data-manager.js
+++ b/src/utils/data-manager.js
@@ -765,8 +765,9 @@ export default class DataManager {
               if (value) {
                 return value
                   .toString()
+                  .normalize('NFD').replace(/[\u0300-\u036f]/g,"")
                   .toUpperCase()
-                  .includes(trimmedSearchText.toUpperCase());
+                  .includes(trimmedSearchText.normalize('NFD').replace(/[\u0300-\u036f]/g,"").toUpperCase());
               }
             }
           });


### PR DESCRIPTION
## Description

Searching (usually in spain) exists a lot of accents in the words, and when you search, sometimes the accents are not written. Then users want to search the words with and without accents. 

Ex.
Search: "Lápiz"
Results of search: "Lapiz", "Lápiz"

## Impacted Areas in Application

Spanish lang search
