### PR TITLE
Added MTableEditCell to exported components

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -242,6 +242,7 @@ export const MTableActions: (props: any) => React.ReactElement<any>;
 export const MTableBody: (props: any) => React.ReactElement<any>;
 export const MTableBodyRow: (props: any) => React.ReactElement<any>;
 export const MTableCell: (props: any) => React.ReactElement<any>;
+export const MTableEditCell: (props: any) => React.ReactElement<any>;
 export const MTableEditField: (props: any) => React.ReactElement<any>;
 export const MTableEditRow: (props: any) => React.ReactElement<any>;
 export const MTableFilterRow: (props: any) => React.ReactElement<any>;


### PR DESCRIPTION
## Description

Added a line in types/index so that MTableEditCell can also be imported from the package

## Related PRs

None

## Impacted Areas in Application

None

## Additional Notes

Did not test the build, but simply adding the row on the installed package was enough, so I suppose it should be the same with the original type file.
