### PR TITLE
Added search field size prop.

### DIFF
--- a/src/components/m-table-toolbar.js
+++ b/src/components/m-table-toolbar.js
@@ -135,6 +135,7 @@ export class MTableToolbar extends React.Component {
           onChange={(event) => this.onSearchChange(event.target.value)}
           placeholder={localization.searchPlaceholder}
           variant={this.props.searchFieldVariant}
+          size={this.props.searchFieldSize}
           InputProps={{
             startAdornment: (
               <InputAdornment position="start">
@@ -398,6 +399,7 @@ MTableToolbar.defaultProps = {
   searchAutoFocus: false,
   searchFieldAlignment: "right",
   searchFieldVariant: "standard",
+  searchFieldSize: "normal",
   selectedRows: [],
   title: "No Title!",
 };
@@ -416,6 +418,7 @@ MTableToolbar.propTypes = {
   search: PropTypes.bool.isRequired,
   searchFieldStyle: PropTypes.object,
   searchFieldVariant: PropTypes.string,
+  searchFieldSize: PropTypes.string,
   selectedRows: PropTypes.array,
   title: PropTypes.oneOfType([PropTypes.element, PropTypes.string]),
   showTitle: PropTypes.bool.isRequired,

--- a/src/default-props.js
+++ b/src/default-props.js
@@ -232,6 +232,7 @@ export const defaultProps = {
     searchFieldAlignment: "right",
     searchFieldStyle: {},
     searchFieldVariant: "standard",
+    searchFieldSize: "normal",
     selection: false,
     selectionProps: {},
     sorting: true,

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -348,6 +348,7 @@ export const propTypes = {
     searchFieldStyle: PropTypes.object,
     searchAutoFocus: PropTypes.bool,
     searchFieldVariant: PropTypes.oneOf(["standard", "filled", "outlined"]),
+    searchFieldSize: PropTypes.oneOf(["small", "normal"]),
     selection: PropTypes.bool,
     selectionProps: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
     showEmptyDataSourceMessage: PropTypes.bool,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -347,6 +347,7 @@ export interface Options<RowData extends object> {
   searchFieldAlignment?: "left" | "right";
   searchFieldStyle?: React.CSSProperties;
   searchFieldVariant?: "standard" | "filled" | "outlined";
+  searchFieldSize?: "small" | "normal";
   searchAutoFocus?: boolean;
   selection?: boolean;
   selectionProps?: any | ((data: any) => any);


### PR DESCRIPTION

## Description

The search field did not have an option to give the size.
Added a prop to make the size configurable.

## Impacted Areas in Application

This PR will affect the search field component in the toolbar.

\*

## Additional Notes

This is optional, feel free to follow your hearth and write here :)
