### PR TITLE
checking cell editable function value before allowing edits

### DIFF
--- a/src/components/m-table-body-row.js
+++ b/src/components/m-table-body-row.js
@@ -66,7 +66,10 @@ export default class MTableBodyRow extends React.Component {
               }
               rowData={this.props.data}
               cellEditable={
-                columnDef.editable !== "never" && !!this.props.cellEditable
+                columnDef.editable !== "never" &&
+                (typeof columnDef.editable !== "function" ||
+                  columnDef.editable(columnDef, this.props.data)) &&
+                !!this.props.cellEditable
               }
               onCellEditStarted={this.props.onCellEditStarted}
               scrollWidth={this.props.scrollWidth}


### PR DESCRIPTION
## Related Issue

Relate the Github issue with this PR using `#`
#2760

## Description
There seems to be a bug in the `columnDef.editable` property. Despite defining the appropriate functions, the cell is still editable. For example, refer to the screenshot below
<img width="720" alt="Screen Shot 2021-01-27 at 3 03 29 PM" src="https://user-images.githubusercontent.com/62398805/106065953-de98d280-60b0-11eb-9105-bf2259c498aa.png">

Added in a fix which only displays a cell as editable when the `editable` function for the column is `true`.

## Impacted Areas in Application

List general components of the application that this PR will affect:
\* table body rows
\* cells (editable)
