### PR TITLE
Allow compatible versions of dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,18 +75,18 @@
     "webpack-dev-server": "3.1.10"
   },
   "dependencies": {
-    "@date-io/date-fns": "1.1.0",
-    "@material-ui/pickers": "3.2.2",
-    "classnames": "2.2.6",
-    "date-fns": "2.0.0-alpha.27",
-    "debounce": "1.2.0",
-    "fast-deep-equal": "2.0.1",
-    "filefy": "0.1.10",
-    "jspdf": "2.1.0",
-    "jspdf-autotable": "3.5.9",
-    "prop-types": "15.6.2",
-    "react-beautiful-dnd": "13.0.0",
-    "react-double-scrollbar": "0.0.15"
+    "@date-io/date-fns": "^1.1.0",
+    "@material-ui/pickers": "^3.2.2",
+    "classnames": "^2.2.6",
+    "date-fns": "^2.0.0-alpha.27",
+    "debounce": "^1.2.0",
+    "fast-deep-equal": "^2.0.1",
+    "filefy": "^0.1.10",
+    "jspdf": "^2.1.0",
+    "jspdf-autotable": "^3.5.9",
+    "prop-types": "^15.6.2",
+    "react-beautiful-dnd": "^13.0.0",
+    "react-double-scrollbar": "^0.0.15"
   },
   "peerDependencies": {
     "@date-io/core": "1.3.6",


### PR DESCRIPTION
## Description

When installing material-table along with the latest version of material-ui via yarn, several warnings appear since material-table forces particular versions of its dependencies. For instance:

```[INFO] [3/4] Linking dependencies...
[ERROR] warning " > material-table@1.69.2" has incorrect peer dependency "@date-io/core@1.3.6".
[ERROR] warning " > material-table@1.69.2" has incorrect peer dependency "@material-ui/core@4.0.1".
[ERROR] warning " > material-table@1.69.2" has incorrect peer dependency "react@16.8.4".
[ERROR] warning " > material-table@1.69.2" has incorrect peer dependency "react-dom@16.8.4".
[ERROR] warning "material-table > @material-ui/pickers@3.2.2" has incorrect peer dependency "@date-io/core@^1.3.6".```

This PR allows any compatible versions of libraries to be used, eliminating these warnings.
