### PR TITLE
Enable access to the edited state of the row within the editable function

### DIFF
--- a/dist/components/index.js
+++ b/dist/components/index.js
@@ -1,0 +1,129 @@
+"use strict";
+
+var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
+
+Object.defineProperty(exports, "__esModule", {
+  value: true,
+});
+Object.defineProperty(exports, "MTableAction", {
+  enumerable: true,
+  get: function get() {
+    return _mTableAction.default;
+  },
+});
+Object.defineProperty(exports, "MTableActions", {
+  enumerable: true,
+  get: function get() {
+    return _mTableActions.default;
+  },
+});
+Object.defineProperty(exports, "MTableBody", {
+  enumerable: true,
+  get: function get() {
+    return _mTableBody.default;
+  },
+});
+Object.defineProperty(exports, "MTableBodyRow", {
+  enumerable: true,
+  get: function get() {
+    return _mTableBodyRow.default;
+  },
+});
+Object.defineProperty(exports, "MTableGroupbar", {
+  enumerable: true,
+  get: function get() {
+    return _mTableGroupbar.default;
+  },
+});
+Object.defineProperty(exports, "MTableGroupRow", {
+  enumerable: true,
+  get: function get() {
+    return _mTableGroupRow.default;
+  },
+});
+Object.defineProperty(exports, "MTableCell", {
+  enumerable: true,
+  get: function get() {
+    return _mTableCell.default;
+  },
+});
+Object.defineProperty(exports, "MTableEditCell", {
+  enumerable: true,
+  get: function get() {
+    return _mTableEditCell.default;
+  },
+});
+Object.defineProperty(exports, "MTableEditRow", {
+  enumerable: true,
+  get: function get() {
+    return _mTableEditRow.default;
+  },
+});
+Object.defineProperty(exports, "MTableEditField", {
+  enumerable: true,
+  get: function get() {
+    return _mTableEditField.default;
+  },
+});
+Object.defineProperty(exports, "MTableFilterRow", {
+  enumerable: true,
+  get: function get() {
+    return _mTableFilterRow.default;
+  },
+});
+Object.defineProperty(exports, "MTableHeader", {
+  enumerable: true,
+  get: function get() {
+    return _mTableHeader.default;
+  },
+});
+Object.defineProperty(exports, "MTablePagination", {
+  enumerable: true,
+  get: function get() {
+    return _mTablePagination.default;
+  },
+});
+Object.defineProperty(exports, "MTableSteppedPagination", {
+  enumerable: true,
+  get: function get() {
+    return _mTableSteppedPagination.default;
+  },
+});
+Object.defineProperty(exports, "MTableToolbar", {
+  enumerable: true,
+  get: function get() {
+    return _mTableToolbar.default;
+  },
+});
+
+var _mTableAction = _interopRequireDefault(require("./m-table-action"));
+
+var _mTableActions = _interopRequireDefault(require("./m-table-actions"));
+
+var _mTableBody = _interopRequireDefault(require("./m-table-body"));
+
+var _mTableBodyRow = _interopRequireDefault(require("./m-table-body-row"));
+
+var _mTableGroupbar = _interopRequireDefault(require("./m-table-groupbar"));
+
+var _mTableGroupRow = _interopRequireDefault(require("./m-table-group-row"));
+
+var _mTableCell = _interopRequireDefault(require("./m-table-cell"));
+
+var _mTableEditCell = _interopRequireDefault(require("./m-table-edit-cell"));
+
+var _mTableEditRow = _interopRequireDefault(require("./m-table-edit-row"));
+
+var _mTableEditField = _interopRequireDefault(require("./m-table-edit-field"));
+
+var _mTableFilterRow = _interopRequireDefault(require("./m-table-filter-row"));
+
+var _mTableHeader = _interopRequireDefault(require("./m-table-header"));
+
+var _mTablePagination = _interopRequireDefault(require("./m-table-pagination"));
+
+var _mTableSteppedPagination = _interopRequireDefault(
+  require("./m-table-stepped-pagination")
+);
+
+var _mTableToolbar = _interopRequireDefault(require("./m-table-toolbar"));

--- a/dist/components/m-table-action.js
+++ b/dist/components/m-table-action.js
@@ -1,0 +1,192 @@
+"use strict";
+
+var _interopRequireWildcard = require("@babel/runtime/helpers/interopRequireWildcard");
+
+var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
+
+Object.defineProperty(exports, "__esModule", {
+  value: true,
+});
+exports.default = void 0;
+
+var _objectSpread2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/objectSpread")
+);
+
+var _classCallCheck2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/classCallCheck")
+);
+
+var _createClass2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/createClass")
+);
+
+var _inherits2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/inherits")
+);
+
+var _possibleConstructorReturn2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/possibleConstructorReturn")
+);
+
+var _getPrototypeOf2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/getPrototypeOf")
+);
+
+var React = _interopRequireWildcard(require("react"));
+
+var _propTypes = _interopRequireDefault(require("prop-types"));
+
+var _Icon = _interopRequireDefault(require("@material-ui/core/Icon"));
+
+var _IconButton = _interopRequireDefault(
+  require("@material-ui/core/IconButton")
+);
+
+var _Tooltip = _interopRequireDefault(require("@material-ui/core/Tooltip"));
+
+function _createSuper(Derived) {
+  var hasNativeReflectConstruct = _isNativeReflectConstruct();
+  return function _createSuperInternal() {
+    var Super = (0, _getPrototypeOf2.default)(Derived),
+      result;
+    if (hasNativeReflectConstruct) {
+      var NewTarget = (0, _getPrototypeOf2.default)(this).constructor;
+      result = Reflect.construct(Super, arguments, NewTarget);
+    } else {
+      result = Super.apply(this, arguments);
+    }
+    return (0, _possibleConstructorReturn2.default)(this, result);
+  };
+}
+
+function _isNativeReflectConstruct() {
+  if (typeof Reflect === "undefined" || !Reflect.construct) return false;
+  if (Reflect.construct.sham) return false;
+  if (typeof Proxy === "function") return true;
+  try {
+    Date.prototype.toString.call(Reflect.construct(Date, [], function () {}));
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
+/* eslint-enable no-unused-vars */
+var MTableAction = /*#__PURE__*/ (function (_React$Component) {
+  (0, _inherits2.default)(MTableAction, _React$Component);
+
+  var _super = _createSuper(MTableAction);
+
+  function MTableAction() {
+    (0, _classCallCheck2.default)(this, MTableAction);
+    return _super.apply(this, arguments);
+  }
+
+  (0, _createClass2.default)(MTableAction, [
+    {
+      key: "render",
+      value: function render() {
+        var _this = this;
+
+        var action = this.props.action;
+
+        if (typeof action === "function") {
+          action = action(this.props.data);
+
+          if (!action) {
+            return null;
+          }
+        }
+
+        if (action.action) {
+          action = action.action(this.props.data);
+
+          if (!action) {
+            return null;
+          }
+        }
+
+        if (action.hidden) {
+          return null;
+        }
+
+        var disabled = action.disabled || this.props.disabled;
+
+        var handleOnClick = function handleOnClick(event) {
+          if (action.onClick) {
+            action.onClick(event, _this.props.data);
+            event.stopPropagation();
+          }
+        };
+
+        var icon =
+          typeof action.icon === "string"
+            ? /*#__PURE__*/ React.createElement(
+                _Icon.default,
+                action.iconProps,
+                action.icon
+              )
+            : typeof action.icon === "function"
+            ? action.icon(
+                (0, _objectSpread2.default)({}, action.iconProps, {
+                  disabled: disabled,
+                })
+              )
+            : /*#__PURE__*/ React.createElement(action.icon, null);
+        var button = /*#__PURE__*/ React.createElement(
+          _IconButton.default,
+          {
+            size: this.props.size,
+            color: "inherit",
+            disabled: disabled,
+            onClick: handleOnClick,
+          },
+          icon
+        );
+
+        if (action.tooltip) {
+          // fix for issue #1049
+          // https://github.com/mbrn/material-table/issues/1049
+          return disabled
+            ? /*#__PURE__*/ React.createElement(
+                _Tooltip.default,
+                {
+                  title: action.tooltip,
+                },
+                /*#__PURE__*/ React.createElement("span", null, button)
+              )
+            : /*#__PURE__*/ React.createElement(
+                _Tooltip.default,
+                {
+                  title: action.tooltip,
+                },
+                button
+              );
+        } else {
+          return button;
+        }
+      },
+    },
+  ]);
+  return MTableAction;
+})(React.Component);
+
+MTableAction.defaultProps = {
+  action: {},
+  data: {},
+};
+MTableAction.propTypes = {
+  action: _propTypes.default.oneOfType([
+    _propTypes.default.func,
+    _propTypes.default.object,
+  ]).isRequired,
+  data: _propTypes.default.oneOfType([
+    _propTypes.default.object,
+    _propTypes.default.arrayOf(_propTypes.default.object),
+  ]),
+  disabled: _propTypes.default.bool,
+  size: _propTypes.default.string,
+};
+var _default = MTableAction;
+exports.default = _default;

--- a/dist/components/m-table-actions.js
+++ b/dist/components/m-table-actions.js
@@ -1,0 +1,117 @@
+"use strict";
+
+var _interopRequireWildcard = require("@babel/runtime/helpers/interopRequireWildcard");
+
+var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
+
+Object.defineProperty(exports, "__esModule", {
+  value: true,
+});
+exports.default = void 0;
+
+var _classCallCheck2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/classCallCheck")
+);
+
+var _createClass2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/createClass")
+);
+
+var _inherits2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/inherits")
+);
+
+var _possibleConstructorReturn2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/possibleConstructorReturn")
+);
+
+var _getPrototypeOf2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/getPrototypeOf")
+);
+
+var React = _interopRequireWildcard(require("react"));
+
+var _propTypes = _interopRequireDefault(require("prop-types"));
+
+function _createSuper(Derived) {
+  var hasNativeReflectConstruct = _isNativeReflectConstruct();
+  return function _createSuperInternal() {
+    var Super = (0, _getPrototypeOf2.default)(Derived),
+      result;
+    if (hasNativeReflectConstruct) {
+      var NewTarget = (0, _getPrototypeOf2.default)(this).constructor;
+      result = Reflect.construct(Super, arguments, NewTarget);
+    } else {
+      result = Super.apply(this, arguments);
+    }
+    return (0, _possibleConstructorReturn2.default)(this, result);
+  };
+}
+
+function _isNativeReflectConstruct() {
+  if (typeof Reflect === "undefined" || !Reflect.construct) return false;
+  if (Reflect.construct.sham) return false;
+  if (typeof Proxy === "function") return true;
+  try {
+    Date.prototype.toString.call(Reflect.construct(Date, [], function () {}));
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
+/* eslint-enable no-unused-vars */
+var MTableActions = /*#__PURE__*/ (function (_React$Component) {
+  (0, _inherits2.default)(MTableActions, _React$Component);
+
+  var _super = _createSuper(MTableActions);
+
+  function MTableActions() {
+    (0, _classCallCheck2.default)(this, MTableActions);
+    return _super.apply(this, arguments);
+  }
+
+  (0, _createClass2.default)(MTableActions, [
+    {
+      key: "render",
+      value: function render() {
+        var _this = this;
+
+        if (this.props.actions) {
+          return this.props.actions.map(function (action, index) {
+            return /*#__PURE__*/ React.createElement(
+              _this.props.components.Action,
+              {
+                action: action,
+                key: "action-" + index,
+                data: _this.props.data,
+                size: _this.props.size,
+                disabled: _this.props.disabled,
+              }
+            );
+          });
+        }
+
+        return null;
+      },
+    },
+  ]);
+  return MTableActions;
+})(React.Component);
+
+MTableActions.defaultProps = {
+  actions: [],
+  data: {},
+};
+MTableActions.propTypes = {
+  components: _propTypes.default.object.isRequired,
+  actions: _propTypes.default.array.isRequired,
+  data: _propTypes.default.oneOfType([
+    _propTypes.default.object,
+    _propTypes.default.arrayOf(_propTypes.default.object),
+  ]),
+  disabled: _propTypes.default.bool,
+  size: _propTypes.default.string,
+};
+var _default = MTableActions;
+exports.default = _default;

--- a/dist/components/m-table-body-row.js
+++ b/dist/components/m-table-body-row.js
@@ -1,0 +1,815 @@
+"use strict";
+
+var _interopRequireWildcard = require("@babel/runtime/helpers/interopRequireWildcard");
+
+var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
+
+Object.defineProperty(exports, "__esModule", {
+  value: true,
+});
+exports.default = void 0;
+
+var _toConsumableArray2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/toConsumableArray")
+);
+
+var _objectWithoutProperties2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/objectWithoutProperties")
+);
+
+var _extends2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/extends")
+);
+
+var _objectSpread2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/objectSpread")
+);
+
+var _classCallCheck2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/classCallCheck")
+);
+
+var _createClass2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/createClass")
+);
+
+var _assertThisInitialized2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/assertThisInitialized")
+);
+
+var _inherits2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/inherits")
+);
+
+var _possibleConstructorReturn2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/possibleConstructorReturn")
+);
+
+var _getPrototypeOf2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/getPrototypeOf")
+);
+
+var _defineProperty2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/defineProperty")
+);
+
+var _Checkbox = _interopRequireDefault(require("@material-ui/core/Checkbox"));
+
+var _TableCell = _interopRequireDefault(require("@material-ui/core/TableCell"));
+
+var _TableRow = _interopRequireDefault(require("@material-ui/core/TableRow"));
+
+var _IconButton = _interopRequireDefault(
+  require("@material-ui/core/IconButton")
+);
+
+var _Icon = _interopRequireDefault(require("@material-ui/core/Icon"));
+
+var _Tooltip = _interopRequireDefault(require("@material-ui/core/Tooltip"));
+
+var _propTypes = _interopRequireDefault(require("prop-types"));
+
+var React = _interopRequireWildcard(require("react"));
+
+var CommonValues = _interopRequireWildcard(require("../utils/common-values"));
+
+function _createSuper(Derived) {
+  var hasNativeReflectConstruct = _isNativeReflectConstruct();
+  return function _createSuperInternal() {
+    var Super = (0, _getPrototypeOf2.default)(Derived),
+      result;
+    if (hasNativeReflectConstruct) {
+      var NewTarget = (0, _getPrototypeOf2.default)(this).constructor;
+      result = Reflect.construct(Super, arguments, NewTarget);
+    } else {
+      result = Super.apply(this, arguments);
+    }
+    return (0, _possibleConstructorReturn2.default)(this, result);
+  };
+}
+
+function _isNativeReflectConstruct() {
+  if (typeof Reflect === "undefined" || !Reflect.construct) return false;
+  if (Reflect.construct.sham) return false;
+  if (typeof Proxy === "function") return true;
+  try {
+    Date.prototype.toString.call(Reflect.construct(Date, [], function () {}));
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
+/* eslint-enable no-unused-vars */
+var MTableBodyRow = /*#__PURE__*/ (function (_React$Component) {
+  (0, _inherits2.default)(MTableBodyRow, _React$Component);
+
+  var _super = _createSuper(MTableBodyRow);
+
+  function MTableBodyRow() {
+    var _this;
+
+    (0, _classCallCheck2.default)(this, MTableBodyRow);
+
+    for (
+      var _len = arguments.length, args = new Array(_len), _key = 0;
+      _key < _len;
+      _key++
+    ) {
+      args[_key] = arguments[_key];
+    }
+
+    _this = _super.call.apply(_super, [this].concat(args));
+    (0, _defineProperty2.default)(
+      (0, _assertThisInitialized2.default)(_this),
+      "rotateIconStyle",
+      function (isOpen) {
+        return {
+          transform: isOpen ? "rotate(90deg)" : "none",
+        };
+      }
+    );
+    return _this;
+  }
+
+  (0, _createClass2.default)(MTableBodyRow, [
+    {
+      key: "renderColumns",
+      value: function renderColumns() {
+        var _this2 = this;
+
+        var size = CommonValues.elementSize(this.props);
+        var mapArr = this.props.columns
+          .filter(function (columnDef) {
+            return !columnDef.hidden && !(columnDef.tableData.groupOrder > -1);
+          })
+          .sort(function (a, b) {
+            return a.tableData.columnOrder - b.tableData.columnOrder;
+          })
+          .map(function (columnDef, index) {
+            var value = _this2.props.getFieldValue(
+              _this2.props.data,
+              columnDef
+            );
+
+            if (
+              _this2.props.data.tableData.editCellList &&
+              _this2.props.data.tableData.editCellList.find(function (c) {
+                return c.tableData.id === columnDef.tableData.id;
+              })
+            ) {
+              return /*#__PURE__*/ React.createElement(
+                _this2.props.components.EditCell,
+                {
+                  components: _this2.props.components,
+                  icons: _this2.props.icons,
+                  localization: _this2.props.localization,
+                  columnDef: columnDef,
+                  size: size,
+                  key:
+                    "cell-" +
+                    _this2.props.data.tableData.id +
+                    "-" +
+                    columnDef.tableData.id,
+                  rowData: _this2.props.data,
+                  cellEditable: _this2.props.cellEditable,
+                  onCellEditFinished: _this2.props.onCellEditFinished,
+                  scrollWidth: _this2.props.scrollWidth,
+                }
+              );
+            } else {
+              return /*#__PURE__*/ React.createElement(
+                _this2.props.components.Cell,
+                {
+                  size: size,
+                  errorState: _this2.props.errorState,
+                  icons: _this2.props.icons,
+                  columnDef: (0, _objectSpread2.default)(
+                    {
+                      cellStyle: _this2.props.options.cellStyle,
+                    },
+                    columnDef
+                  ),
+                  value: value,
+                  key:
+                    "cell-" +
+                    _this2.props.data.tableData.id +
+                    "-" +
+                    columnDef.tableData.id,
+                  rowData: _this2.props.data,
+                  cellEditable:
+                    columnDef.editable !== "never" &&
+                    !!_this2.props.cellEditable,
+                  onCellEditStarted: _this2.props.onCellEditStarted,
+                  scrollWidth: _this2.props.scrollWidth,
+                }
+              );
+            }
+          });
+        return mapArr;
+      },
+    },
+    {
+      key: "renderActions",
+      value: function renderActions() {
+        var size = CommonValues.elementSize(this.props);
+        var actions = CommonValues.rowActions(this.props);
+        var width = actions.length * CommonValues.baseIconSize(this.props);
+        return /*#__PURE__*/ React.createElement(
+          _TableCell.default,
+          {
+            size: size,
+            padding: "none",
+            key: "key-actions-column",
+            style: (0, _objectSpread2.default)(
+              {
+                width: width,
+                padding: "0px 5px",
+                boxSizing: "border-box",
+              },
+              this.props.options.actionsCellStyle
+            ),
+          },
+          /*#__PURE__*/ React.createElement(
+            "div",
+            {
+              style: {
+                display: "flex",
+              },
+            },
+            /*#__PURE__*/ React.createElement(this.props.components.Actions, {
+              data: this.props.data,
+              actions: actions,
+              components: this.props.components,
+              size: size,
+              disabled: this.props.hasAnyEditingRow,
+            })
+          )
+        );
+      },
+    },
+    {
+      key: "renderSelectionColumn",
+      value: function renderSelectionColumn() {
+        var _this3 = this;
+
+        var checkboxProps = this.props.options.selectionProps || {};
+
+        if (typeof checkboxProps === "function") {
+          checkboxProps = checkboxProps(this.props.data);
+        }
+
+        var size = CommonValues.elementSize(this.props);
+        var selectionWidth = CommonValues.selectionMaxWidth(
+          this.props,
+          this.props.treeDataMaxLevel
+        );
+        var styles =
+          size === "medium"
+            ? {
+                marginLeft: this.props.level * 9,
+              }
+            : {
+                padding: "4px",
+                marginLeft: 5 + this.props.level * 9,
+              };
+        return /*#__PURE__*/ React.createElement(
+          _TableCell.default,
+          {
+            size: size,
+            padding: "none",
+            key: "key-selection-column",
+            style: {
+              width: selectionWidth,
+            },
+          },
+          /*#__PURE__*/ React.createElement(
+            _Checkbox.default,
+            (0, _extends2.default)(
+              {
+                size: size,
+                checked: this.props.data.tableData.checked === true,
+                onClick: function onClick(e) {
+                  return e.stopPropagation();
+                },
+                value: this.props.data.tableData.id.toString(),
+                onChange: function onChange(event) {
+                  return _this3.props.onRowSelected(
+                    event,
+                    _this3.props.path,
+                    _this3.props.data
+                  );
+                },
+                style: styles,
+              },
+              checkboxProps
+            )
+          )
+        );
+      },
+    },
+    {
+      key: "renderDetailPanelColumn",
+      value: function renderDetailPanelColumn() {
+        var _this4 = this;
+
+        var size = CommonValues.elementSize(this.props);
+
+        var CustomIcon = function CustomIcon(_ref) {
+          var icon = _ref.icon,
+            iconProps = _ref.iconProps;
+          return typeof icon === "string"
+            ? /*#__PURE__*/ React.createElement(_Icon.default, iconProps, icon)
+            : React.createElement(
+                icon,
+                (0, _objectSpread2.default)({}, iconProps)
+              );
+        };
+
+        if (typeof this.props.detailPanel == "function") {
+          return /*#__PURE__*/ React.createElement(
+            _TableCell.default,
+            {
+              size: size,
+              padding: "none",
+              key: "key-detail-panel-column",
+              style: (0, _objectSpread2.default)(
+                {
+                  width: 42,
+                  textAlign: "center",
+                },
+                this.props.options.detailPanelColumnStyle
+              ),
+            },
+            /*#__PURE__*/ React.createElement(
+              _IconButton.default,
+              {
+                size: size,
+                style: (0, _objectSpread2.default)(
+                  {
+                    transition: "all ease 200ms",
+                  },
+                  this.rotateIconStyle(
+                    this.props.data.tableData.showDetailPanel
+                  )
+                ),
+                onClick: function onClick(event) {
+                  _this4.props.onToggleDetailPanel(
+                    _this4.props.path,
+                    _this4.props.detailPanel
+                  );
+
+                  event.stopPropagation();
+                },
+              },
+              /*#__PURE__*/ React.createElement(
+                this.props.icons.DetailPanel,
+                null
+              )
+            )
+          );
+        } else {
+          return /*#__PURE__*/ React.createElement(
+            _TableCell.default,
+            {
+              size: size,
+              padding: "none",
+              key: "key-detail-panel-column",
+            },
+            /*#__PURE__*/ React.createElement(
+              "div",
+              {
+                style: (0, _objectSpread2.default)(
+                  {
+                    width: 42 * this.props.detailPanel.length,
+                    textAlign: "center",
+                    display: "flex",
+                  },
+                  this.props.options.detailPanelColumnStyle
+                ),
+              },
+              this.props.detailPanel.map(function (panel, index) {
+                if (typeof panel === "function") {
+                  panel = panel(_this4.props.data);
+                }
+
+                var isOpen =
+                  (
+                    _this4.props.data.tableData.showDetailPanel || ""
+                  ).toString() === panel.render.toString();
+                var iconButton = /*#__PURE__*/ React.createElement(
+                  _this4.props.icons.DetailPanel,
+                  null
+                );
+                var animation = true;
+
+                if (isOpen) {
+                  if (panel.openIcon) {
+                    iconButton = /*#__PURE__*/ React.createElement(CustomIcon, {
+                      icon: panel.openIcon,
+                      iconProps: panel.iconProps,
+                    });
+                    animation = false;
+                  } else if (panel.icon) {
+                    iconButton = /*#__PURE__*/ React.createElement(CustomIcon, {
+                      icon: panel.icon,
+                      iconProps: panel.iconProps,
+                    });
+                  }
+                } else if (panel.icon) {
+                  iconButton = /*#__PURE__*/ React.createElement(CustomIcon, {
+                    icon: panel.icon,
+                    iconProps: panel.iconProps,
+                  });
+                  animation = false;
+                }
+
+                iconButton = /*#__PURE__*/ React.createElement(
+                  _IconButton.default,
+                  {
+                    size: size,
+                    key: "key-detail-panel-" + index,
+                    style: (0, _objectSpread2.default)(
+                      {
+                        transition: "all ease 200ms",
+                      },
+                      _this4.rotateIconStyle(animation && isOpen)
+                    ),
+                    disabled: panel.disabled,
+                    onClick: function onClick(event) {
+                      _this4.props.onToggleDetailPanel(
+                        _this4.props.path,
+                        panel.render
+                      );
+
+                      event.stopPropagation();
+                    },
+                  },
+                  iconButton
+                );
+
+                if (panel.tooltip) {
+                  iconButton = /*#__PURE__*/ React.createElement(
+                    _Tooltip.default,
+                    {
+                      key: "key-detail-panel-" + index,
+                      title: panel.tooltip,
+                    },
+                    iconButton
+                  );
+                }
+
+                return iconButton;
+              })
+            )
+          );
+        }
+      },
+    },
+    {
+      key: "renderTreeDataColumn",
+      value: function renderTreeDataColumn() {
+        var _this5 = this;
+
+        var size = CommonValues.elementSize(this.props);
+
+        if (
+          this.props.data.tableData.childRows &&
+          this.props.data.tableData.childRows.length > 0
+        ) {
+          return /*#__PURE__*/ React.createElement(
+            _TableCell.default,
+            {
+              size: size,
+              padding: "none",
+              key: "key-tree-data-column",
+              style: {
+                width: 48 + 9 * (this.props.treeDataMaxLevel - 2),
+              },
+            },
+            /*#__PURE__*/ React.createElement(
+              _IconButton.default,
+              {
+                size: size,
+                style: (0, _objectSpread2.default)(
+                  {
+                    transition: "all ease 200ms",
+                    marginLeft: this.props.level * 9,
+                  },
+                  this.rotateIconStyle(this.props.data.tableData.isTreeExpanded)
+                ),
+                onClick: function onClick(event) {
+                  _this5.props.onTreeExpandChanged(
+                    _this5.props.path,
+                    _this5.props.data
+                  );
+
+                  event.stopPropagation();
+                },
+              },
+              /*#__PURE__*/ React.createElement(
+                this.props.icons.DetailPanel,
+                null
+              )
+            )
+          );
+        } else {
+          return /*#__PURE__*/ React.createElement(_TableCell.default, {
+            padding: "none",
+            key: "key-tree-data-column",
+          });
+        }
+      },
+    },
+    {
+      key: "getStyle",
+      value: function getStyle(index, level) {
+        var style = {
+          transition: "all ease 300ms",
+        };
+
+        if (typeof this.props.options.rowStyle === "function") {
+          style = (0, _objectSpread2.default)(
+            {},
+            style,
+            this.props.options.rowStyle(
+              this.props.data,
+              index,
+              level,
+              this.props.hasAnyEditingRow
+            )
+          );
+        } else if (this.props.options.rowStyle) {
+          style = (0, _objectSpread2.default)(
+            {},
+            style,
+            this.props.options.rowStyle
+          );
+        }
+
+        if (this.props.onRowClick) {
+          style.cursor = "pointer";
+        }
+
+        if (this.props.hasAnyEditingRow) {
+          style.opacity = style.opacity ? style.opacity : 0.2;
+        }
+
+        return style;
+      },
+    },
+    {
+      key: "render",
+      value: function render() {
+        var _this6 = this;
+
+        var size = CommonValues.elementSize(this.props);
+        var renderColumns = this.renderColumns();
+
+        if (this.props.options.selection) {
+          renderColumns.splice(0, 0, this.renderSelectionColumn());
+        }
+
+        if (
+          this.props.actions &&
+          this.props.actions.filter(function (a) {
+            return a.position === "row" || typeof a === "function";
+          }).length > 0
+        ) {
+          if (this.props.options.actionsColumnIndex === -1) {
+            renderColumns.push(this.renderActions());
+          } else if (this.props.options.actionsColumnIndex >= 0) {
+            var endPos = 0;
+
+            if (this.props.options.selection) {
+              endPos = 1;
+            }
+
+            renderColumns.splice(
+              this.props.options.actionsColumnIndex + endPos,
+              0,
+              this.renderActions()
+            );
+          }
+        } // Then we add detail panel icon
+
+        if (this.props.detailPanel) {
+          if (this.props.options.detailPanelColumnAlignment === "right") {
+            renderColumns.push(this.renderDetailPanelColumn());
+          } else {
+            renderColumns.splice(0, 0, this.renderDetailPanelColumn());
+          }
+        } // Lastly we add tree data icon
+
+        if (this.props.isTreeData) {
+          renderColumns.splice(0, 0, this.renderTreeDataColumn());
+        }
+
+        this.props.columns
+          .filter(function (columnDef) {
+            return columnDef.tableData.groupOrder > -1;
+          })
+          .forEach(function (columnDef) {
+            renderColumns.splice(
+              0,
+              0,
+              /*#__PURE__*/ React.createElement(_TableCell.default, {
+                size: size,
+                padding: "none",
+                key: "key-group-cell" + columnDef.tableData.id,
+              })
+            );
+          });
+        var _this$props = this.props,
+          icons = _this$props.icons,
+          data = _this$props.data,
+          columns = _this$props.columns,
+          components = _this$props.components,
+          detailPanel = _this$props.detailPanel,
+          getFieldValue = _this$props.getFieldValue,
+          isTreeData = _this$props.isTreeData,
+          onRowClick = _this$props.onRowClick,
+          onRowSelected = _this$props.onRowSelected,
+          onTreeExpandChanged = _this$props.onTreeExpandChanged,
+          onToggleDetailPanel = _this$props.onToggleDetailPanel,
+          onEditingCanceled = _this$props.onEditingCanceled,
+          onEditingApproved = _this$props.onEditingApproved,
+          options = _this$props.options,
+          hasAnyEditingRow = _this$props.hasAnyEditingRow,
+          treeDataMaxLevel = _this$props.treeDataMaxLevel,
+          localization = _this$props.localization,
+          actions = _this$props.actions,
+          errorState = _this$props.errorState,
+          cellEditable = _this$props.cellEditable,
+          onCellEditStarted = _this$props.onCellEditStarted,
+          onCellEditFinished = _this$props.onCellEditFinished,
+          scrollWidth = _this$props.scrollWidth,
+          rowProps = (0, _objectWithoutProperties2.default)(_this$props, [
+            "icons",
+            "data",
+            "columns",
+            "components",
+            "detailPanel",
+            "getFieldValue",
+            "isTreeData",
+            "onRowClick",
+            "onRowSelected",
+            "onTreeExpandChanged",
+            "onToggleDetailPanel",
+            "onEditingCanceled",
+            "onEditingApproved",
+            "options",
+            "hasAnyEditingRow",
+            "treeDataMaxLevel",
+            "localization",
+            "actions",
+            "errorState",
+            "cellEditable",
+            "onCellEditStarted",
+            "onCellEditFinished",
+            "scrollWidth",
+          ]);
+        return /*#__PURE__*/ React.createElement(
+          React.Fragment,
+          null,
+          /*#__PURE__*/ React.createElement(
+            _TableRow.default,
+            (0, _extends2.default)(
+              {
+                selected: hasAnyEditingRow,
+              },
+              rowProps,
+              {
+                hover: onRowClick ? true : false,
+                style: this.getStyle(this.props.index, this.props.level),
+                onClick: function onClick(event) {
+                  onRowClick &&
+                    onRowClick(event, _this6.props.data, function (panelIndex) {
+                      var panel = detailPanel;
+
+                      if (Array.isArray(panel)) {
+                        panel = panel[panelIndex || 0];
+
+                        if (typeof panel === "function") {
+                          panel = panel(_this6.props.data);
+                        }
+
+                        panel = panel.render;
+                      }
+
+                      onToggleDetailPanel(_this6.props.path, panel);
+                    });
+                },
+              }
+            ),
+            renderColumns
+          ),
+          this.props.data.tableData &&
+            this.props.data.tableData.showDetailPanel &&
+            /*#__PURE__*/ React.createElement(
+              _TableRow.default, // selected={this.props.index % 2 === 0}
+              null,
+              /*#__PURE__*/ React.createElement(
+                _TableCell.default,
+                {
+                  size: size,
+                  colSpan: renderColumns.length,
+                  padding: "none",
+                },
+                this.props.data.tableData.showDetailPanel(this.props.data)
+              )
+            ),
+          this.props.data.tableData.childRows &&
+            this.props.data.tableData.isTreeExpanded &&
+            this.props.data.tableData.childRows.map(function (data, index) {
+              if (data.tableData.editing) {
+                return /*#__PURE__*/ React.createElement(
+                  _this6.props.components.EditRow,
+                  {
+                    columns: _this6.props.columns.filter(function (columnDef) {
+                      return !columnDef.hidden;
+                    }),
+                    components: _this6.props.components,
+                    data: data,
+                    icons: _this6.props.icons,
+                    localization: _this6.props.localization,
+                    getFieldValue: _this6.props.getFieldValue,
+                    key: index,
+                    mode: data.tableData.editing,
+                    options: _this6.props.options,
+                    isTreeData: _this6.props.isTreeData,
+                    detailPanel: _this6.props.detailPanel,
+                    onEditingCanceled: onEditingCanceled,
+                    onEditingApproved: onEditingApproved,
+                    errorState: _this6.props.errorState,
+                  }
+                );
+              } else {
+                return /*#__PURE__*/ React.createElement(
+                  _this6.props.components.Row,
+                  (0, _extends2.default)({}, _this6.props, {
+                    data: data,
+                    index: index,
+                    key: index,
+                    level: _this6.props.level + 1,
+                    path: [].concat(
+                      (0, _toConsumableArray2.default)(_this6.props.path),
+                      [index]
+                    ),
+                    onEditingCanceled: onEditingCanceled,
+                    onEditingApproved: onEditingApproved,
+                    hasAnyEditingRow: _this6.props.hasAnyEditingRow,
+                    treeDataMaxLevel: treeDataMaxLevel,
+                    errorState: _this6.props.errorState,
+                    cellEditable: cellEditable,
+                    onCellEditStarted: onCellEditStarted,
+                    onCellEditFinished: onCellEditFinished,
+                  })
+                );
+              }
+            })
+        );
+      },
+    },
+  ]);
+  return MTableBodyRow;
+})(React.Component);
+
+exports.default = MTableBodyRow;
+MTableBodyRow.defaultProps = {
+  actions: [],
+  index: 0,
+  data: {},
+  options: {},
+  path: [],
+};
+MTableBodyRow.propTypes = {
+  actions: _propTypes.default.array,
+  icons: _propTypes.default.any.isRequired,
+  index: _propTypes.default.number.isRequired,
+  data: _propTypes.default.object.isRequired,
+  detailPanel: _propTypes.default.oneOfType([
+    _propTypes.default.func,
+    _propTypes.default.arrayOf(
+      _propTypes.default.oneOfType([
+        _propTypes.default.object,
+        _propTypes.default.func,
+      ])
+    ),
+  ]),
+  hasAnyEditingRow: _propTypes.default.bool,
+  options: _propTypes.default.object.isRequired,
+  onRowSelected: _propTypes.default.func,
+  path: _propTypes.default.arrayOf(_propTypes.default.number),
+  treeDataMaxLevel: _propTypes.default.number,
+  getFieldValue: _propTypes.default.func.isRequired,
+  columns: _propTypes.default.array,
+  onToggleDetailPanel: _propTypes.default.func.isRequired,
+  onRowClick: _propTypes.default.func,
+  onEditingApproved: _propTypes.default.func,
+  onEditingCanceled: _propTypes.default.func,
+  errorState: _propTypes.default.oneOfType([
+    _propTypes.default.object,
+    _propTypes.default.bool,
+  ]),
+};

--- a/dist/components/m-table-body.js
+++ b/dist/components/m-table-body.js
@@ -1,0 +1,497 @@
+"use strict";
+
+var _interopRequireWildcard = require("@babel/runtime/helpers/interopRequireWildcard");
+
+var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
+
+Object.defineProperty(exports, "__esModule", {
+  value: true,
+});
+exports.default = void 0;
+
+var _toConsumableArray2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/toConsumableArray")
+);
+
+var _objectSpread2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/objectSpread")
+);
+
+var _classCallCheck2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/classCallCheck")
+);
+
+var _createClass2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/createClass")
+);
+
+var _inherits2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/inherits")
+);
+
+var _possibleConstructorReturn2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/possibleConstructorReturn")
+);
+
+var _getPrototypeOf2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/getPrototypeOf")
+);
+
+var _TableBody = _interopRequireDefault(require("@material-ui/core/TableBody"));
+
+var _TableCell = _interopRequireDefault(require("@material-ui/core/TableCell"));
+
+var _TableRow = _interopRequireDefault(require("@material-ui/core/TableRow"));
+
+var _propTypes = _interopRequireDefault(require("prop-types"));
+
+var React = _interopRequireWildcard(require("react"));
+
+function _createSuper(Derived) {
+  var hasNativeReflectConstruct = _isNativeReflectConstruct();
+  return function _createSuperInternal() {
+    var Super = (0, _getPrototypeOf2.default)(Derived),
+      result;
+    if (hasNativeReflectConstruct) {
+      var NewTarget = (0, _getPrototypeOf2.default)(this).constructor;
+      result = Reflect.construct(Super, arguments, NewTarget);
+    } else {
+      result = Super.apply(this, arguments);
+    }
+    return (0, _possibleConstructorReturn2.default)(this, result);
+  };
+}
+
+function _isNativeReflectConstruct() {
+  if (typeof Reflect === "undefined" || !Reflect.construct) return false;
+  if (Reflect.construct.sham) return false;
+  if (typeof Proxy === "function") return true;
+  try {
+    Date.prototype.toString.call(Reflect.construct(Date, [], function () {}));
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
+/* eslint-enable no-unused-vars */
+var MTableBody = /*#__PURE__*/ (function (_React$Component) {
+  (0, _inherits2.default)(MTableBody, _React$Component);
+
+  var _super = _createSuper(MTableBody);
+
+  function MTableBody() {
+    (0, _classCallCheck2.default)(this, MTableBody);
+    return _super.apply(this, arguments);
+  }
+
+  (0, _createClass2.default)(MTableBody, [
+    {
+      key: "renderEmpty",
+      value: function renderEmpty(emptyRowCount, renderData) {
+        var rowHeight = this.props.options.padding === "default" ? 49 : 36;
+        var localization = (0, _objectSpread2.default)(
+          {},
+          MTableBody.defaultProps.localization,
+          this.props.localization
+        );
+
+        if (
+          this.props.options.showEmptyDataSourceMessage &&
+          renderData.length === 0
+        ) {
+          var addColumn = 0;
+
+          if (this.props.options.selection) {
+            addColumn++;
+          }
+
+          if (
+            this.props.actions &&
+            this.props.actions.filter(function (a) {
+              return a.position === "row" || typeof a === "function";
+            }).length > 0
+          ) {
+            addColumn++;
+          }
+
+          if (this.props.hasDetailPanel) {
+            addColumn++;
+          }
+
+          if (this.props.isTreeData) {
+            addColumn++;
+          }
+
+          return /*#__PURE__*/ React.createElement(
+            _TableRow.default,
+            {
+              style: {
+                height:
+                  rowHeight *
+                  (this.props.options.paging &&
+                  this.props.options.emptyRowsWhenPaging
+                    ? this.props.pageSize
+                    : 1),
+              },
+              key: "empty-" + 0,
+            },
+            /*#__PURE__*/ React.createElement(
+              _TableCell.default,
+              {
+                style: {
+                  paddingTop: 0,
+                  paddingBottom: 0,
+                  textAlign: "center",
+                },
+                colSpan: this.props.columns.reduce(function (
+                  currentVal,
+                  columnDef
+                ) {
+                  return columnDef.hidden ? currentVal : currentVal + 1;
+                },
+                addColumn),
+                key: "empty-",
+              },
+              localization.emptyDataSourceMessage
+            )
+          );
+        } else if (this.props.options.emptyRowsWhenPaging) {
+          return /*#__PURE__*/ React.createElement(
+            React.Fragment,
+            null,
+            (0, _toConsumableArray2.default)(Array(emptyRowCount)).map(
+              function (r, index) {
+                return /*#__PURE__*/ React.createElement(_TableRow.default, {
+                  style: {
+                    height: rowHeight,
+                  },
+                  key: "empty-" + index,
+                });
+              }
+            ),
+            emptyRowCount > 0 &&
+              /*#__PURE__*/ React.createElement(_TableRow.default, {
+                style: {
+                  height: 1,
+                },
+                key: "empty-last1",
+              })
+          );
+        }
+      },
+    },
+    {
+      key: "renderUngroupedRows",
+      value: function renderUngroupedRows(renderData) {
+        var _this = this;
+
+        return renderData.map(function (data, index) {
+          if (data.tableData.editing || _this.props.bulkEditOpen) {
+            return /*#__PURE__*/ React.createElement(
+              _this.props.components.EditRow,
+              {
+                columns: _this.props.columns.filter(function (columnDef) {
+                  return !columnDef.hidden;
+                }),
+                components: _this.props.components,
+                data: data,
+                errorState: _this.props.errorState,
+                icons: _this.props.icons,
+                localization: (0, _objectSpread2.default)(
+                  {},
+                  MTableBody.defaultProps.localization.editRow,
+                  _this.props.localization.editRow,
+                  {
+                    dateTimePickerLocalization:
+                      _this.props.localization.dateTimePickerLocalization,
+                  }
+                ),
+                key: "row-" + data.tableData.id,
+                mode: _this.props.bulkEditOpen
+                  ? "bulk"
+                  : data.tableData.editing,
+                options: _this.props.options,
+                isTreeData: _this.props.isTreeData,
+                detailPanel: _this.props.detailPanel,
+                onEditingCanceled: _this.props.onEditingCanceled,
+                onEditingApproved: _this.props.onEditingApproved,
+                getFieldValue: _this.props.getFieldValue,
+                onBulkEditRowChanged: _this.props.onBulkEditRowChanged,
+                scrollWidth: _this.props.scrollWidth,
+              }
+            );
+          } else {
+            return /*#__PURE__*/ React.createElement(
+              _this.props.components.Row,
+              {
+                components: _this.props.components,
+                icons: _this.props.icons,
+                data: data,
+                index: index,
+                errorState: _this.props.errorState,
+                key: "row-" + data.tableData.id,
+                level: 0,
+                options: _this.props.options,
+                localization: (0, _objectSpread2.default)(
+                  {},
+                  MTableBody.defaultProps.localization.editRow,
+                  _this.props.localization.editRow,
+                  {
+                    dateTimePickerLocalization:
+                      _this.props.localization.dateTimePickerLocalization,
+                  }
+                ),
+                onRowSelected: _this.props.onRowSelected,
+                actions: _this.props.actions,
+                columns: _this.props.columns,
+                getFieldValue: _this.props.getFieldValue,
+                detailPanel: _this.props.detailPanel,
+                path: [index + _this.props.pageSize * _this.props.currentPage],
+                onToggleDetailPanel: _this.props.onToggleDetailPanel,
+                onRowClick: _this.props.onRowClick,
+                isTreeData: _this.props.isTreeData,
+                onTreeExpandChanged: _this.props.onTreeExpandChanged,
+                onEditingCanceled: _this.props.onEditingCanceled,
+                onEditingApproved: _this.props.onEditingApproved,
+                hasAnyEditingRow: _this.props.hasAnyEditingRow,
+                treeDataMaxLevel: _this.props.treeDataMaxLevel,
+                cellEditable: _this.props.cellEditable,
+                onCellEditStarted: _this.props.onCellEditStarted,
+                onCellEditFinished: _this.props.onCellEditFinished,
+                scrollWidth: _this.props.scrollWidth,
+              }
+            );
+          }
+        });
+      },
+    },
+    {
+      key: "renderGroupedRows",
+      value: function renderGroupedRows(groups, renderData) {
+        var _this2 = this;
+
+        return renderData.map(function (groupData, index) {
+          return /*#__PURE__*/ React.createElement(
+            _this2.props.components.GroupRow,
+            {
+              actions: _this2.props.actions,
+              key: groupData.value == null ? "" + index : groupData.value,
+              columns: _this2.props.columns,
+              components: _this2.props.components,
+              detailPanel: _this2.props.detailPanel,
+              getFieldValue: _this2.props.getFieldValue,
+              groupData: groupData,
+              groups: groups,
+              icons: _this2.props.icons,
+              level: 0,
+              path: [index + _this2.props.pageSize * _this2.props.currentPage],
+              onGroupExpandChanged: _this2.props.onGroupExpandChanged,
+              onRowSelected: _this2.props.onRowSelected,
+              onRowClick: _this2.props.onRowClick,
+              onEditingCanceled: _this2.props.onEditingCanceled,
+              onEditingApproved: _this2.props.onEditingApproved,
+              onToggleDetailPanel: _this2.props.onToggleDetailPanel,
+              onTreeExpandChanged: _this2.props.onTreeExpandChanged,
+              options: _this2.props.options,
+              isTreeData: _this2.props.isTreeData,
+              hasAnyEditingRow: _this2.props.hasAnyEditingRow,
+              localization: (0, _objectSpread2.default)(
+                {},
+                MTableBody.defaultProps.localization.editRow,
+                _this2.props.localization.editRow,
+                {
+                  dateTimePickerLocalization:
+                    _this2.props.localization.dateTimePickerLocalization,
+                }
+              ),
+              cellEditable: _this2.props.cellEditable,
+              onCellEditStarted: _this2.props.onCellEditStarted,
+              onCellEditFinished: _this2.props.onCellEditFinished,
+              onBulkEditRowChanged: _this2.props.onBulkEditRowChanged,
+              scrollWidth: _this2.props.scrollWidth,
+            }
+          );
+        });
+      },
+    },
+    {
+      key: "render",
+      value: function render() {
+        var renderData = this.props.renderData;
+        var groups = this.props.columns
+          .filter(function (col) {
+            return col.tableData.groupOrder > -1;
+          })
+          .sort(function (col1, col2) {
+            return col1.tableData.groupOrder - col2.tableData.groupOrder;
+          });
+        var emptyRowCount = 0;
+
+        if (this.props.options.paging) {
+          emptyRowCount = this.props.pageSize - renderData.length;
+        }
+
+        return /*#__PURE__*/ React.createElement(
+          _TableBody.default,
+          null,
+          this.props.options.filtering &&
+            /*#__PURE__*/ React.createElement(this.props.components.FilterRow, {
+              columns: this.props.columns.filter(function (columnDef) {
+                return !columnDef.hidden;
+              }),
+              icons: this.props.icons,
+              hasActions:
+                this.props.actions.filter(function (a) {
+                  return a.position === "row" || typeof a === "function";
+                }).length > 0,
+              actionsColumnIndex: this.props.options.actionsColumnIndex,
+              onFilterChanged: this.props.onFilterChanged,
+              selection: this.props.options.selection,
+              localization: (0, _objectSpread2.default)(
+                {},
+                MTableBody.defaultProps.localization.filterRow,
+                this.props.localization.filterRow,
+                {
+                  dateTimePickerLocalization: this.props.localization
+                    .dateTimePickerLocalization,
+                }
+              ),
+              hasDetailPanel: !!this.props.detailPanel,
+              detailPanelColumnAlignment: this.props.options
+                .detailPanelColumnAlignment,
+              isTreeData: this.props.isTreeData,
+              filterCellStyle: this.props.options.filterCellStyle,
+              filterRowStyle: this.props.options.filterRowStyle,
+              hideFilterIcons: this.props.options.hideFilterIcons,
+              scrollWidth: this.props.scrollWidth,
+            }),
+          this.props.showAddRow &&
+            this.props.options.addRowPosition === "first" &&
+            /*#__PURE__*/ React.createElement(this.props.components.EditRow, {
+              columns: this.props.columns.filter(function (columnDef) {
+                return !columnDef.hidden;
+              }),
+              data: this.props.initialFormData,
+              components: this.props.components,
+              errorState: this.props.errorState,
+              icons: this.props.icons,
+              key: "key-add-row",
+              mode: "add",
+              localization: (0, _objectSpread2.default)(
+                {},
+                MTableBody.defaultProps.localization.editRow,
+                this.props.localization.editRow,
+                {
+                  dateTimePickerLocalization: this.props.localization
+                    .dateTimePickerLocalization,
+                }
+              ),
+              options: this.props.options,
+              isTreeData: this.props.isTreeData,
+              detailPanel: this.props.detailPanel,
+              onEditingCanceled: this.props.onEditingCanceled,
+              onEditingApproved: this.props.onEditingApproved,
+              getFieldValue: this.props.getFieldValue,
+              scrollWidth: this.props.scrollWidth,
+            }),
+          groups.length > 0
+            ? this.renderGroupedRows(groups, renderData)
+            : this.renderUngroupedRows(renderData),
+          this.props.showAddRow &&
+            this.props.options.addRowPosition === "last" &&
+            /*#__PURE__*/ React.createElement(this.props.components.EditRow, {
+              columns: this.props.columns.filter(function (columnDef) {
+                return !columnDef.hidden;
+              }),
+              data: this.props.initialFormData,
+              components: this.props.components,
+              errorState: this.props.errorState,
+              icons: this.props.icons,
+              key: "key-add-row",
+              mode: "add",
+              localization: (0, _objectSpread2.default)(
+                {},
+                MTableBody.defaultProps.localization.editRow,
+                this.props.localization.editRow,
+                {
+                  dateTimePickerLocalization: this.props.localization
+                    .dateTimePickerLocalization,
+                }
+              ),
+              options: this.props.options,
+              isTreeData: this.props.isTreeData,
+              detailPanel: this.props.detailPanel,
+              onEditingCanceled: this.props.onEditingCanceled,
+              onEditingApproved: this.props.onEditingApproved,
+              getFieldValue: this.props.getFieldValue,
+              scrollWidth: this.props.scrollWidth,
+            }),
+          this.renderEmpty(emptyRowCount, renderData)
+        );
+      },
+    },
+  ]);
+  return MTableBody;
+})(React.Component);
+
+MTableBody.defaultProps = {
+  actions: [],
+  currentPage: 0,
+  pageSize: 5,
+  renderData: [],
+  selection: false,
+  localization: {
+    emptyDataSourceMessage: "No records to display",
+    filterRow: {},
+    editRow: {},
+  },
+};
+MTableBody.propTypes = {
+  actions: _propTypes.default.array,
+  components: _propTypes.default.object.isRequired,
+  columns: _propTypes.default.array.isRequired,
+  currentPage: _propTypes.default.number,
+  detailPanel: _propTypes.default.oneOfType([
+    _propTypes.default.func,
+    _propTypes.default.arrayOf(
+      _propTypes.default.oneOfType([
+        _propTypes.default.object,
+        _propTypes.default.func,
+      ])
+    ),
+  ]),
+  getFieldValue: _propTypes.default.func.isRequired,
+  hasAnyEditingRow: _propTypes.default.bool,
+  hasDetailPanel: _propTypes.default.bool.isRequired,
+  icons: _propTypes.default.object.isRequired,
+  isTreeData: _propTypes.default.bool.isRequired,
+  onRowSelected: _propTypes.default.func,
+  options: _propTypes.default.object.isRequired,
+  pageSize: _propTypes.default.number,
+  renderData: _propTypes.default.array,
+  initialFormData: _propTypes.default.object,
+  selection: _propTypes.default.bool.isRequired,
+  scrollWidth: _propTypes.default.number.isRequired,
+  showAddRow: _propTypes.default.bool,
+  treeDataMaxLevel: _propTypes.default.number,
+  localization: _propTypes.default.object,
+  onFilterChanged: _propTypes.default.func,
+  onGroupExpandChanged: _propTypes.default.func,
+  onToggleDetailPanel: _propTypes.default.func.isRequired,
+  onTreeExpandChanged: _propTypes.default.func.isRequired,
+  onRowClick: _propTypes.default.func,
+  onEditingCanceled: _propTypes.default.func,
+  onEditingApproved: _propTypes.default.func,
+  errorState: _propTypes.default.oneOfType([
+    _propTypes.default.object,
+    _propTypes.default.bool,
+  ]),
+  cellEditable: _propTypes.default.object,
+  onCellEditStarted: _propTypes.default.func,
+  onCellEditFinished: _propTypes.default.func,
+  bulkEditOpen: _propTypes.default.bool,
+  onBulkEditRowChanged: _propTypes.default.func,
+};
+var _default = MTableBody;
+exports.default = _default;

--- a/dist/components/m-table-cell.js
+++ b/dist/components/m-table-cell.js
@@ -1,0 +1,379 @@
+"use strict";
+
+var _interopRequireWildcard = require("@babel/runtime/helpers/interopRequireWildcard");
+
+var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
+
+Object.defineProperty(exports, "__esModule", {
+  value: true,
+});
+exports.default = void 0;
+
+var _extends2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/extends")
+);
+
+var _objectWithoutProperties2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/objectWithoutProperties")
+);
+
+var _objectSpread2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/objectSpread")
+);
+
+var _classCallCheck2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/classCallCheck")
+);
+
+var _createClass2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/createClass")
+);
+
+var _assertThisInitialized2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/assertThisInitialized")
+);
+
+var _inherits2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/inherits")
+);
+
+var _possibleConstructorReturn2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/possibleConstructorReturn")
+);
+
+var _getPrototypeOf2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/getPrototypeOf")
+);
+
+var _defineProperty2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/defineProperty")
+);
+
+var React = _interopRequireWildcard(require("react"));
+
+var _TableCell = _interopRequireDefault(require("@material-ui/core/TableCell"));
+
+var _propTypes = _interopRequireDefault(require("prop-types"));
+
+var _parseISO = _interopRequireDefault(require("date-fns/parseISO"));
+
+var CommonValues = _interopRequireWildcard(require("../utils/common-values"));
+
+function _createSuper(Derived) {
+  var hasNativeReflectConstruct = _isNativeReflectConstruct();
+  return function _createSuperInternal() {
+    var Super = (0, _getPrototypeOf2.default)(Derived),
+      result;
+    if (hasNativeReflectConstruct) {
+      var NewTarget = (0, _getPrototypeOf2.default)(this).constructor;
+      result = Reflect.construct(Super, arguments, NewTarget);
+    } else {
+      result = Super.apply(this, arguments);
+    }
+    return (0, _possibleConstructorReturn2.default)(this, result);
+  };
+}
+
+function _isNativeReflectConstruct() {
+  if (typeof Reflect === "undefined" || !Reflect.construct) return false;
+  if (Reflect.construct.sham) return false;
+  if (typeof Proxy === "function") return true;
+  try {
+    Date.prototype.toString.call(Reflect.construct(Date, [], function () {}));
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
+/* eslint-enable no-unused-vars */
+
+/* eslint-disable no-useless-escape */
+var isoDateRegex = /^\d{4}-(0[1-9]|1[0-2])-([12]\d|0[1-9]|3[01])([T\s](([01]\d|2[0-3])\:[0-5]\d|24\:00)(\:[0-5]\d([\.,]\d+)?)?([zZ]|([\+-])([01]\d|2[0-3])\:?([0-5]\d)?)?)?$/;
+/* eslint-enable no-useless-escape */
+
+var MTableCell = /*#__PURE__*/ (function (_React$Component) {
+  (0, _inherits2.default)(MTableCell, _React$Component);
+
+  var _super = _createSuper(MTableCell);
+
+  function MTableCell() {
+    var _this;
+
+    (0, _classCallCheck2.default)(this, MTableCell);
+
+    for (
+      var _len = arguments.length, args = new Array(_len), _key = 0;
+      _key < _len;
+      _key++
+    ) {
+      args[_key] = arguments[_key];
+    }
+
+    _this = _super.call.apply(_super, [this].concat(args));
+    (0, _defineProperty2.default)(
+      (0, _assertThisInitialized2.default)(_this),
+      "handleClickCell",
+      function (e) {
+        if (_this.props.columnDef.disableClick) {
+          e.stopPropagation();
+        }
+      }
+    );
+    (0, _defineProperty2.default)(
+      (0, _assertThisInitialized2.default)(_this),
+      "getStyle",
+      function () {
+        var width = CommonValues.reducePercentsInCalc(
+          _this.props.columnDef.tableData.width,
+          _this.props.scrollWidth
+        );
+        var cellStyle = {
+          color: "inherit",
+          width: width,
+          maxWidth: _this.props.columnDef.maxWidth,
+          minWidth: _this.props.columnDef.minWidth,
+          boxSizing: "border-box",
+          fontSize: "inherit",
+          fontFamily: "inherit",
+          fontWeight: "inherit",
+        };
+
+        if (typeof _this.props.columnDef.cellStyle === "function") {
+          cellStyle = (0, _objectSpread2.default)(
+            {},
+            cellStyle,
+            _this.props.columnDef.cellStyle(
+              _this.props.value,
+              _this.props.rowData
+            )
+          );
+        } else {
+          cellStyle = (0, _objectSpread2.default)(
+            {},
+            cellStyle,
+            _this.props.columnDef.cellStyle
+          );
+        }
+
+        if (_this.props.columnDef.disableClick) {
+          cellStyle.cursor = "default";
+        }
+
+        return (0, _objectSpread2.default)({}, _this.props.style, cellStyle);
+      }
+    );
+    return _this;
+  }
+
+  (0, _createClass2.default)(MTableCell, [
+    {
+      key: "getRenderValue",
+      value: function getRenderValue() {
+        var dateLocale =
+          this.props.columnDef.dateSetting &&
+          this.props.columnDef.dateSetting.locale
+            ? this.props.columnDef.dateSetting.locale
+            : undefined;
+
+        if (
+          this.props.columnDef.emptyValue !== undefined &&
+          (this.props.value === undefined || this.props.value === null)
+        ) {
+          return this.getEmptyValue(this.props.columnDef.emptyValue);
+        }
+
+        if (this.props.columnDef.render) {
+          if (this.props.rowData) {
+            return this.props.columnDef.render(this.props.rowData, "row");
+          } else if (this.props.value) {
+            return this.props.columnDef.render(this.props.value, "group");
+          }
+        } else if (this.props.columnDef.type === "boolean") {
+          var style = {
+            textAlign: "left",
+            verticalAlign: "middle",
+            width: 48,
+          };
+
+          if (this.props.value) {
+            return /*#__PURE__*/ React.createElement(this.props.icons.Check, {
+              style: style,
+            });
+          } else {
+            return /*#__PURE__*/ React.createElement(
+              this.props.icons.ThirdStateCheck,
+              {
+                style: style,
+              }
+            );
+          }
+        } else if (this.props.columnDef.type === "date") {
+          if (this.props.value instanceof Date) {
+            return this.props.value.toLocaleDateString(dateLocale);
+          } else if (isoDateRegex.exec(this.props.value)) {
+            return (0, _parseISO.default)(this.props.value).toLocaleDateString(
+              dateLocale
+            );
+          } else {
+            return this.props.value;
+          }
+        } else if (this.props.columnDef.type === "time") {
+          if (this.props.value instanceof Date) {
+            return this.props.value.toLocaleTimeString();
+          } else if (isoDateRegex.exec(this.props.value)) {
+            return (0, _parseISO.default)(this.props.value).toLocaleTimeString(
+              dateLocale
+            );
+          } else {
+            return this.props.value;
+          }
+        } else if (this.props.columnDef.type === "datetime") {
+          if (this.props.value instanceof Date) {
+            return this.props.value.toLocaleString();
+          } else if (isoDateRegex.exec(this.props.value)) {
+            return (0, _parseISO.default)(this.props.value).toLocaleString(
+              dateLocale
+            );
+          } else {
+            return this.props.value;
+          }
+        } else if (this.props.columnDef.type === "currency") {
+          return this.getCurrencyValue(
+            this.props.columnDef.currencySetting,
+            this.props.value
+          );
+        } else if (typeof this.props.value === "boolean") {
+          // To avoid forwardref boolean children.
+          return this.props.value.toString();
+        }
+
+        return this.props.value;
+      },
+    },
+    {
+      key: "getEmptyValue",
+      value: function getEmptyValue(emptyValue) {
+        if (typeof emptyValue === "function") {
+          return this.props.columnDef.emptyValue(this.props.rowData);
+        } else {
+          return emptyValue;
+        }
+      },
+    },
+    {
+      key: "getCurrencyValue",
+      value: function getCurrencyValue(currencySetting, value) {
+        if (currencySetting !== undefined) {
+          return new Intl.NumberFormat(
+            currencySetting.locale !== undefined
+              ? currencySetting.locale
+              : "en-US",
+            {
+              style: "currency",
+              currency:
+                currencySetting.currencyCode !== undefined
+                  ? currencySetting.currencyCode
+                  : "USD",
+              minimumFractionDigits:
+                currencySetting.minimumFractionDigits !== undefined
+                  ? currencySetting.minimumFractionDigits
+                  : 2,
+              maximumFractionDigits:
+                currencySetting.maximumFractionDigits !== undefined
+                  ? currencySetting.maximumFractionDigits
+                  : 2,
+            }
+          ).format(value !== undefined ? value : 0);
+        } else {
+          return new Intl.NumberFormat("en-US", {
+            style: "currency",
+            currency: "USD",
+          }).format(value !== undefined ? value : 0);
+        }
+      },
+    },
+    {
+      key: "render",
+      value: function render() {
+        var _this2 = this;
+
+        var _this$props = this.props,
+          icons = _this$props.icons,
+          columnDef = _this$props.columnDef,
+          rowData = _this$props.rowData,
+          errorState = _this$props.errorState,
+          cellEditable = _this$props.cellEditable,
+          onCellEditStarted = _this$props.onCellEditStarted,
+          scrollWidth = _this$props.scrollWidth,
+          cellProps = (0, _objectWithoutProperties2.default)(_this$props, [
+            "icons",
+            "columnDef",
+            "rowData",
+            "errorState",
+            "cellEditable",
+            "onCellEditStarted",
+            "scrollWidth",
+          ]);
+        var cellAlignment =
+          columnDef.align !== undefined
+            ? columnDef.align
+            : ["numeric", "currency"].indexOf(this.props.columnDef.type) !== -1
+            ? "right"
+            : "left";
+        var renderValue = this.getRenderValue();
+
+        if (cellEditable) {
+          renderValue = /*#__PURE__*/ React.createElement(
+            "div",
+            {
+              style: {
+                borderBottom: "1px dashed grey",
+                cursor: "pointer",
+                width: "max-content",
+              },
+              onClick: function onClick(e) {
+                e.stopPropagation();
+                onCellEditStarted(_this2.props.rowData, _this2.props.columnDef);
+              },
+            },
+            renderValue
+          );
+        }
+
+        return /*#__PURE__*/ React.createElement(
+          _TableCell.default,
+          (0, _extends2.default)(
+            {
+              size: this.props.size,
+            },
+            cellProps,
+            {
+              style: this.getStyle(),
+              align: cellAlignment,
+              onClick: this.handleClickCell,
+            }
+          ),
+          this.props.children,
+          renderValue
+        );
+      },
+    },
+  ]);
+  return MTableCell;
+})(React.Component);
+
+exports.default = MTableCell;
+MTableCell.defaultProps = {
+  columnDef: {},
+  value: undefined,
+};
+MTableCell.propTypes = {
+  columnDef: _propTypes.default.object.isRequired,
+  value: _propTypes.default.any,
+  rowData: _propTypes.default.object,
+  errorState: _propTypes.default.oneOfType([
+    _propTypes.default.object,
+    _propTypes.default.bool,
+  ]),
+};

--- a/dist/components/m-table-edit-cell.js
+++ b/dist/components/m-table-edit-cell.js
@@ -1,0 +1,333 @@
+"use strict";
+
+var _interopRequireWildcard = require("@babel/runtime/helpers/interopRequireWildcard");
+
+var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
+
+Object.defineProperty(exports, "__esModule", {
+  value: true,
+});
+exports.default = void 0;
+
+var _objectSpread2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/objectSpread")
+);
+
+var _classCallCheck2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/classCallCheck")
+);
+
+var _createClass2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/createClass")
+);
+
+var _assertThisInitialized2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/assertThisInitialized")
+);
+
+var _inherits2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/inherits")
+);
+
+var _possibleConstructorReturn2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/possibleConstructorReturn")
+);
+
+var _getPrototypeOf2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/getPrototypeOf")
+);
+
+var _defineProperty2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/defineProperty")
+);
+
+var React = _interopRequireWildcard(require("react"));
+
+var _propTypes = _interopRequireDefault(require("prop-types"));
+
+var _TableCell = _interopRequireDefault(require("@material-ui/core/TableCell"));
+
+var _CircularProgress = _interopRequireDefault(
+  require("@material-ui/core/CircularProgress")
+);
+
+var _colorManipulator = require("@material-ui/core/styles/colorManipulator");
+
+var _withTheme = _interopRequireDefault(
+  require("@material-ui/core/styles/withTheme")
+);
+
+var _ = require("..");
+
+function _createSuper(Derived) {
+  var hasNativeReflectConstruct = _isNativeReflectConstruct();
+  return function _createSuperInternal() {
+    var Super = (0, _getPrototypeOf2.default)(Derived),
+      result;
+    if (hasNativeReflectConstruct) {
+      var NewTarget = (0, _getPrototypeOf2.default)(this).constructor;
+      result = Reflect.construct(Super, arguments, NewTarget);
+    } else {
+      result = Super.apply(this, arguments);
+    }
+    return (0, _possibleConstructorReturn2.default)(this, result);
+  };
+}
+
+function _isNativeReflectConstruct() {
+  if (typeof Reflect === "undefined" || !Reflect.construct) return false;
+  if (Reflect.construct.sham) return false;
+  if (typeof Proxy === "function") return true;
+  try {
+    Date.prototype.toString.call(Reflect.construct(Date, [], function () {}));
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
+/* eslint-enable no-unused-vars */
+var MTableEditCell = /*#__PURE__*/ (function (_React$Component) {
+  (0, _inherits2.default)(MTableEditCell, _React$Component);
+
+  var _super = _createSuper(MTableEditCell);
+
+  function MTableEditCell(props) {
+    var _this;
+
+    (0, _classCallCheck2.default)(this, MTableEditCell);
+    _this = _super.call(this, props);
+    (0, _defineProperty2.default)(
+      (0, _assertThisInitialized2.default)(_this),
+      "getStyle",
+      function () {
+        var cellStyle = {
+          boxShadow: "2px 0px 15px rgba(125,147,178,.25)",
+          color: "inherit",
+          width: _this.props.columnDef.tableData.width,
+          boxSizing: "border-box",
+          fontSize: "inherit",
+          fontFamily: "inherit",
+          fontWeight: "inherit",
+          padding: "0 16px",
+        };
+
+        if (typeof _this.props.columnDef.cellStyle === "function") {
+          cellStyle = (0, _objectSpread2.default)(
+            {},
+            cellStyle,
+            _this.props.columnDef.cellStyle(
+              _this.state.value,
+              _this.props.rowData
+            )
+          );
+        } else {
+          cellStyle = (0, _objectSpread2.default)(
+            {},
+            cellStyle,
+            _this.props.columnDef.cellStyle
+          );
+        }
+
+        if (typeof _this.props.cellEditable.cellStyle === "function") {
+          cellStyle = (0, _objectSpread2.default)(
+            {},
+            cellStyle,
+            _this.props.cellEditable.cellStyle(
+              _this.state.value,
+              _this.props.rowData,
+              _this.props.columnDef
+            )
+          );
+        } else {
+          cellStyle = (0, _objectSpread2.default)(
+            {},
+            cellStyle,
+            _this.props.cellEditable.cellStyle
+          );
+        }
+
+        return cellStyle;
+      }
+    );
+    (0, _defineProperty2.default)(
+      (0, _assertThisInitialized2.default)(_this),
+      "handleKeyDown",
+      function (e) {
+        if (e.keyCode === 13) {
+          _this.onApprove();
+        } else if (e.keyCode === 27) {
+          _this.onCancel();
+        }
+      }
+    );
+    (0, _defineProperty2.default)(
+      (0, _assertThisInitialized2.default)(_this),
+      "onApprove",
+      function () {
+        _this.setState(
+          {
+            isLoading: true,
+          },
+          function () {
+            _this.props.cellEditable
+              .onCellEditApproved(
+                _this.state.value, // newValue
+                _this.props.rowData[_this.props.columnDef.field], // oldValue
+                _this.props.rowData, // rowData with old value
+                _this.props.columnDef // columnDef
+              )
+              .then(function () {
+                _this.setState({
+                  isLoading: false,
+                });
+
+                _this.props.onCellEditFinished(
+                  _this.props.rowData,
+                  _this.props.columnDef
+                );
+              })
+              .catch(function (error) {
+                _this.setState({
+                  isLoading: false,
+                });
+              });
+          }
+        );
+      }
+    );
+    (0, _defineProperty2.default)(
+      (0, _assertThisInitialized2.default)(_this),
+      "onCancel",
+      function () {
+        _this.props.onCellEditFinished(
+          _this.props.rowData,
+          _this.props.columnDef
+        );
+      }
+    );
+    _this.state = {
+      isLoading: false,
+      value: _this.props.rowData[_this.props.columnDef.field],
+    };
+    return _this;
+  }
+
+  (0, _createClass2.default)(MTableEditCell, [
+    {
+      key: "renderActions",
+      value: function renderActions() {
+        if (this.state.isLoading) {
+          return /*#__PURE__*/ React.createElement(
+            "div",
+            {
+              style: {
+                display: "flex",
+                justifyContent: "center",
+                width: 60,
+              },
+            },
+            /*#__PURE__*/ React.createElement(_CircularProgress.default, {
+              size: 20,
+            })
+          );
+        }
+
+        var actions = [
+          {
+            icon: this.props.icons.Check,
+            tooltip: this.props.localization.saveTooltip,
+            onClick: this.onApprove,
+            disabled: this.state.isLoading,
+          },
+          {
+            icon: this.props.icons.Clear,
+            tooltip: this.props.localization.cancelTooltip,
+            onClick: this.onCancel,
+            disabled: this.state.isLoading,
+          },
+        ];
+        return /*#__PURE__*/ React.createElement(
+          this.props.components.Actions,
+          {
+            actions: actions,
+            components: this.props.components,
+            size: "small",
+          }
+        );
+      },
+    },
+    {
+      key: "render",
+      value: function render() {
+        var _this2 = this;
+
+        return /*#__PURE__*/ React.createElement(
+          _TableCell.default,
+          {
+            size: this.props.size,
+            style: this.getStyle(),
+            padding: "none",
+          },
+          /*#__PURE__*/ React.createElement(
+            "div",
+            {
+              style: {
+                display: "flex",
+                alignItems: "center",
+              },
+            },
+            /*#__PURE__*/ React.createElement(
+              "div",
+              {
+                style: {
+                  flex: 1,
+                  marginRight: 4,
+                },
+              },
+              /*#__PURE__*/ React.createElement(
+                this.props.components.EditField,
+                {
+                  columnDef: this.props.columnDef,
+                  value: this.state.value,
+                  onChange: function onChange(value) {
+                    return _this2.setState({
+                      value: value,
+                    });
+                  },
+                  onKeyDown: this.handleKeyDown,
+                  disabled: this.state.isLoading,
+                  autoFocus: true,
+                }
+              )
+            ),
+            this.renderActions()
+          )
+        );
+      },
+    },
+  ]);
+  return MTableEditCell;
+})(React.Component);
+
+MTableEditCell.defaultProps = {
+  columnDef: {},
+};
+MTableEditCell.propTypes = {
+  cellEditable: _propTypes.default.object.isRequired,
+  columnDef: _propTypes.default.object.isRequired,
+  components: _propTypes.default.object.isRequired,
+  errorState: _propTypes.default.oneOfType([
+    _propTypes.default.object,
+    _propTypes.default.bool,
+  ]),
+  icons: _propTypes.default.object.isRequired,
+  localization: _propTypes.default.object.isRequired,
+  onCellEditFinished: _propTypes.default.func.isRequired,
+  rowData: _propTypes.default.object.isRequired,
+  size: _propTypes.default.string,
+};
+
+var _default = (0, _withTheme.default)(MTableEditCell);
+
+exports.default = _default;

--- a/dist/components/m-table-edit-field.js
+++ b/dist/components/m-table-edit-field.js
@@ -1,0 +1,448 @@
+"use strict";
+
+var _interopRequireWildcard = require("@babel/runtime/helpers/interopRequireWildcard");
+
+var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
+
+Object.defineProperty(exports, "__esModule", {
+  value: true,
+});
+exports.default = void 0;
+
+var _extends2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/extends")
+);
+
+var _objectWithoutProperties2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/objectWithoutProperties")
+);
+
+var _classCallCheck2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/classCallCheck")
+);
+
+var _createClass2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/createClass")
+);
+
+var _inherits2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/inherits")
+);
+
+var _possibleConstructorReturn2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/possibleConstructorReturn")
+);
+
+var _getPrototypeOf2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/getPrototypeOf")
+);
+
+var React = _interopRequireWildcard(require("react"));
+
+var _TextField = _interopRequireDefault(require("@material-ui/core/TextField"));
+
+var _Checkbox = _interopRequireDefault(require("@material-ui/core/Checkbox"));
+
+var _Select = _interopRequireDefault(require("@material-ui/core/Select"));
+
+var _MenuItem = _interopRequireDefault(require("@material-ui/core/MenuItem"));
+
+var _FormControl = _interopRequireDefault(
+  require("@material-ui/core/FormControl")
+);
+
+var _FormHelperText = _interopRequireDefault(
+  require("@material-ui/core/FormHelperText")
+);
+
+var _FormGroup = _interopRequireDefault(require("@material-ui/core/FormGroup"));
+
+var _FormControlLabel = _interopRequireDefault(
+  require("@material-ui/core/FormControlLabel")
+);
+
+var _dateFns = _interopRequireDefault(require("@date-io/date-fns"));
+
+var _pickers = require("@material-ui/pickers");
+
+var _propTypes = _interopRequireDefault(require("prop-types"));
+
+function _createSuper(Derived) {
+  var hasNativeReflectConstruct = _isNativeReflectConstruct();
+  return function _createSuperInternal() {
+    var Super = (0, _getPrototypeOf2.default)(Derived),
+      result;
+    if (hasNativeReflectConstruct) {
+      var NewTarget = (0, _getPrototypeOf2.default)(this).constructor;
+      result = Reflect.construct(Super, arguments, NewTarget);
+    } else {
+      result = Super.apply(this, arguments);
+    }
+    return (0, _possibleConstructorReturn2.default)(this, result);
+  };
+}
+
+function _isNativeReflectConstruct() {
+  if (typeof Reflect === "undefined" || !Reflect.construct) return false;
+  if (Reflect.construct.sham) return false;
+  if (typeof Proxy === "function") return true;
+  try {
+    Date.prototype.toString.call(Reflect.construct(Date, [], function () {}));
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
+var MTableEditField = /*#__PURE__*/ (function (_React$Component) {
+  (0, _inherits2.default)(MTableEditField, _React$Component);
+
+  var _super = _createSuper(MTableEditField);
+
+  function MTableEditField() {
+    (0, _classCallCheck2.default)(this, MTableEditField);
+    return _super.apply(this, arguments);
+  }
+
+  (0, _createClass2.default)(MTableEditField, [
+    {
+      key: "getProps",
+      value: function getProps() {
+        var _this$props = this.props,
+          columnDef = _this$props.columnDef,
+          rowData = _this$props.rowData,
+          onRowDataChange = _this$props.onRowDataChange,
+          errorState = _this$props.errorState,
+          onBulkEditRowChanged = _this$props.onBulkEditRowChanged,
+          scrollWidth = _this$props.scrollWidth,
+          props = (0, _objectWithoutProperties2.default)(_this$props, [
+            "columnDef",
+            "rowData",
+            "onRowDataChange",
+            "errorState",
+            "onBulkEditRowChanged",
+            "scrollWidth",
+          ]);
+        return props;
+      },
+    },
+    {
+      key: "renderLookupField",
+      value: function renderLookupField() {
+        var _this = this;
+
+        var _this$getProps = this.getProps(),
+          helperText = _this$getProps.helperText,
+          error = _this$getProps.error,
+          props = (0, _objectWithoutProperties2.default)(_this$getProps, [
+            "helperText",
+            "error",
+          ]);
+
+        return /*#__PURE__*/ React.createElement(
+          _FormControl.default,
+          {
+            error: Boolean(error),
+          },
+          /*#__PURE__*/ React.createElement(
+            _Select.default,
+            (0, _extends2.default)({}, props, {
+              value: this.props.value === undefined ? "" : this.props.value,
+              onChange: function onChange(event) {
+                return _this.props.onChange(event.target.value);
+              },
+              style: {
+                fontSize: 13,
+              },
+              SelectDisplayProps: {
+                "aria-label": this.props.columnDef.title,
+              },
+            }),
+            Object.keys(this.props.columnDef.lookup).map(function (key) {
+              return /*#__PURE__*/ React.createElement(
+                _MenuItem.default,
+                {
+                  key: key,
+                  value: key,
+                },
+                _this.props.columnDef.lookup[key]
+              );
+            })
+          ),
+          Boolean(helperText) &&
+            /*#__PURE__*/ React.createElement(
+              _FormHelperText.default,
+              null,
+              helperText
+            )
+        );
+      },
+    },
+    {
+      key: "renderBooleanField",
+      value: function renderBooleanField() {
+        var _this2 = this;
+
+        var _this$getProps2 = this.getProps(),
+          helperText = _this$getProps2.helperText,
+          error = _this$getProps2.error,
+          props = (0, _objectWithoutProperties2.default)(_this$getProps2, [
+            "helperText",
+            "error",
+          ]);
+
+        return /*#__PURE__*/ React.createElement(
+          _FormControl.default,
+          {
+            error: Boolean(error),
+            component: "fieldset",
+          },
+          /*#__PURE__*/ React.createElement(
+            _FormGroup.default,
+            null,
+            /*#__PURE__*/ React.createElement(_FormControlLabel.default, {
+              label: "",
+              control: /*#__PURE__*/ React.createElement(
+                _Checkbox.default,
+                (0, _extends2.default)({}, props, {
+                  value: String(this.props.value),
+                  checked: Boolean(this.props.value),
+                  onChange: function onChange(event) {
+                    return _this2.props.onChange(event.target.checked);
+                  },
+                  style: {
+                    padding: 0,
+                    width: 24,
+                    marginLeft: 9,
+                  },
+                  inputProps: {
+                    "aria-label": this.props.columnDef.title,
+                  },
+                })
+              ),
+            })
+          ),
+          /*#__PURE__*/ React.createElement(
+            _FormHelperText.default,
+            null,
+            helperText
+          )
+        );
+      },
+    },
+    {
+      key: "renderDateField",
+      value: function renderDateField() {
+        var dateFormat =
+          this.props.columnDef.dateSetting &&
+          this.props.columnDef.dateSetting.format
+            ? this.props.columnDef.dateSetting.format
+            : "dd.MM.yyyy";
+        return /*#__PURE__*/ React.createElement(
+          _pickers.MuiPickersUtilsProvider,
+          {
+            utils: _dateFns.default,
+            locale: this.props.locale,
+          },
+          /*#__PURE__*/ React.createElement(
+            _pickers.DatePicker,
+            (0, _extends2.default)({}, this.getProps(), {
+              format: dateFormat,
+              value: this.props.value || null,
+              onChange: this.props.onChange,
+              clearable: true,
+              InputProps: {
+                style: {
+                  fontSize: 13,
+                },
+              },
+              inputProps: {
+                "aria-label": "".concat(
+                  this.props.columnDef.title,
+                  ": press space to edit"
+                ),
+              },
+            })
+          )
+        );
+      },
+    },
+    {
+      key: "renderTimeField",
+      value: function renderTimeField() {
+        return /*#__PURE__*/ React.createElement(
+          _pickers.MuiPickersUtilsProvider,
+          {
+            utils: _dateFns.default,
+            locale: this.props.locale,
+          },
+          /*#__PURE__*/ React.createElement(
+            _pickers.TimePicker,
+            (0, _extends2.default)({}, this.getProps(), {
+              format: "HH:mm:ss",
+              value: this.props.value || null,
+              onChange: this.props.onChange,
+              clearable: true,
+              InputProps: {
+                style: {
+                  fontSize: 13,
+                },
+              },
+              inputProps: {
+                "aria-label": "".concat(
+                  this.props.columnDef.title,
+                  ": press space to edit"
+                ),
+              },
+            })
+          )
+        );
+      },
+    },
+    {
+      key: "renderDateTimeField",
+      value: function renderDateTimeField() {
+        return /*#__PURE__*/ React.createElement(
+          _pickers.MuiPickersUtilsProvider,
+          {
+            utils: _dateFns.default,
+            locale: this.props.locale,
+          },
+          /*#__PURE__*/ React.createElement(
+            _pickers.DateTimePicker,
+            (0, _extends2.default)({}, this.getProps(), {
+              format: "dd.MM.yyyy HH:mm:ss",
+              value: this.props.value || null,
+              onChange: this.props.onChange,
+              clearable: true,
+              InputProps: {
+                style: {
+                  fontSize: 13,
+                },
+              },
+              inputProps: {
+                "aria-label": "".concat(
+                  this.props.columnDef.title,
+                  ": press space to edit"
+                ),
+              },
+            })
+          )
+        );
+      },
+    },
+    {
+      key: "renderTextField",
+      value: function renderTextField() {
+        var _this3 = this;
+
+        return /*#__PURE__*/ React.createElement(
+          _TextField.default,
+          (0, _extends2.default)({}, this.getProps(), {
+            fullWidth: true,
+            style:
+              this.props.columnDef.type === "numeric"
+                ? {
+                    float: "right",
+                  }
+                : {},
+            type: this.props.columnDef.type === "numeric" ? "number" : "text",
+            placeholder:
+              this.props.columnDef.editPlaceholder ||
+              this.props.columnDef.title,
+            value: this.props.value === undefined ? "" : this.props.value,
+            onChange: function onChange(event) {
+              return _this3.props.onChange(
+                _this3.props.columnDef.type === "numeric"
+                  ? event.target.valueAsNumber
+                  : event.target.value
+              );
+            },
+            InputProps: {
+              style: {
+                fontSize: 13,
+              },
+            },
+            inputProps: {
+              "aria-label": this.props.columnDef.title,
+            },
+          })
+        );
+      },
+    },
+    {
+      key: "renderCurrencyField",
+      value: function renderCurrencyField() {
+        var _this4 = this;
+
+        return /*#__PURE__*/ React.createElement(
+          _TextField.default,
+          (0, _extends2.default)({}, this.getProps(), {
+            placeholder:
+              this.props.columnDef.editPlaceholder ||
+              this.props.columnDef.title,
+            style: {
+              float: "right",
+            },
+            type: "number",
+            value: this.props.value === undefined ? "" : this.props.value,
+            onChange: function onChange(event) {
+              var value = event.target.valueAsNumber;
+
+              if (!value && value !== 0) {
+                value = undefined;
+              }
+
+              return _this4.props.onChange(value);
+            },
+            InputProps: {
+              style: {
+                fontSize: 13,
+                textAlign: "right",
+              },
+            },
+            inputProps: {
+              "aria-label": this.props.columnDef.title,
+            },
+            onKeyDown: this.props.onKeyDown,
+            autoFocus: this.props.autoFocus,
+          })
+        );
+      },
+    },
+    {
+      key: "render",
+      value: function render() {
+        var component = "ok";
+
+        if (this.props.columnDef.lookup) {
+          component = this.renderLookupField();
+        } else if (this.props.columnDef.type === "boolean") {
+          component = this.renderBooleanField();
+        } else if (this.props.columnDef.type === "date") {
+          component = this.renderDateField();
+        } else if (this.props.columnDef.type === "time") {
+          component = this.renderTimeField();
+        } else if (this.props.columnDef.type === "datetime") {
+          component = this.renderDateTimeField();
+        } else if (this.props.columnDef.type === "currency") {
+          component = this.renderCurrencyField();
+        } else {
+          component = this.renderTextField();
+        }
+
+        return component;
+      },
+    },
+  ]);
+  return MTableEditField;
+})(React.Component);
+
+MTableEditField.propTypes = {
+  value: _propTypes.default.any,
+  onChange: _propTypes.default.func.isRequired,
+  columnDef: _propTypes.default.object.isRequired,
+  locale: _propTypes.default.object,
+};
+var _default = MTableEditField;
+exports.default = _default;

--- a/dist/components/m-table-edit-row.js
+++ b/dist/components/m-table-edit-row.js
@@ -1,0 +1,672 @@
+"use strict";
+
+var _interopRequireWildcard = require("@babel/runtime/helpers/interopRequireWildcard");
+
+var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
+
+Object.defineProperty(exports, "__esModule", {
+  value: true,
+});
+exports.default = void 0;
+
+var _extends2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/extends")
+);
+
+var _typeof2 = _interopRequireDefault(require("@babel/runtime/helpers/typeof"));
+
+var _objectWithoutProperties2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/objectWithoutProperties")
+);
+
+var _objectSpread2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/objectSpread")
+);
+
+var _classCallCheck2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/classCallCheck")
+);
+
+var _createClass2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/createClass")
+);
+
+var _assertThisInitialized2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/assertThisInitialized")
+);
+
+var _inherits2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/inherits")
+);
+
+var _possibleConstructorReturn2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/possibleConstructorReturn")
+);
+
+var _getPrototypeOf2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/getPrototypeOf")
+);
+
+var _defineProperty2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/defineProperty")
+);
+
+var _TableCell = _interopRequireDefault(require("@material-ui/core/TableCell"));
+
+var _TableRow = _interopRequireDefault(require("@material-ui/core/TableRow"));
+
+var _Typography = _interopRequireDefault(
+  require("@material-ui/core/Typography")
+);
+
+var _propTypes = _interopRequireDefault(require("prop-types"));
+
+var React = _interopRequireWildcard(require("react"));
+
+var _utils = require("../utils");
+
+var CommonValues = _interopRequireWildcard(require("../utils/common-values"));
+
+function _createSuper(Derived) {
+  var hasNativeReflectConstruct = _isNativeReflectConstruct();
+  return function _createSuperInternal() {
+    var Super = (0, _getPrototypeOf2.default)(Derived),
+      result;
+    if (hasNativeReflectConstruct) {
+      var NewTarget = (0, _getPrototypeOf2.default)(this).constructor;
+      result = Reflect.construct(Super, arguments, NewTarget);
+    } else {
+      result = Super.apply(this, arguments);
+    }
+    return (0, _possibleConstructorReturn2.default)(this, result);
+  };
+}
+
+function _isNativeReflectConstruct() {
+  if (typeof Reflect === "undefined" || !Reflect.construct) return false;
+  if (Reflect.construct.sham) return false;
+  if (typeof Proxy === "function") return true;
+  try {
+    Date.prototype.toString.call(Reflect.construct(Date, [], function () {}));
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
+/* eslint-enable no-unused-vars */
+var MTableEditRow = /*#__PURE__*/ (function (_React$Component) {
+  (0, _inherits2.default)(MTableEditRow, _React$Component);
+
+  var _super = _createSuper(MTableEditRow);
+
+  function MTableEditRow(props) {
+    var _this;
+
+    (0, _classCallCheck2.default)(this, MTableEditRow);
+    _this = _super.call(this, props);
+    (0, _defineProperty2.default)(
+      (0, _assertThisInitialized2.default)(_this),
+      "handleSave",
+      function () {
+        var newData = _this.state.data;
+        delete newData.tableData;
+
+        _this.props.onEditingApproved(
+          _this.props.mode,
+          _this.state.data,
+          _this.props.data
+        );
+      }
+    );
+    (0, _defineProperty2.default)(
+      (0, _assertThisInitialized2.default)(_this),
+      "handleKeyDown",
+      function (e) {
+        if (e.keyCode === 13 && e.target.type !== "textarea") {
+          _this.handleSave();
+        } else if (
+          e.keyCode === 13 &&
+          e.target.type === "textarea" &&
+          e.shiftKey
+        ) {
+          _this.handleSave();
+        } else if (e.keyCode === 27) {
+          _this.props.onEditingCanceled(_this.props.mode, _this.props.data);
+        }
+      }
+    );
+    _this.state = {
+      data: props.data
+        ? JSON.parse(JSON.stringify(props.data))
+        : _this.createRowData(),
+    };
+    return _this;
+  }
+
+  (0, _createClass2.default)(MTableEditRow, [
+    {
+      key: "createRowData",
+      value: function createRowData() {
+        return this.props.columns
+          .filter(function (column) {
+            return "initialEditValue" in column && column.field;
+          })
+          .reduce(function (prev, column) {
+            prev[column.field] = column.initialEditValue;
+            return prev;
+          }, {});
+      },
+    },
+    {
+      key: "renderColumns",
+      value: function renderColumns() {
+        var _this2 = this;
+
+        var size = CommonValues.elementSize(this.props);
+        var mapArr = this.props.columns
+          .filter(function (columnDef) {
+            return !columnDef.hidden && !(columnDef.tableData.groupOrder > -1);
+          })
+          .sort(function (a, b) {
+            return a.tableData.columnOrder - b.tableData.columnOrder;
+          })
+          .map(function (columnDef, index) {
+            var value =
+              typeof _this2.state.data[columnDef.field] !== "undefined"
+                ? _this2.state.data[columnDef.field]
+                : (0, _utils.byString)(_this2.state.data, columnDef.field);
+
+            var getCellStyle = function getCellStyle(columnDef, value) {
+              var cellStyle = {
+                color: "inherit",
+              };
+
+              if (typeof columnDef.cellStyle === "function") {
+                cellStyle = (0, _objectSpread2.default)(
+                  {},
+                  cellStyle,
+                  columnDef.cellStyle(value, _this2.props.data)
+                );
+              } else {
+                cellStyle = (0, _objectSpread2.default)(
+                  {},
+                  cellStyle,
+                  columnDef.cellStyle
+                );
+              }
+
+              if (columnDef.disableClick) {
+                cellStyle.cursor = "default";
+              }
+
+              return (0, _objectSpread2.default)({}, cellStyle);
+            };
+
+            var style = {};
+
+            if (index === 0) {
+              style.paddingLeft = 24 + _this2.props.level * 20;
+            }
+
+            var allowEditing = false;
+
+            if (columnDef.editable === undefined) {
+              allowEditing = true;
+            }
+
+            if (columnDef.editable === "always") {
+              allowEditing = true;
+            }
+
+            if (columnDef.editable === "onAdd" && _this2.props.mode === "add") {
+              allowEditing = true;
+            }
+
+            if (
+              columnDef.editable === "onUpdate" &&
+              _this2.props.mode === "update"
+            ) {
+              allowEditing = true;
+            }
+
+            if (typeof columnDef.editable === "function") {
+              allowEditing = columnDef.editable(
+                columnDef,
+                _this2.props.data,
+                _this2.state.data
+              );
+            }
+
+            if (!columnDef.field || !allowEditing) {
+              var readonlyValue = _this2.props.getFieldValue(
+                _this2.state.data,
+                columnDef
+              );
+
+              return /*#__PURE__*/ React.createElement(
+                _this2.props.components.Cell,
+                {
+                  size: size,
+                  icons: _this2.props.icons,
+                  columnDef: columnDef,
+                  value: readonlyValue,
+                  key: columnDef.tableData.id,
+                  rowData: _this2.props.data,
+                  style: getCellStyle(columnDef, value),
+                }
+              );
+            } else {
+              var editComponent = columnDef.editComponent,
+                cellProps = (0, _objectWithoutProperties2.default)(columnDef, [
+                  "editComponent",
+                ]);
+              var EditComponent =
+                editComponent || _this2.props.components.EditField;
+              var error = {
+                isValid: true,
+                helperText: "",
+              };
+
+              if (columnDef.validate) {
+                var validateResponse = columnDef.validate(_this2.state.data);
+
+                switch ((0, _typeof2.default)(validateResponse)) {
+                  case "object":
+                    error = (0, _objectSpread2.default)({}, validateResponse);
+                    break;
+
+                  case "boolean":
+                    error = {
+                      isValid: validateResponse,
+                      helperText: "",
+                    };
+                    break;
+
+                  case "string":
+                    error = {
+                      isValid: false,
+                      helperText: validateResponse,
+                    };
+                    break;
+                }
+              }
+
+              return /*#__PURE__*/ React.createElement(
+                _TableCell.default,
+                {
+                  size: size,
+                  key: columnDef.tableData.id,
+                  align:
+                    ["numeric"].indexOf(columnDef.type) !== -1
+                      ? "right"
+                      : "left",
+                  style: getCellStyle(columnDef, value),
+                },
+                /*#__PURE__*/ React.createElement(EditComponent, {
+                  key: columnDef.tableData.id,
+                  columnDef: cellProps,
+                  value: value,
+                  error: !error.isValid,
+                  helperText: error.helperText,
+                  locale: _this2.props.localization.dateTimePickerLocalization,
+                  rowData: _this2.state.data,
+                  onChange: function onChange(value) {
+                    var data = (0, _objectSpread2.default)(
+                      {},
+                      _this2.state.data
+                    );
+                    (0, _utils.setByString)(data, columnDef.field, value); // data[columnDef.field] = value;
+
+                    _this2.setState(
+                      {
+                        data: data,
+                      },
+                      function () {
+                        if (_this2.props.onBulkEditRowChanged) {
+                          _this2.props.onBulkEditRowChanged(
+                            _this2.props.data,
+                            data
+                          );
+                        }
+                      }
+                    );
+                  },
+                  onRowDataChange: function onRowDataChange(data) {
+                    _this2.setState(
+                      {
+                        data: data,
+                      },
+                      function () {
+                        if (_this2.props.onBulkEditRowChanged) {
+                          _this2.props.onBulkEditRowChanged(
+                            _this2.props.data,
+                            data
+                          );
+                        }
+                      }
+                    );
+                  },
+                })
+              );
+            }
+          });
+        return mapArr;
+      },
+    },
+    {
+      key: "renderActions",
+      value: function renderActions() {
+        var _this3 = this;
+
+        if (this.props.mode === "bulk") {
+          return /*#__PURE__*/ React.createElement(_TableCell.default, {
+            padding: "none",
+            key: "key-actions-column",
+          });
+        }
+
+        var size = CommonValues.elementSize(this.props);
+        var localization = (0, _objectSpread2.default)(
+          {},
+          MTableEditRow.defaultProps.localization,
+          this.props.localization
+        );
+        var isValid = this.props.columns.every(function (column) {
+          if (column.validate) {
+            var response = column.validate(_this3.state.data);
+
+            switch ((0, _typeof2.default)(response)) {
+              case "object":
+                return response.isValid;
+
+              case "string":
+                return response.length === 0;
+
+              case "boolean":
+                return response;
+            }
+          } else {
+            return true;
+          }
+        });
+        var actions = [
+          {
+            icon: this.props.icons.Check,
+            tooltip: localization.saveTooltip,
+            disabled: !isValid,
+            onClick: this.handleSave,
+          },
+          {
+            icon: this.props.icons.Clear,
+            tooltip: localization.cancelTooltip,
+            onClick: function onClick() {
+              _this3.props.onEditingCanceled(
+                _this3.props.mode,
+                _this3.props.data
+              );
+            },
+          },
+        ];
+        return /*#__PURE__*/ React.createElement(
+          _TableCell.default,
+          {
+            size: size,
+            padding: "none",
+            key: "key-actions-column",
+            style: (0, _objectSpread2.default)(
+              {
+                width: 42 * actions.length,
+                padding: "0px 5px",
+              },
+              this.props.options.editCellStyle
+            ),
+          },
+          /*#__PURE__*/ React.createElement(
+            "div",
+            {
+              style: {
+                display: "flex",
+              },
+            },
+            /*#__PURE__*/ React.createElement(this.props.components.Actions, {
+              data: this.props.data,
+              actions: actions,
+              components: this.props.components,
+              size: size,
+            })
+          )
+        );
+      },
+    },
+    {
+      key: "getStyle",
+      value: function getStyle() {
+        var style = {
+          // boxShadow: '1px 1px 1px 1px rgba(0,0,0,0.2)',
+          borderBottom: "1px solid red",
+        };
+        return style;
+      },
+    },
+    {
+      key: "render",
+      value: function render() {
+        var size = CommonValues.elementSize(this.props);
+        var localization = (0, _objectSpread2.default)(
+          {},
+          MTableEditRow.defaultProps.localization,
+          this.props.localization
+        );
+        var columns;
+
+        if (
+          this.props.mode === "add" ||
+          this.props.mode === "update" ||
+          this.props.mode === "bulk"
+        ) {
+          columns = this.renderColumns();
+        } else {
+          var colSpan = this.props.columns.filter(function (columnDef) {
+            return !columnDef.hidden && !(columnDef.tableData.groupOrder > -1);
+          }).length;
+          columns = [
+            /*#__PURE__*/ React.createElement(
+              _TableCell.default,
+              {
+                size: size,
+                padding:
+                  this.props.options.actionsColumnIndex === 0
+                    ? "none"
+                    : undefined,
+                key: "key-edit-cell",
+                colSpan: colSpan,
+              },
+              /*#__PURE__*/ React.createElement(
+                _Typography.default,
+                {
+                  variant: "h6",
+                },
+                localization.deleteText
+              )
+            ),
+          ];
+        }
+
+        if (this.props.options.selection) {
+          columns.splice(
+            0,
+            0,
+            /*#__PURE__*/ React.createElement(_TableCell.default, {
+              padding: "none",
+              key: "key-selection-cell",
+            })
+          );
+        }
+
+        if (this.props.isTreeData) {
+          columns.splice(
+            0,
+            0,
+            /*#__PURE__*/ React.createElement(_TableCell.default, {
+              padding: "none",
+              key: "key-tree-data-cell",
+            })
+          );
+        }
+
+        if (this.props.options.actionsColumnIndex === -1) {
+          columns.push(this.renderActions());
+        } else if (this.props.options.actionsColumnIndex >= 0) {
+          var endPos = 0;
+
+          if (this.props.options.selection) {
+            endPos = 1;
+          }
+
+          if (this.props.isTreeData) {
+            endPos = 1;
+
+            if (this.props.options.selection) {
+              columns.splice(1, 1);
+            }
+          }
+
+          columns.splice(
+            this.props.options.actionsColumnIndex + endPos,
+            0,
+            this.renderActions()
+          );
+        } // Lastly we add detail panel icon
+
+        if (this.props.detailPanel) {
+          var aligment = this.props.options.detailPanelColumnAlignment;
+          var index = aligment === "left" ? 0 : columns.length;
+          columns.splice(
+            index,
+            0,
+            /*#__PURE__*/ React.createElement(_TableCell.default, {
+              padding: "none",
+              key: "key-detail-panel-cell",
+            })
+          );
+        }
+
+        this.props.columns
+          .filter(function (columnDef) {
+            return columnDef.tableData.groupOrder > -1;
+          })
+          .forEach(function (columnDef) {
+            columns.splice(
+              0,
+              0,
+              /*#__PURE__*/ React.createElement(_TableCell.default, {
+                padding: "none",
+                key: "key-group-cell" + columnDef.tableData.id,
+              })
+            );
+          });
+        var _this$props = this.props,
+          detailPanel = _this$props.detailPanel,
+          isTreeData = _this$props.isTreeData,
+          onRowClick = _this$props.onRowClick,
+          onRowSelected = _this$props.onRowSelected,
+          onTreeExpandChanged = _this$props.onTreeExpandChanged,
+          onToggleDetailPanel = _this$props.onToggleDetailPanel,
+          onEditingApproved = _this$props.onEditingApproved,
+          onEditingCanceled = _this$props.onEditingCanceled,
+          getFieldValue = _this$props.getFieldValue,
+          components = _this$props.components,
+          icons = _this$props.icons,
+          columnsProp = _this$props.columns,
+          localizationProp = _this$props.localization,
+          options = _this$props.options,
+          actions = _this$props.actions,
+          errorState = _this$props.errorState,
+          onBulkEditRowChanged = _this$props.onBulkEditRowChanged,
+          scrollWidth = _this$props.scrollWidth,
+          rowProps = (0, _objectWithoutProperties2.default)(_this$props, [
+            "detailPanel",
+            "isTreeData",
+            "onRowClick",
+            "onRowSelected",
+            "onTreeExpandChanged",
+            "onToggleDetailPanel",
+            "onEditingApproved",
+            "onEditingCanceled",
+            "getFieldValue",
+            "components",
+            "icons",
+            "columns",
+            "localization",
+            "options",
+            "actions",
+            "errorState",
+            "onBulkEditRowChanged",
+            "scrollWidth",
+          ]);
+        return /*#__PURE__*/ React.createElement(
+          React.Fragment,
+          null,
+          /*#__PURE__*/ React.createElement(
+            _TableRow.default,
+            (0, _extends2.default)(
+              {
+                onKeyDown: this.handleKeyDown,
+              },
+              rowProps,
+              {
+                style: this.getStyle(),
+              }
+            ),
+            columns
+          )
+        );
+      },
+    },
+  ]);
+  return MTableEditRow;
+})(React.Component);
+
+exports.default = MTableEditRow;
+MTableEditRow.defaultProps = {
+  actions: [],
+  index: 0,
+  options: {},
+  path: [],
+  localization: {
+    saveTooltip: "Save",
+    cancelTooltip: "Cancel",
+    deleteText: "Are you sure you want to delete this row?",
+  },
+  onBulkEditRowChanged: function onBulkEditRowChanged() {},
+};
+MTableEditRow.propTypes = {
+  actions: _propTypes.default.array,
+  icons: _propTypes.default.any.isRequired,
+  index: _propTypes.default.number.isRequired,
+  data: _propTypes.default.object,
+  detailPanel: _propTypes.default.oneOfType([
+    _propTypes.default.func,
+    _propTypes.default.arrayOf(
+      _propTypes.default.oneOfType([
+        _propTypes.default.object,
+        _propTypes.default.func,
+      ])
+    ),
+  ]),
+  options: _propTypes.default.object.isRequired,
+  onRowSelected: _propTypes.default.func,
+  path: _propTypes.default.arrayOf(_propTypes.default.number),
+  columns: _propTypes.default.array,
+  onRowClick: _propTypes.default.func,
+  onEditingApproved: _propTypes.default.func,
+  onEditingCanceled: _propTypes.default.func,
+  localization: _propTypes.default.object,
+  getFieldValue: _propTypes.default.func,
+  errorState: _propTypes.default.oneOfType([
+    _propTypes.default.object,
+    _propTypes.default.bool,
+  ]),
+  onBulkEditRowChanged: _propTypes.default.func,
+};

--- a/dist/components/m-table-edit-row.js
+++ b/dist/components/m-table-edit-row.js
@@ -253,6 +253,7 @@ var MTableEditRow = /*#__PURE__*/ (function (_React$Component) {
                   value: readonlyValue,
                   key: columnDef.tableData.id,
                   rowData: _this2.props.data,
+                  updatedData: _this2.state.data,
                   style: getCellStyle(columnDef, value),
                 }
               );
@@ -269,7 +270,10 @@ var MTableEditRow = /*#__PURE__*/ (function (_React$Component) {
               };
 
               if (columnDef.validate) {
-                var validateResponse = columnDef.validate(_this2.state.data);
+                var validateResponse = columnDef.validate(
+                  _this2.state.data,
+                  _this2.props.data
+                );
 
                 switch ((0, _typeof2.default)(validateResponse)) {
                   case "object":
@@ -311,6 +315,7 @@ var MTableEditRow = /*#__PURE__*/ (function (_React$Component) {
                   helperText: error.helperText,
                   locale: _this2.props.localization.dateTimePickerLocalization,
                   rowData: _this2.state.data,
+                  originalData: _this2.props.data,
                   onChange: function onChange(value) {
                     var data = (0, _objectSpread2.default)(
                       {},

--- a/dist/components/m-table-filter-row.js
+++ b/dist/components/m-table-filter-row.js
@@ -1,0 +1,551 @@
+"use strict";
+
+var _interopRequireWildcard = require("@babel/runtime/helpers/interopRequireWildcard");
+
+var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
+
+Object.defineProperty(exports, "__esModule", {
+  value: true,
+});
+exports.default = void 0;
+
+var _slicedToArray2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/slicedToArray")
+);
+
+var _objectSpread2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/objectSpread")
+);
+
+var _classCallCheck2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/classCallCheck")
+);
+
+var _createClass2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/createClass")
+);
+
+var _assertThisInitialized2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/assertThisInitialized")
+);
+
+var _inherits2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/inherits")
+);
+
+var _possibleConstructorReturn2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/possibleConstructorReturn")
+);
+
+var _getPrototypeOf2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/getPrototypeOf")
+);
+
+var _defineProperty2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/defineProperty")
+);
+
+var React = _interopRequireWildcard(require("react"));
+
+var _propTypes = _interopRequireDefault(require("prop-types"));
+
+var _TableCell = _interopRequireDefault(require("@material-ui/core/TableCell"));
+
+var _TableRow = _interopRequireDefault(require("@material-ui/core/TableRow"));
+
+var _TextField = _interopRequireDefault(require("@material-ui/core/TextField"));
+
+var _FormControl = _interopRequireDefault(
+  require("@material-ui/core/FormControl")
+);
+
+var _Select = _interopRequireDefault(require("@material-ui/core/Select"));
+
+var _Input = _interopRequireDefault(require("@material-ui/core/Input"));
+
+var _InputLabel = _interopRequireDefault(
+  require("@material-ui/core/InputLabel")
+);
+
+var _MenuItem = _interopRequireDefault(require("@material-ui/core/MenuItem"));
+
+var _Checkbox = _interopRequireDefault(require("@material-ui/core/Checkbox"));
+
+var _ListItemText = _interopRequireDefault(
+  require("@material-ui/core/ListItemText")
+);
+
+var _InputAdornment = _interopRequireDefault(
+  require("@material-ui/core/InputAdornment")
+);
+
+var _Icon = _interopRequireDefault(require("@material-ui/core/Icon"));
+
+var _Tooltip = _interopRequireDefault(require("@material-ui/core/Tooltip"));
+
+var _dateFns = _interopRequireDefault(require("@date-io/date-fns"));
+
+var _pickers = require("@material-ui/pickers");
+
+function _createSuper(Derived) {
+  var hasNativeReflectConstruct = _isNativeReflectConstruct();
+  return function _createSuperInternal() {
+    var Super = (0, _getPrototypeOf2.default)(Derived),
+      result;
+    if (hasNativeReflectConstruct) {
+      var NewTarget = (0, _getPrototypeOf2.default)(this).constructor;
+      result = Reflect.construct(Super, arguments, NewTarget);
+    } else {
+      result = Super.apply(this, arguments);
+    }
+    return (0, _possibleConstructorReturn2.default)(this, result);
+  };
+}
+
+function _isNativeReflectConstruct() {
+  if (typeof Reflect === "undefined" || !Reflect.construct) return false;
+  if (Reflect.construct.sham) return false;
+  if (typeof Proxy === "function") return true;
+  try {
+    Date.prototype.toString.call(Reflect.construct(Date, [], function () {}));
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
+var ITEM_HEIGHT = 48;
+var ITEM_PADDING_TOP = 8;
+var MenuProps = {
+  PaperProps: {
+    style: {
+      maxHeight: ITEM_HEIGHT * 4.5 + ITEM_PADDING_TOP,
+      width: 250,
+    },
+  },
+};
+
+var MTableFilterRow = /*#__PURE__*/ (function (_React$Component) {
+  (0, _inherits2.default)(MTableFilterRow, _React$Component);
+
+  var _super = _createSuper(MTableFilterRow);
+
+  function MTableFilterRow() {
+    var _this;
+
+    (0, _classCallCheck2.default)(this, MTableFilterRow);
+
+    for (
+      var _len = arguments.length, args = new Array(_len), _key = 0;
+      _key < _len;
+      _key++
+    ) {
+      args[_key] = arguments[_key];
+    }
+
+    _this = _super.call.apply(_super, [this].concat(args));
+    (0, _defineProperty2.default)(
+      (0, _assertThisInitialized2.default)(_this),
+      "getLocalizationData",
+      function () {
+        return (0, _objectSpread2.default)(
+          {},
+          MTableFilterRow.defaultProps.localization,
+          _this.props.localization
+        );
+      }
+    );
+    (0, _defineProperty2.default)(
+      (0, _assertThisInitialized2.default)(_this),
+      "getLocalizedFilterPlaceHolder",
+      function (columnDef) {
+        return (
+          columnDef.filterPlaceholder ||
+          _this.getLocalizationData().filterPlaceHolder ||
+          ""
+        );
+      }
+    );
+    (0, _defineProperty2.default)(
+      (0, _assertThisInitialized2.default)(_this),
+      "LookupFilter",
+      function (_ref) {
+        var columnDef = _ref.columnDef;
+
+        var _React$useState = React.useState(
+            columnDef.tableData.filterValue || []
+          ),
+          _React$useState2 = (0, _slicedToArray2.default)(_React$useState, 2),
+          selectedFilter = _React$useState2[0],
+          setSelectedFilter = _React$useState2[1];
+
+        React.useEffect(
+          function () {
+            setSelectedFilter(columnDef.tableData.filterValue || []);
+          },
+          [columnDef.tableData.filterValue]
+        );
+        return /*#__PURE__*/ React.createElement(
+          _FormControl.default,
+          {
+            style: {
+              width: "100%",
+            },
+          },
+          /*#__PURE__*/ React.createElement(
+            _InputLabel.default,
+            {
+              htmlFor: "select-multiple-checkbox" + columnDef.tableData.id,
+              style: {
+                marginTop: -16,
+              },
+            },
+            _this.getLocalizedFilterPlaceHolder(columnDef)
+          ),
+          /*#__PURE__*/ React.createElement(
+            _Select.default,
+            {
+              multiple: true,
+              value: selectedFilter,
+              onClose: function onClose() {
+                if (columnDef.filterOnItemSelect !== true)
+                  _this.props.onFilterChanged(
+                    columnDef.tableData.id,
+                    selectedFilter
+                  );
+              },
+              onChange: function onChange(event) {
+                setSelectedFilter(event.target.value);
+                if (columnDef.filterOnItemSelect === true)
+                  _this.props.onFilterChanged(
+                    columnDef.tableData.id,
+                    event.target.value
+                  );
+              },
+              input: /*#__PURE__*/ React.createElement(_Input.default, {
+                id: "select-multiple-checkbox" + columnDef.tableData.id,
+              }),
+              renderValue: function renderValue(selecteds) {
+                return selecteds
+                  .map(function (selected) {
+                    return columnDef.lookup[selected];
+                  })
+                  .join(", ");
+              },
+              MenuProps: MenuProps,
+              style: {
+                marginTop: 0,
+              },
+            },
+            Object.keys(columnDef.lookup).map(function (key) {
+              return /*#__PURE__*/ React.createElement(
+                _MenuItem.default,
+                {
+                  key: key,
+                  value: key,
+                },
+                /*#__PURE__*/ React.createElement(_Checkbox.default, {
+                  checked: selectedFilter.indexOf(key.toString()) > -1,
+                }),
+                /*#__PURE__*/ React.createElement(_ListItemText.default, {
+                  primary: columnDef.lookup[key],
+                })
+              );
+            })
+          )
+        );
+      }
+    );
+    (0, _defineProperty2.default)(
+      (0, _assertThisInitialized2.default)(_this),
+      "renderFilterComponent",
+      function (columnDef) {
+        return React.createElement(columnDef.filterComponent, {
+          columnDef: columnDef,
+          onFilterChanged: _this.props.onFilterChanged,
+        });
+      }
+    );
+    (0, _defineProperty2.default)(
+      (0, _assertThisInitialized2.default)(_this),
+      "renderBooleanFilter",
+      function (columnDef) {
+        return /*#__PURE__*/ React.createElement(_Checkbox.default, {
+          indeterminate: columnDef.tableData.filterValue === undefined,
+          checked: columnDef.tableData.filterValue === "checked",
+          onChange: function onChange() {
+            var val;
+
+            if (columnDef.tableData.filterValue === undefined) {
+              val = "checked";
+            } else if (columnDef.tableData.filterValue === "checked") {
+              val = "unchecked";
+            }
+
+            _this.props.onFilterChanged(columnDef.tableData.id, val);
+          },
+        });
+      }
+    );
+    (0, _defineProperty2.default)(
+      (0, _assertThisInitialized2.default)(_this),
+      "renderDefaultFilter",
+      function (columnDef) {
+        var localization = _this.getLocalizationData();
+
+        var FilterIcon = _this.props.icons.Filter;
+        return /*#__PURE__*/ React.createElement(_TextField.default, {
+          style:
+            columnDef.type === "numeric"
+              ? {
+                  float: "right",
+                }
+              : {},
+          type: columnDef.type === "numeric" ? "number" : "search",
+          value: columnDef.tableData.filterValue || "",
+          placeholder: _this.getLocalizedFilterPlaceHolder(columnDef),
+          onChange: function onChange(event) {
+            _this.props.onFilterChanged(
+              columnDef.tableData.id,
+              event.target.value
+            );
+          },
+          inputProps: {
+            "aria-label": "filter data by ".concat(columnDef.title),
+          },
+          InputProps:
+            _this.props.hideFilterIcons || columnDef.hideFilterIcon
+              ? undefined
+              : {
+                  startAdornment: /*#__PURE__*/ React.createElement(
+                    _InputAdornment.default,
+                    {
+                      position: "start",
+                    },
+                    /*#__PURE__*/ React.createElement(
+                      _Tooltip.default,
+                      {
+                        title: localization.filterTooltip,
+                      },
+                      /*#__PURE__*/ React.createElement(FilterIcon, null)
+                    )
+                  ),
+                },
+        });
+      }
+    );
+    (0, _defineProperty2.default)(
+      (0, _assertThisInitialized2.default)(_this),
+      "renderDateTypeFilter",
+      function (columnDef) {
+        var onDateInputChange = function onDateInputChange(date) {
+          return _this.props.onFilterChanged(columnDef.tableData.id, date);
+        };
+
+        var pickerProps = {
+          value: columnDef.tableData.filterValue || null,
+          onChange: onDateInputChange,
+          placeholder: _this.getLocalizedFilterPlaceHolder(columnDef),
+          clearable: true,
+        };
+        var dateInputElement = null;
+
+        if (columnDef.type === "date") {
+          dateInputElement = /*#__PURE__*/ React.createElement(
+            _pickers.DatePicker,
+            pickerProps
+          );
+        } else if (columnDef.type === "datetime") {
+          dateInputElement = /*#__PURE__*/ React.createElement(
+            _pickers.DateTimePicker,
+            pickerProps
+          );
+        } else if (columnDef.type === "time") {
+          dateInputElement = /*#__PURE__*/ React.createElement(
+            _pickers.TimePicker,
+            pickerProps
+          );
+        }
+
+        return /*#__PURE__*/ React.createElement(
+          _pickers.MuiPickersUtilsProvider,
+          {
+            utils: _dateFns.default,
+            locale: _this.props.localization.dateTimePickerLocalization,
+          },
+          dateInputElement
+        );
+      }
+    );
+    return _this;
+  }
+
+  (0, _createClass2.default)(MTableFilterRow, [
+    {
+      key: "getComponentForColumn",
+      value: function getComponentForColumn(columnDef) {
+        if (columnDef.filtering === false) {
+          return null;
+        }
+
+        if (columnDef.field || columnDef.customFilterAndSearch) {
+          if (columnDef.filterComponent) {
+            return this.renderFilterComponent(columnDef);
+          } else if (columnDef.lookup) {
+            return /*#__PURE__*/ React.createElement(this.LookupFilter, {
+              columnDef: columnDef,
+            });
+          } else if (columnDef.type === "boolean") {
+            return this.renderBooleanFilter(columnDef);
+          } else if (["date", "datetime", "time"].includes(columnDef.type)) {
+            return this.renderDateTypeFilter(columnDef);
+          } else {
+            return this.renderDefaultFilter(columnDef);
+          }
+        }
+      },
+    },
+    {
+      key: "render",
+      value: function render() {
+        var _this2 = this;
+
+        var columns = this.props.columns
+          .filter(function (columnDef) {
+            return !columnDef.hidden && !(columnDef.tableData.groupOrder > -1);
+          })
+          .sort(function (a, b) {
+            return a.tableData.columnOrder - b.tableData.columnOrder;
+          })
+          .map(function (columnDef) {
+            return /*#__PURE__*/ React.createElement(
+              _TableCell.default,
+              {
+                key: columnDef.tableData.id,
+                style: (0, _objectSpread2.default)(
+                  {},
+                  _this2.props.filterCellStyle,
+                  columnDef.filterCellStyle
+                ),
+              },
+              _this2.getComponentForColumn(columnDef)
+            );
+          });
+
+        if (this.props.selection) {
+          columns.splice(
+            0,
+            0,
+            /*#__PURE__*/ React.createElement(_TableCell.default, {
+              padding: "none",
+              key: "key-selection-column",
+            })
+          );
+        }
+
+        if (this.props.hasActions) {
+          if (this.props.actionsColumnIndex === -1) {
+            columns.push(
+              /*#__PURE__*/ React.createElement(_TableCell.default, {
+                key: "key-action-column",
+              })
+            );
+          } else {
+            var endPos = 0;
+
+            if (this.props.selection) {
+              endPos = 1;
+            }
+
+            columns.splice(
+              this.props.actionsColumnIndex + endPos,
+              0,
+              /*#__PURE__*/ React.createElement(_TableCell.default, {
+                key: "key-action-column",
+              })
+            );
+          }
+        }
+
+        if (this.props.hasDetailPanel) {
+          var alignment = this.props.detailPanelColumnAlignment;
+          var index = alignment === "left" ? 0 : columns.length;
+          columns.splice(
+            index,
+            0,
+            /*#__PURE__*/ React.createElement(_TableCell.default, {
+              padding: "none",
+              key: "key-detail-panel-column",
+            })
+          );
+        }
+
+        if (this.props.isTreeData > 0) {
+          columns.splice(
+            0,
+            0,
+            /*#__PURE__*/ React.createElement(_TableCell.default, {
+              padding: "none",
+              key: "key-tree-data-filter",
+            })
+          );
+        }
+
+        this.props.columns
+          .filter(function (columnDef) {
+            return columnDef.tableData.groupOrder > -1;
+          })
+          .forEach(function (columnDef) {
+            columns.splice(
+              0,
+              0,
+              /*#__PURE__*/ React.createElement(_TableCell.default, {
+                padding: "checkbox",
+                key: "key-group-filter" + columnDef.tableData.id,
+              })
+            );
+          });
+        return /*#__PURE__*/ React.createElement(
+          _TableRow.default,
+          {
+            style: (0, _objectSpread2.default)(
+              {
+                height: 10,
+              },
+              this.props.filterRowStyle
+            ),
+          },
+          columns
+        );
+      },
+    },
+  ]);
+  return MTableFilterRow;
+})(React.Component);
+
+MTableFilterRow.defaultProps = {
+  columns: [],
+  detailPanelColumnAlignment: "left",
+  selection: false,
+  hasActions: false,
+  localization: {
+    filterTooltip: "Filter",
+  },
+  hideFilterIcons: false,
+};
+MTableFilterRow.propTypes = {
+  columns: _propTypes.default.array.isRequired,
+  hasDetailPanel: _propTypes.default.bool.isRequired,
+  detailPanelColumnAlignment: _propTypes.default.string,
+  isTreeData: _propTypes.default.bool.isRequired,
+  onFilterChanged: _propTypes.default.func.isRequired,
+  filterCellStyle: _propTypes.default.object,
+  filterRowStyle: _propTypes.default.object,
+  selection: _propTypes.default.bool.isRequired,
+  actionsColumnIndex: _propTypes.default.number,
+  hasActions: _propTypes.default.bool,
+  localization: _propTypes.default.object,
+  hideFilterIcons: _propTypes.default.bool,
+};
+var _default = MTableFilterRow;
+exports.default = _default;

--- a/dist/components/m-table-group-row.js
+++ b/dist/components/m-table-group-row.js
@@ -1,0 +1,346 @@
+"use strict";
+
+var _interopRequireWildcard = require("@babel/runtime/helpers/interopRequireWildcard");
+
+var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
+
+Object.defineProperty(exports, "__esModule", {
+  value: true,
+});
+exports.default = void 0;
+
+var _objectSpread2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/objectSpread")
+);
+
+var _toConsumableArray2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/toConsumableArray")
+);
+
+var _classCallCheck2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/classCallCheck")
+);
+
+var _createClass2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/createClass")
+);
+
+var _assertThisInitialized2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/assertThisInitialized")
+);
+
+var _inherits2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/inherits")
+);
+
+var _possibleConstructorReturn2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/possibleConstructorReturn")
+);
+
+var _getPrototypeOf2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/getPrototypeOf")
+);
+
+var _defineProperty2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/defineProperty")
+);
+
+var _TableCell = _interopRequireDefault(require("@material-ui/core/TableCell"));
+
+var _TableRow = _interopRequireDefault(require("@material-ui/core/TableRow"));
+
+var _IconButton = _interopRequireDefault(
+  require("@material-ui/core/IconButton")
+);
+
+var _propTypes = _interopRequireDefault(require("prop-types"));
+
+var React = _interopRequireWildcard(require("react"));
+
+function _createSuper(Derived) {
+  var hasNativeReflectConstruct = _isNativeReflectConstruct();
+  return function _createSuperInternal() {
+    var Super = (0, _getPrototypeOf2.default)(Derived),
+      result;
+    if (hasNativeReflectConstruct) {
+      var NewTarget = (0, _getPrototypeOf2.default)(this).constructor;
+      result = Reflect.construct(Super, arguments, NewTarget);
+    } else {
+      result = Super.apply(this, arguments);
+    }
+    return (0, _possibleConstructorReturn2.default)(this, result);
+  };
+}
+
+function _isNativeReflectConstruct() {
+  if (typeof Reflect === "undefined" || !Reflect.construct) return false;
+  if (Reflect.construct.sham) return false;
+  if (typeof Proxy === "function") return true;
+  try {
+    Date.prototype.toString.call(Reflect.construct(Date, [], function () {}));
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
+/* eslint-enable no-unused-vars */
+var MTableGroupRow = /*#__PURE__*/ (function (_React$Component) {
+  (0, _inherits2.default)(MTableGroupRow, _React$Component);
+
+  var _super = _createSuper(MTableGroupRow);
+
+  function MTableGroupRow() {
+    var _this;
+
+    (0, _classCallCheck2.default)(this, MTableGroupRow);
+
+    for (
+      var _len = arguments.length, args = new Array(_len), _key = 0;
+      _key < _len;
+      _key++
+    ) {
+      args[_key] = arguments[_key];
+    }
+
+    _this = _super.call.apply(_super, [this].concat(args));
+    (0, _defineProperty2.default)(
+      (0, _assertThisInitialized2.default)(_this),
+      "rotateIconStyle",
+      function (isOpen) {
+        return {
+          transform: isOpen ? "rotate(90deg)" : "none",
+        };
+      }
+    );
+    return _this;
+  }
+
+  (0, _createClass2.default)(MTableGroupRow, [
+    {
+      key: "render",
+      value: function render() {
+        var _this2 = this;
+
+        var colSpan = this.props.columns.filter(function (columnDef) {
+          return !columnDef.hidden;
+        }).length;
+        this.props.options.selection && colSpan++;
+        this.props.detailPanel && colSpan++;
+        this.props.actions && this.props.actions.length > 0 && colSpan++;
+        var column = this.props.groups[this.props.level];
+        var detail;
+
+        if (this.props.groupData.isExpanded) {
+          if (this.props.groups.length > this.props.level + 1) {
+            // Is there another group
+            detail = this.props.groupData.groups.map(function (
+              groupData,
+              index
+            ) {
+              return /*#__PURE__*/ React.createElement(
+                _this2.props.components.GroupRow,
+                {
+                  actions: _this2.props.actions,
+                  key: groupData.value || "" + index,
+                  columns: _this2.props.columns,
+                  components: _this2.props.components,
+                  detailPanel: _this2.props.detailPanel,
+                  getFieldValue: _this2.props.getFieldValue,
+                  groupData: groupData,
+                  groups: _this2.props.groups,
+                  icons: _this2.props.icons,
+                  level: _this2.props.level + 1,
+                  path: [].concat(
+                    (0, _toConsumableArray2.default)(_this2.props.path),
+                    [index]
+                  ),
+                  onGroupExpandChanged: _this2.props.onGroupExpandChanged,
+                  onRowSelected: _this2.props.onRowSelected,
+                  onRowClick: _this2.props.onRowClick,
+                  onToggleDetailPanel: _this2.props.onToggleDetailPanel,
+                  onTreeExpandChanged: _this2.props.onTreeExpandChanged,
+                  onEditingCanceled: _this2.props.onEditingCanceled,
+                  onEditingApproved: _this2.props.onEditingApproved,
+                  options: _this2.props.options,
+                  hasAnyEditingRow: _this2.props.hasAnyEditingRow,
+                  isTreeData: _this2.props.isTreeData,
+                  cellEditable: _this2.props.cellEditable,
+                  onCellEditStarted: _this2.props.onCellEditStarted,
+                  onCellEditFinished: _this2.props.onCellEditFinished,
+                  scrollWidth: _this2.props.scrollWidth,
+                }
+              );
+            });
+          } else {
+            detail = this.props.groupData.data.map(function (rowData, index) {
+              if (rowData.tableData.editing) {
+                return /*#__PURE__*/ React.createElement(
+                  _this2.props.components.EditRow,
+                  {
+                    columns: _this2.props.columns,
+                    components: _this2.props.components,
+                    data: rowData,
+                    icons: _this2.props.icons,
+                    path: [].concat(
+                      (0, _toConsumableArray2.default)(_this2.props.path),
+                      [index]
+                    ),
+                    localization: _this2.props.localization,
+                    key: index,
+                    mode: rowData.tableData.editing,
+                    options: _this2.props.options,
+                    isTreeData: _this2.props.isTreeData,
+                    detailPanel: _this2.props.detailPanel,
+                    onEditingCanceled: _this2.props.onEditingCanceled,
+                    onEditingApproved: _this2.props.onEditingApproved,
+                    getFieldValue: _this2.props.getFieldValue,
+                    onBulkEditRowChanged: _this2.props.onBulkEditRowChanged,
+                    scrollWidth: _this2.props.scrollWidth,
+                  }
+                );
+              } else {
+                return /*#__PURE__*/ React.createElement(
+                  _this2.props.components.Row,
+                  {
+                    actions: _this2.props.actions,
+                    key: index,
+                    columns: _this2.props.columns,
+                    components: _this2.props.components,
+                    data: rowData,
+                    detailPanel: _this2.props.detailPanel,
+                    getFieldValue: _this2.props.getFieldValue,
+                    icons: _this2.props.icons,
+                    path: [].concat(
+                      (0, _toConsumableArray2.default)(_this2.props.path),
+                      [index]
+                    ),
+                    onRowSelected: _this2.props.onRowSelected,
+                    onRowClick: _this2.props.onRowClick,
+                    onToggleDetailPanel: _this2.props.onToggleDetailPanel,
+                    options: _this2.props.options,
+                    isTreeData: _this2.props.isTreeData,
+                    onTreeExpandChanged: _this2.props.onTreeExpandChanged,
+                    onEditingCanceled: _this2.props.onEditingCanceled,
+                    onEditingApproved: _this2.props.onEditingApproved,
+                    hasAnyEditingRow: _this2.props.hasAnyEditingRow,
+                    cellEditable: _this2.props.cellEditable,
+                    onCellEditStarted: _this2.props.onCellEditStarted,
+                    onCellEditFinished: _this2.props.onCellEditFinished,
+                    scrollWidth: _this2.props.scrollWidth,
+                  }
+                );
+              }
+            });
+          }
+        }
+
+        var freeCells = [];
+
+        for (var i = 0; i < this.props.level; i++) {
+          freeCells.push(
+            /*#__PURE__*/ React.createElement(_TableCell.default, {
+              padding: "checkbox",
+              key: i,
+            })
+          );
+        }
+
+        var value = this.props.groupData.value;
+
+        if (column.lookup) {
+          value = column.lookup[value];
+        }
+
+        var title = column.title;
+
+        if (typeof this.props.options.groupTitle === "function") {
+          title = this.props.options.groupTitle(this.props.groupData);
+        } else if (typeof title !== "string") {
+          title = React.cloneElement(title);
+        }
+
+        var separator = this.props.options.groupRowSeparator || ": ";
+        return /*#__PURE__*/ React.createElement(
+          React.Fragment,
+          null,
+          /*#__PURE__*/ React.createElement(
+            _TableRow.default,
+            null,
+            freeCells,
+            /*#__PURE__*/ React.createElement(
+              this.props.components.Cell,
+              {
+                colSpan: colSpan,
+                padding: "none",
+                columnDef: column,
+                value: value,
+                icons: this.props.icons,
+              },
+              /*#__PURE__*/ React.createElement(
+                _IconButton.default,
+                {
+                  style: (0, _objectSpread2.default)(
+                    {
+                      transition: "all ease 200ms",
+                    },
+                    this.rotateIconStyle(this.props.groupData.isExpanded)
+                  ),
+                  onClick: function onClick(event) {
+                    _this2.props.onGroupExpandChanged(_this2.props.path);
+                  },
+                },
+                /*#__PURE__*/ React.createElement(
+                  this.props.icons.DetailPanel,
+                  null
+                )
+              ),
+              /*#__PURE__*/ React.createElement("b", null, title, separator)
+            )
+          ),
+          detail
+        );
+      },
+    },
+  ]);
+  return MTableGroupRow;
+})(React.Component);
+
+exports.default = MTableGroupRow;
+MTableGroupRow.defaultProps = {
+  columns: [],
+  groups: [],
+  options: {},
+  level: 0,
+};
+MTableGroupRow.propTypes = {
+  actions: _propTypes.default.array,
+  columns: _propTypes.default.arrayOf(_propTypes.default.object),
+  components: _propTypes.default.object,
+  detailPanel: _propTypes.default.oneOfType([
+    _propTypes.default.func,
+    _propTypes.default.arrayOf(_propTypes.default.object),
+  ]),
+  getFieldValue: _propTypes.default.func,
+  groupData: _propTypes.default.object,
+  groups: _propTypes.default.arrayOf(_propTypes.default.object),
+  hasAnyEditingRow: _propTypes.default.bool,
+  icons: _propTypes.default.object,
+  isTreeData: _propTypes.default.bool.isRequired,
+  level: _propTypes.default.number,
+  localization: _propTypes.default.object,
+  onGroupExpandChanged: _propTypes.default.func,
+  onRowSelected: _propTypes.default.func,
+  onRowClick: _propTypes.default.func,
+  onToggleDetailPanel: _propTypes.default.func.isRequired,
+  onTreeExpandChanged: _propTypes.default.func.isRequired,
+  onEditingCanceled: _propTypes.default.func,
+  onEditingApproved: _propTypes.default.func,
+  options: _propTypes.default.object,
+  path: _propTypes.default.arrayOf(_propTypes.default.number),
+  scrollWidth: _propTypes.default.number.isRequired,
+  cellEditable: _propTypes.default.object,
+  onCellEditStarted: _propTypes.default.func,
+  onCellEditFinished: _propTypes.default.func,
+  onBulkEditRowChanged: _propTypes.default.func,
+};

--- a/dist/components/m-table-groupbar.js
+++ b/dist/components/m-table-groupbar.js
@@ -1,0 +1,282 @@
+"use strict";
+
+var _interopRequireWildcard = require("@babel/runtime/helpers/interopRequireWildcard");
+
+var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
+
+Object.defineProperty(exports, "__esModule", {
+  value: true,
+});
+exports.default = void 0;
+
+var _extends2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/extends")
+);
+
+var _objectSpread2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/objectSpread")
+);
+
+var _classCallCheck2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/classCallCheck")
+);
+
+var _createClass2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/createClass")
+);
+
+var _assertThisInitialized2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/assertThisInitialized")
+);
+
+var _inherits2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/inherits")
+);
+
+var _possibleConstructorReturn2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/possibleConstructorReturn")
+);
+
+var _getPrototypeOf2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/getPrototypeOf")
+);
+
+var _defineProperty2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/defineProperty")
+);
+
+var _Toolbar = _interopRequireDefault(require("@material-ui/core/Toolbar"));
+
+var _Chip = _interopRequireDefault(require("@material-ui/core/Chip"));
+
+var _Typography = _interopRequireDefault(
+  require("@material-ui/core/Typography")
+);
+
+var _propTypes = _interopRequireDefault(require("prop-types"));
+
+var React = _interopRequireWildcard(require("react"));
+
+var _reactBeautifulDnd = require("react-beautiful-dnd");
+
+function _createSuper(Derived) {
+  var hasNativeReflectConstruct = _isNativeReflectConstruct();
+  return function _createSuperInternal() {
+    var Super = (0, _getPrototypeOf2.default)(Derived),
+      result;
+    if (hasNativeReflectConstruct) {
+      var NewTarget = (0, _getPrototypeOf2.default)(this).constructor;
+      result = Reflect.construct(Super, arguments, NewTarget);
+    } else {
+      result = Super.apply(this, arguments);
+    }
+    return (0, _possibleConstructorReturn2.default)(this, result);
+  };
+}
+
+function _isNativeReflectConstruct() {
+  if (typeof Reflect === "undefined" || !Reflect.construct) return false;
+  if (Reflect.construct.sham) return false;
+  if (typeof Proxy === "function") return true;
+  try {
+    Date.prototype.toString.call(Reflect.construct(Date, [], function () {}));
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
+/* eslint-enable no-unused-vars */
+var MTableGroupbar = /*#__PURE__*/ (function (_React$Component) {
+  (0, _inherits2.default)(MTableGroupbar, _React$Component);
+
+  var _super = _createSuper(MTableGroupbar);
+
+  function MTableGroupbar(props) {
+    var _this;
+
+    (0, _classCallCheck2.default)(this, MTableGroupbar);
+    _this = _super.call(this, props);
+    (0, _defineProperty2.default)(
+      (0, _assertThisInitialized2.default)(_this),
+      "getItemStyle",
+      function (isDragging, draggableStyle) {
+        return (0, _objectSpread2.default)(
+          {
+            // some basic styles to make the items look a bit nicer
+            userSelect: "none",
+            // padding: '8px 16px',
+            margin: "0 ".concat(8, "px 0 0"),
+          },
+          draggableStyle
+        );
+      }
+    );
+    (0, _defineProperty2.default)(
+      (0, _assertThisInitialized2.default)(_this),
+      "getListStyle",
+      function (isDraggingOver) {
+        return {
+          // background: isDraggingOver ? 'lightblue' : '#0000000a',
+          background: "#0000000a",
+          display: "flex",
+          width: "100%",
+          padding: 8,
+          overflow: "auto",
+          border: "1px solid #ccc",
+          borderStyle: "dashed",
+        };
+      }
+    );
+    _this.state = {};
+    return _this;
+  }
+
+  (0, _createClass2.default)(MTableGroupbar, [
+    {
+      key: "render",
+      value: function render() {
+        var _this2 = this;
+
+        return /*#__PURE__*/ React.createElement(
+          _Toolbar.default,
+          {
+            style: {
+              padding: 0,
+              minHeight: "unset",
+            },
+          },
+          /*#__PURE__*/ React.createElement(
+            _reactBeautifulDnd.Droppable,
+            {
+              droppableId: "groups",
+              direction: "horizontal",
+              placeholder: "Deneme",
+            },
+            function (provided, snapshot) {
+              return /*#__PURE__*/ React.createElement(
+                "div",
+                {
+                  ref: provided.innerRef,
+                  style: _this2.getListStyle(snapshot.isDraggingOver),
+                },
+                _this2.props.groupColumns.length > 0 &&
+                  /*#__PURE__*/ React.createElement(
+                    _Typography.default,
+                    {
+                      variant: "caption",
+                      style: {
+                        padding: 8,
+                      },
+                    },
+                    _this2.props.localization.groupedBy
+                  ),
+                _this2.props.groupColumns.map(function (columnDef, index) {
+                  return /*#__PURE__*/ React.createElement(
+                    _reactBeautifulDnd.Draggable,
+                    {
+                      key: columnDef.tableData.id,
+                      draggableId: columnDef.tableData.id.toString(),
+                      index: index,
+                    },
+                    function (provided, snapshot) {
+                      return /*#__PURE__*/ React.createElement(
+                        "div",
+                        (0, _extends2.default)(
+                          {
+                            ref: provided.innerRef,
+                          },
+                          provided.draggableProps,
+                          provided.dragHandleProps,
+                          {
+                            style: _this2.getItemStyle(
+                              snapshot.isDragging,
+                              provided.draggableProps.style
+                            ),
+                          }
+                        ),
+                        /*#__PURE__*/ React.createElement(
+                          _Chip.default,
+                          (0, _extends2.default)({}, provided.dragHandleProps, {
+                            onClick: function onClick() {
+                              return _this2.props.onSortChanged(columnDef);
+                            },
+                            label: /*#__PURE__*/ React.createElement(
+                              "div",
+                              {
+                                style: {
+                                  display: "flex",
+                                  alignItems: "center",
+                                },
+                              },
+                              /*#__PURE__*/ React.createElement(
+                                "div",
+                                {
+                                  style: {
+                                    float: "left",
+                                  },
+                                },
+                                columnDef.title
+                              ),
+                              columnDef.tableData.groupSort &&
+                                /*#__PURE__*/ React.createElement(
+                                  _this2.props.icons.SortArrow,
+                                  {
+                                    style: {
+                                      transition: "300ms ease all",
+                                      transform:
+                                        columnDef.tableData.groupSort === "asc"
+                                          ? "rotate(-180deg)"
+                                          : "none",
+                                      fontSize: 18,
+                                    },
+                                  }
+                                )
+                            ),
+                            style: {
+                              boxShadow: "none",
+                              textTransform: "none",
+                            },
+                            onDelete: function onDelete() {
+                              return _this2.props.onGroupRemoved(
+                                columnDef,
+                                index
+                              );
+                            },
+                          })
+                        )
+                      );
+                    }
+                  );
+                }),
+                _this2.props.groupColumns.length === 0 &&
+                  /*#__PURE__*/ React.createElement(
+                    _Typography.default,
+                    {
+                      variant: "caption",
+                      style: {
+                        padding: 8,
+                      },
+                    },
+                    _this2.props.localization.placeholder
+                  ),
+                provided.placeholder
+              );
+            }
+          )
+        );
+      },
+    },
+  ]);
+  return MTableGroupbar;
+})(React.Component);
+
+MTableGroupbar.defaultProps = {};
+MTableGroupbar.propTypes = {
+  localization: _propTypes.default.shape({
+    groupedBy: _propTypes.default.string,
+    placeholder: _propTypes.default.string,
+  }),
+};
+var _default = MTableGroupbar;
+exports.default = _default;

--- a/dist/components/m-table-header.js
+++ b/dist/components/m-table-header.js
@@ -1,0 +1,580 @@
+"use strict";
+
+var _interopRequireWildcard = require("@babel/runtime/helpers/interopRequireWildcard");
+
+var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
+
+Object.defineProperty(exports, "__esModule", {
+  value: true,
+});
+exports.default = exports.styles = exports.MTableHeader = void 0;
+
+var _extends2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/extends")
+);
+
+var _objectSpread2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/objectSpread")
+);
+
+var _classCallCheck2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/classCallCheck")
+);
+
+var _createClass2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/createClass")
+);
+
+var _assertThisInitialized2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/assertThisInitialized")
+);
+
+var _inherits2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/inherits")
+);
+
+var _possibleConstructorReturn2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/possibleConstructorReturn")
+);
+
+var _getPrototypeOf2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/getPrototypeOf")
+);
+
+var _defineProperty2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/defineProperty")
+);
+
+var React = _interopRequireWildcard(require("react"));
+
+var _propTypes = _interopRequireDefault(require("prop-types"));
+
+var _TableHead = _interopRequireDefault(require("@material-ui/core/TableHead"));
+
+var _TableRow = _interopRequireDefault(require("@material-ui/core/TableRow"));
+
+var _TableCell = _interopRequireDefault(require("@material-ui/core/TableCell"));
+
+var _TableSortLabel = _interopRequireDefault(
+  require("@material-ui/core/TableSortLabel")
+);
+
+var _Checkbox = _interopRequireDefault(require("@material-ui/core/Checkbox"));
+
+var _withStyles = _interopRequireDefault(
+  require("@material-ui/core/styles/withStyles")
+);
+
+var _reactBeautifulDnd = require("react-beautiful-dnd");
+
+var _core = require("@material-ui/core");
+
+var CommonValues = _interopRequireWildcard(require("../utils/common-values"));
+
+var _fastDeepEqual = _interopRequireDefault(require("fast-deep-equal"));
+
+function _createSuper(Derived) {
+  var hasNativeReflectConstruct = _isNativeReflectConstruct();
+  return function _createSuperInternal() {
+    var Super = (0, _getPrototypeOf2.default)(Derived),
+      result;
+    if (hasNativeReflectConstruct) {
+      var NewTarget = (0, _getPrototypeOf2.default)(this).constructor;
+      result = Reflect.construct(Super, arguments, NewTarget);
+    } else {
+      result = Super.apply(this, arguments);
+    }
+    return (0, _possibleConstructorReturn2.default)(this, result);
+  };
+}
+
+function _isNativeReflectConstruct() {
+  if (typeof Reflect === "undefined" || !Reflect.construct) return false;
+  if (Reflect.construct.sham) return false;
+  if (typeof Proxy === "function") return true;
+  try {
+    Date.prototype.toString.call(Reflect.construct(Date, [], function () {}));
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
+/* eslint-enable no-unused-vars */
+var MTableHeader = /*#__PURE__*/ (function (_React$Component) {
+  (0, _inherits2.default)(MTableHeader, _React$Component);
+
+  var _super = _createSuper(MTableHeader);
+
+  function MTableHeader(props) {
+    var _this;
+
+    (0, _classCallCheck2.default)(this, MTableHeader);
+    _this = _super.call(this, props);
+    (0, _defineProperty2.default)(
+      (0, _assertThisInitialized2.default)(_this),
+      "handleMouseDown",
+      function (e, columnDef) {
+        _this.setState({
+          lastAdditionalWidth: columnDef.tableData.additionalWidth,
+          lastX: e.clientX,
+          resizingColumnDef: columnDef,
+        });
+      }
+    );
+    (0, _defineProperty2.default)(
+      (0, _assertThisInitialized2.default)(_this),
+      "handleMouseMove",
+      function (e) {
+        if (!_this.state.resizingColumnDef) {
+          return;
+        }
+
+        var additionalWidth =
+          _this.state.lastAdditionalWidth + e.clientX - _this.state.lastX;
+        additionalWidth = Math.min(
+          _this.state.resizingColumnDef.maxWidth || additionalWidth,
+          additionalWidth
+        );
+
+        if (
+          _this.state.resizingColumnDef.tableData.additionalWidth !==
+          additionalWidth
+        ) {
+          _this.props.onColumnResized(
+            _this.state.resizingColumnDef.tableData.id,
+            additionalWidth
+          );
+        }
+      }
+    );
+    (0, _defineProperty2.default)(
+      (0, _assertThisInitialized2.default)(_this),
+      "handleMouseUp",
+      function (e) {
+        _this.setState({
+          resizingColumnDef: undefined,
+        });
+      }
+    );
+    (0, _defineProperty2.default)(
+      (0, _assertThisInitialized2.default)(_this),
+      "getCellStyle",
+      function (columnDef) {
+        var width = CommonValues.reducePercentsInCalc(
+          columnDef.tableData.width,
+          _this.props.scrollWidth
+        );
+        var style = (0, _objectSpread2.default)(
+          {},
+          _this.props.headerStyle,
+          columnDef.headerStyle,
+          {
+            boxSizing: "border-box",
+            width: width,
+            maxWidth: columnDef.maxWidth,
+            minWidth: columnDef.minWidth,
+          }
+        );
+
+        if (
+          _this.props.options.tableLayout === "fixed" &&
+          _this.props.options.columnResizable &&
+          columnDef.resizable !== false
+        ) {
+          style.paddingRight = 2;
+        }
+
+        return style;
+      }
+    );
+    _this.state = {
+      lastX: 0,
+      resizingColumnDef: undefined,
+    };
+    return _this;
+  } // shouldComponentUpdate(nextProps, nextState){
+  //   return !equal(nextProps, this.props) || !equal(nextState, this.state);
+  // }
+
+  (0, _createClass2.default)(MTableHeader, [
+    {
+      key: "componentDidMount",
+      value: function componentDidMount() {
+        document.addEventListener("mousemove", this.handleMouseMove);
+        document.addEventListener("mouseup", this.handleMouseUp);
+      },
+    },
+    {
+      key: "componentWillUnmount",
+      value: function componentWillUnmount() {
+        document.removeEventListener("mousemove", this.handleMouseMove);
+        document.removeEventListener("mouseup", this.handleMouseUp);
+      },
+    },
+    {
+      key: "renderHeader",
+      value: function renderHeader() {
+        var _this2 = this;
+
+        var size =
+          this.props.options.padding === "default" ? "medium" : "small";
+        var mapArr = this.props.columns
+          .filter(function (columnDef) {
+            return !columnDef.hidden && !(columnDef.tableData.groupOrder > -1);
+          })
+          .sort(function (a, b) {
+            return a.tableData.columnOrder - b.tableData.columnOrder;
+          })
+          .map(function (columnDef, index) {
+            var content = columnDef.title;
+
+            if (_this2.props.draggable) {
+              content = /*#__PURE__*/ React.createElement(
+                _reactBeautifulDnd.Draggable,
+                {
+                  key: columnDef.tableData.id,
+                  draggableId: columnDef.tableData.id.toString(),
+                  index: index,
+                },
+                function (provided, snapshot) {
+                  return /*#__PURE__*/ React.createElement(
+                    "div",
+                    (0, _extends2.default)(
+                      {
+                        ref: provided.innerRef,
+                      },
+                      provided.draggableProps,
+                      provided.dragHandleProps
+                    ),
+                    columnDef.title
+                  );
+                }
+              );
+            }
+
+            if (columnDef.sorting !== false && _this2.props.sorting) {
+              content = /*#__PURE__*/ React.createElement(
+                _TableSortLabel.default,
+                {
+                  IconComponent: _this2.props.icons.SortArrow,
+                  active: _this2.props.orderBy === columnDef.tableData.id,
+                  direction: _this2.props.orderDirection || "asc",
+                  onClick: function onClick() {
+                    var orderDirection =
+                      columnDef.tableData.id !== _this2.props.orderBy
+                        ? "asc"
+                        : _this2.props.orderDirection === "asc"
+                        ? "desc"
+                        : _this2.props.orderDirection === "desc" &&
+                          _this2.props.thirdSortClick
+                        ? ""
+                        : _this2.props.orderDirection === "desc" &&
+                          !_this2.props.thirdSortClick
+                        ? "asc"
+                        : _this2.props.orderDirection === ""
+                        ? "asc"
+                        : "desc";
+
+                    _this2.props.onOrderChange(
+                      columnDef.tableData.id,
+                      orderDirection
+                    );
+                  },
+                },
+                content
+              );
+            }
+
+            if (columnDef.tooltip) {
+              content = /*#__PURE__*/ React.createElement(
+                _core.Tooltip,
+                {
+                  title: columnDef.tooltip,
+                  placement: "bottom",
+                },
+                /*#__PURE__*/ React.createElement("span", null, content)
+              );
+            }
+
+            if (
+              _this2.props.options.tableLayout === "fixed" &&
+              _this2.props.options.columnResizable &&
+              columnDef.resizable !== false
+            ) {
+              content = /*#__PURE__*/ React.createElement(
+                "div",
+                {
+                  style: {
+                    display: "flex",
+                    alignItems: "center",
+                  },
+                },
+                /*#__PURE__*/ React.createElement(
+                  "div",
+                  {
+                    style: {
+                      flex: 1,
+                    },
+                  },
+                  content
+                ),
+                /*#__PURE__*/ React.createElement("div", null),
+                /*#__PURE__*/ React.createElement(_this2.props.icons.Resize, {
+                  style: {
+                    cursor: "col-resize",
+                    color:
+                      _this2.state.resizingColumnDef &&
+                      _this2.state.resizingColumnDef.tableData.id ===
+                        columnDef.tableData.id
+                        ? _this2.props.theme.palette.primary.main
+                        : "inherit",
+                  },
+                  onMouseDown: function onMouseDown(e) {
+                    return _this2.handleMouseDown(e, columnDef);
+                  },
+                })
+              );
+            }
+
+            var cellAlignment =
+              columnDef.align !== undefined
+                ? columnDef.align
+                : ["numeric", "currency"].indexOf(columnDef.type) !== -1
+                ? "right"
+                : "left";
+            return /*#__PURE__*/ React.createElement(
+              _TableCell.default,
+              {
+                key: columnDef.tableData.id,
+                align: cellAlignment,
+                className: _this2.props.classes.header,
+                style: _this2.getCellStyle(columnDef),
+                size: size,
+              },
+              content
+            );
+          });
+        return mapArr;
+      },
+    },
+    {
+      key: "renderActionsHeader",
+      value: function renderActionsHeader() {
+        var localization = (0, _objectSpread2.default)(
+          {},
+          MTableHeader.defaultProps.localization,
+          this.props.localization
+        );
+        var width = CommonValues.actionsColumnWidth(this.props);
+        return /*#__PURE__*/ React.createElement(
+          _TableCell.default,
+          {
+            key: "key-actions-column",
+            padding: "checkbox",
+            className: this.props.classes.header,
+            style: (0, _objectSpread2.default)({}, this.props.headerStyle, {
+              width: width,
+              textAlign: "center",
+              boxSizing: "border-box",
+            }),
+          },
+          /*#__PURE__*/ React.createElement(
+            _TableSortLabel.default,
+            {
+              hideSortIcon: true,
+              disabled: true,
+            },
+            localization.actions
+          )
+        );
+      },
+    },
+    {
+      key: "renderSelectionHeader",
+      value: function renderSelectionHeader() {
+        var _this3 = this;
+
+        var selectionWidth = CommonValues.selectionMaxWidth(
+          this.props,
+          this.props.treeDataMaxLevel
+        );
+        return /*#__PURE__*/ React.createElement(
+          _TableCell.default,
+          {
+            padding: "none",
+            key: "key-selection-column",
+            className: this.props.classes.header,
+            style: (0, _objectSpread2.default)({}, this.props.headerStyle, {
+              width: selectionWidth,
+            }),
+          },
+          this.props.showSelectAllCheckbox &&
+            /*#__PURE__*/ React.createElement(
+              _Checkbox.default,
+              (0, _extends2.default)(
+                {
+                  indeterminate:
+                    this.props.selectedCount > 0 &&
+                    this.props.selectedCount < this.props.dataCount,
+                  checked:
+                    this.props.dataCount > 0 &&
+                    this.props.selectedCount === this.props.dataCount,
+                  onChange: function onChange(event, checked) {
+                    return (
+                      _this3.props.onAllSelected &&
+                      _this3.props.onAllSelected(checked)
+                    );
+                  },
+                },
+                this.props.options.headerSelectionProps
+              )
+            )
+        );
+      },
+    },
+    {
+      key: "renderDetailPanelColumnCell",
+      value: function renderDetailPanelColumnCell() {
+        return /*#__PURE__*/ React.createElement(_TableCell.default, {
+          padding: "none",
+          key: "key-detail-panel-column",
+          className: this.props.classes.header,
+          style: (0, _objectSpread2.default)({}, this.props.headerStyle),
+        });
+      },
+    },
+    {
+      key: "render",
+      value: function render() {
+        var _this4 = this;
+
+        var headers = this.renderHeader();
+
+        if (this.props.hasSelection) {
+          headers.splice(0, 0, this.renderSelectionHeader());
+        }
+
+        if (this.props.showActionsColumn) {
+          if (this.props.actionsHeaderIndex >= 0) {
+            var endPos = 0;
+
+            if (this.props.hasSelection) {
+              endPos = 1;
+            }
+
+            headers.splice(
+              this.props.actionsHeaderIndex + endPos,
+              0,
+              this.renderActionsHeader()
+            );
+          } else if (this.props.actionsHeaderIndex === -1) {
+            headers.push(this.renderActionsHeader());
+          }
+        }
+
+        if (this.props.hasDetailPanel) {
+          if (this.props.detailPanelColumnAlignment === "right") {
+            headers.push(this.renderDetailPanelColumnCell());
+          } else {
+            headers.splice(0, 0, this.renderDetailPanelColumnCell());
+          }
+        }
+
+        if (this.props.isTreeData > 0) {
+          headers.splice(
+            0,
+            0,
+            /*#__PURE__*/ React.createElement(_TableCell.default, {
+              padding: "none",
+              key: "key-tree-data-header",
+              className: this.props.classes.header,
+              style: (0, _objectSpread2.default)({}, this.props.headerStyle),
+            })
+          );
+        }
+
+        this.props.columns
+          .filter(function (columnDef) {
+            return columnDef.tableData.groupOrder > -1;
+          })
+          .forEach(function (columnDef) {
+            headers.splice(
+              0,
+              0,
+              /*#__PURE__*/ React.createElement(_TableCell.default, {
+                padding: "checkbox",
+                key: "key-group-header" + columnDef.tableData.id,
+                className: _this4.props.classes.header,
+              })
+            );
+          });
+        return /*#__PURE__*/ React.createElement(
+          _TableHead.default,
+          null,
+          /*#__PURE__*/ React.createElement(_TableRow.default, null, headers)
+        );
+      },
+    },
+  ]);
+  return MTableHeader;
+})(React.Component);
+
+exports.MTableHeader = MTableHeader;
+MTableHeader.defaultProps = {
+  dataCount: 0,
+  hasSelection: false,
+  headerStyle: {},
+  selectedCount: 0,
+  sorting: true,
+  localization: {
+    actions: "Actions",
+  },
+  orderBy: undefined,
+  orderDirection: "asc",
+  actionsHeaderIndex: 0,
+  detailPanelColumnAlignment: "left",
+  draggable: true,
+  thirdSortClick: true,
+};
+MTableHeader.propTypes = {
+  columns: _propTypes.default.array.isRequired,
+  dataCount: _propTypes.default.number,
+  hasDetailPanel: _propTypes.default.bool.isRequired,
+  detailPanelColumnAlignment: _propTypes.default.string,
+  hasSelection: _propTypes.default.bool,
+  headerStyle: _propTypes.default.object,
+  localization: _propTypes.default.object,
+  selectedCount: _propTypes.default.number,
+  sorting: _propTypes.default.bool,
+  onAllSelected: _propTypes.default.func,
+  onOrderChange: _propTypes.default.func,
+  orderBy: _propTypes.default.number,
+  orderDirection: _propTypes.default.string,
+  actionsHeaderIndex: _propTypes.default.number,
+  showActionsColumn: _propTypes.default.bool,
+  showSelectAllCheckbox: _propTypes.default.bool,
+  draggable: _propTypes.default.bool,
+  thirdSortClick: _propTypes.default.bool,
+  tooltip: _propTypes.default.string,
+};
+
+var styles = function styles(theme) {
+  return {
+    header: {
+      // display: 'inline-block',
+      position: "sticky",
+      top: 0,
+      zIndex: 10,
+      backgroundColor: theme.palette.background.paper, // Change according to theme,
+    },
+  };
+};
+
+exports.styles = styles;
+
+var _default = (0, _withStyles.default)(styles, {
+  withTheme: true,
+})(MTableHeader);
+
+exports.default = _default;

--- a/dist/components/m-table-pagination.js
+++ b/dist/components/m-table-pagination.js
@@ -1,0 +1,346 @@
+"use strict";
+
+var _interopRequireWildcard = require("@babel/runtime/helpers/interopRequireWildcard");
+
+var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
+
+Object.defineProperty(exports, "__esModule", {
+  value: true,
+});
+exports.default = void 0;
+
+var _objectSpread2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/objectSpread")
+);
+
+var _classCallCheck2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/classCallCheck")
+);
+
+var _createClass2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/createClass")
+);
+
+var _assertThisInitialized2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/assertThisInitialized")
+);
+
+var _inherits2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/inherits")
+);
+
+var _possibleConstructorReturn2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/possibleConstructorReturn")
+);
+
+var _getPrototypeOf2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/getPrototypeOf")
+);
+
+var _defineProperty2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/defineProperty")
+);
+
+var _IconButton = _interopRequireDefault(
+  require("@material-ui/core/IconButton")
+);
+
+var _withStyles = _interopRequireDefault(
+  require("@material-ui/core/styles/withStyles")
+);
+
+var _Tooltip = _interopRequireDefault(require("@material-ui/core/Tooltip"));
+
+var _Typography = _interopRequireDefault(
+  require("@material-ui/core/Typography")
+);
+
+var _propTypes = _interopRequireDefault(require("prop-types"));
+
+var React = _interopRequireWildcard(require("react"));
+
+function _createSuper(Derived) {
+  var hasNativeReflectConstruct = _isNativeReflectConstruct();
+  return function _createSuperInternal() {
+    var Super = (0, _getPrototypeOf2.default)(Derived),
+      result;
+    if (hasNativeReflectConstruct) {
+      var NewTarget = (0, _getPrototypeOf2.default)(this).constructor;
+      result = Reflect.construct(Super, arguments, NewTarget);
+    } else {
+      result = Super.apply(this, arguments);
+    }
+    return (0, _possibleConstructorReturn2.default)(this, result);
+  };
+}
+
+function _isNativeReflectConstruct() {
+  if (typeof Reflect === "undefined" || !Reflect.construct) return false;
+  if (Reflect.construct.sham) return false;
+  if (typeof Proxy === "function") return true;
+  try {
+    Date.prototype.toString.call(Reflect.construct(Date, [], function () {}));
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
+/* eslint-enable no-unused-vars */
+var MTablePaginationInner = /*#__PURE__*/ (function (_React$Component) {
+  (0, _inherits2.default)(MTablePaginationInner, _React$Component);
+
+  var _super = _createSuper(MTablePaginationInner);
+
+  function MTablePaginationInner() {
+    var _this;
+
+    (0, _classCallCheck2.default)(this, MTablePaginationInner);
+
+    for (
+      var _len = arguments.length, args = new Array(_len), _key = 0;
+      _key < _len;
+      _key++
+    ) {
+      args[_key] = arguments[_key];
+    }
+
+    _this = _super.call.apply(_super, [this].concat(args));
+    (0, _defineProperty2.default)(
+      (0, _assertThisInitialized2.default)(_this),
+      "handleFirstPageButtonClick",
+      function (event) {
+        _this.props.onChangePage(event, 0);
+      }
+    );
+    (0, _defineProperty2.default)(
+      (0, _assertThisInitialized2.default)(_this),
+      "handleBackButtonClick",
+      function (event) {
+        _this.props.onChangePage(event, _this.props.page - 1);
+      }
+    );
+    (0, _defineProperty2.default)(
+      (0, _assertThisInitialized2.default)(_this),
+      "handleNextButtonClick",
+      function (event) {
+        _this.props.onChangePage(event, _this.props.page + 1);
+      }
+    );
+    (0, _defineProperty2.default)(
+      (0, _assertThisInitialized2.default)(_this),
+      "handleLastPageButtonClick",
+      function (event) {
+        _this.props.onChangePage(
+          event,
+          Math.max(
+            0,
+            Math.ceil(_this.props.count / _this.props.rowsPerPage) - 1
+          )
+        );
+      }
+    );
+    return _this;
+  }
+
+  (0, _createClass2.default)(MTablePaginationInner, [
+    {
+      key: "render",
+      value: function render() {
+        var _this$props = this.props,
+          classes = _this$props.classes,
+          count = _this$props.count,
+          page = _this$props.page,
+          rowsPerPage = _this$props.rowsPerPage,
+          theme = _this$props.theme,
+          showFirstLastPageButtons = _this$props.showFirstLastPageButtons;
+        var localization = (0, _objectSpread2.default)(
+          {},
+          MTablePaginationInner.defaultProps.localization,
+          this.props.localization
+        );
+        return /*#__PURE__*/ React.createElement(
+          "div",
+          {
+            className: classes.root,
+          },
+          showFirstLastPageButtons &&
+            /*#__PURE__*/ React.createElement(
+              _Tooltip.default,
+              {
+                title: localization.firstTooltip,
+              },
+              /*#__PURE__*/ React.createElement(
+                "span",
+                null,
+                /*#__PURE__*/ React.createElement(
+                  _IconButton.default,
+                  {
+                    onClick: this.handleFirstPageButtonClick,
+                    disabled: page === 0,
+                    "aria-label": localization.firstAriaLabel,
+                  },
+                  theme.direction === "rtl"
+                    ? /*#__PURE__*/ React.createElement(
+                        this.props.icons.LastPage,
+                        null
+                      )
+                    : /*#__PURE__*/ React.createElement(
+                        this.props.icons.FirstPage,
+                        null
+                      )
+                )
+              )
+            ),
+          /*#__PURE__*/ React.createElement(
+            _Tooltip.default,
+            {
+              title: localization.previousTooltip,
+            },
+            /*#__PURE__*/ React.createElement(
+              "span",
+              null,
+              /*#__PURE__*/ React.createElement(
+                _IconButton.default,
+                {
+                  onClick: this.handleBackButtonClick,
+                  disabled: page === 0,
+                  "aria-label": localization.previousAriaLabel,
+                },
+                theme.direction === "rtl"
+                  ? /*#__PURE__*/ React.createElement(
+                      this.props.icons.NextPage,
+                      null
+                    )
+                  : /*#__PURE__*/ React.createElement(
+                      this.props.icons.PreviousPage,
+                      null
+                    )
+              )
+            )
+          ),
+          /*#__PURE__*/ React.createElement(
+            _Typography.default,
+            {
+              variant: "caption",
+              style: {
+                flex: 1,
+                textAlign: "center",
+                alignSelf: "center",
+                flexBasis: "inherit",
+              },
+            },
+            localization.labelDisplayedRows
+              .replace(
+                "{from}",
+                this.props.count === 0
+                  ? 0
+                  : this.props.page * this.props.rowsPerPage + 1
+              )
+              .replace(
+                "{to}",
+                Math.min(
+                  (this.props.page + 1) * this.props.rowsPerPage,
+                  this.props.count
+                )
+              )
+              .replace("{count}", this.props.count)
+          ),
+          /*#__PURE__*/ React.createElement(
+            _Tooltip.default,
+            {
+              title: localization.nextTooltip,
+            },
+            /*#__PURE__*/ React.createElement(
+              "span",
+              null,
+              /*#__PURE__*/ React.createElement(
+                _IconButton.default,
+                {
+                  onClick: this.handleNextButtonClick,
+                  disabled: page >= Math.ceil(count / rowsPerPage) - 1,
+                  "aria-label": localization.nextAriaLabel,
+                },
+                theme.direction === "rtl"
+                  ? /*#__PURE__*/ React.createElement(
+                      this.props.icons.PreviousPage,
+                      null
+                    )
+                  : /*#__PURE__*/ React.createElement(
+                      this.props.icons.NextPage,
+                      null
+                    )
+              )
+            )
+          ),
+          showFirstLastPageButtons &&
+            /*#__PURE__*/ React.createElement(
+              _Tooltip.default,
+              {
+                title: localization.lastTooltip,
+              },
+              /*#__PURE__*/ React.createElement(
+                "span",
+                null,
+                /*#__PURE__*/ React.createElement(
+                  _IconButton.default,
+                  {
+                    onClick: this.handleLastPageButtonClick,
+                    disabled: page >= Math.ceil(count / rowsPerPage) - 1,
+                    "aria-label": localization.lastAriaLabel,
+                  },
+                  theme.direction === "rtl"
+                    ? /*#__PURE__*/ React.createElement(
+                        this.props.icons.FirstPage,
+                        null
+                      )
+                    : /*#__PURE__*/ React.createElement(
+                        this.props.icons.LastPage,
+                        null
+                      )
+                )
+              )
+            )
+        );
+      },
+    },
+  ]);
+  return MTablePaginationInner;
+})(React.Component);
+
+var actionsStyles = function actionsStyles(theme) {
+  return {
+    root: {
+      flexShrink: 0,
+      color: theme.palette.text.secondary,
+      display: "flex", // lineHeight: '48px'
+    },
+  };
+};
+
+MTablePaginationInner.propTypes = {
+  onChangePage: _propTypes.default.func,
+  page: _propTypes.default.number,
+  count: _propTypes.default.number,
+  rowsPerPage: _propTypes.default.number,
+  classes: _propTypes.default.object,
+  localization: _propTypes.default.object,
+  theme: _propTypes.default.any,
+  showFirstLastPageButtons: _propTypes.default.bool,
+};
+MTablePaginationInner.defaultProps = {
+  showFirstLastPageButtons: true,
+  localization: {
+    firstTooltip: "First Page",
+    previousTooltip: "Previous Page",
+    nextTooltip: "Next Page",
+    lastTooltip: "Last Page",
+    labelDisplayedRows: "{from}-{to} of {count}",
+    labelRowsPerPage: "Rows per page:",
+  },
+};
+var MTablePagination = (0, _withStyles.default)(actionsStyles, {
+  withTheme: true,
+})(MTablePaginationInner);
+var _default = MTablePagination;
+exports.default = _default;

--- a/dist/components/m-table-stepped-pagination.js
+++ b/dist/components/m-table-stepped-pagination.js
@@ -1,0 +1,360 @@
+"use strict";
+
+var _interopRequireWildcard = require("@babel/runtime/helpers/interopRequireWildcard");
+
+var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
+
+Object.defineProperty(exports, "__esModule", {
+  value: true,
+});
+exports.default = void 0;
+
+var _objectSpread2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/objectSpread")
+);
+
+var _classCallCheck2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/classCallCheck")
+);
+
+var _createClass2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/createClass")
+);
+
+var _assertThisInitialized2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/assertThisInitialized")
+);
+
+var _inherits2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/inherits")
+);
+
+var _possibleConstructorReturn2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/possibleConstructorReturn")
+);
+
+var _getPrototypeOf2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/getPrototypeOf")
+);
+
+var _defineProperty2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/defineProperty")
+);
+
+var _IconButton = _interopRequireDefault(
+  require("@material-ui/core/IconButton")
+);
+
+var _withStyles = _interopRequireDefault(
+  require("@material-ui/core/styles/withStyles")
+);
+
+var _Tooltip = _interopRequireDefault(require("@material-ui/core/Tooltip"));
+
+var _Hidden = _interopRequireDefault(require("@material-ui/core/Hidden"));
+
+var _Button = _interopRequireDefault(require("@material-ui/core/Button"));
+
+var _propTypes = _interopRequireDefault(require("prop-types"));
+
+var React = _interopRequireWildcard(require("react"));
+
+function _createSuper(Derived) {
+  var hasNativeReflectConstruct = _isNativeReflectConstruct();
+  return function _createSuperInternal() {
+    var Super = (0, _getPrototypeOf2.default)(Derived),
+      result;
+    if (hasNativeReflectConstruct) {
+      var NewTarget = (0, _getPrototypeOf2.default)(this).constructor;
+      result = Reflect.construct(Super, arguments, NewTarget);
+    } else {
+      result = Super.apply(this, arguments);
+    }
+    return (0, _possibleConstructorReturn2.default)(this, result);
+  };
+}
+
+function _isNativeReflectConstruct() {
+  if (typeof Reflect === "undefined" || !Reflect.construct) return false;
+  if (Reflect.construct.sham) return false;
+  if (typeof Proxy === "function") return true;
+  try {
+    Date.prototype.toString.call(Reflect.construct(Date, [], function () {}));
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
+/* eslint-enable no-unused-vars */
+var MTablePaginationInner = /*#__PURE__*/ (function (_React$Component) {
+  (0, _inherits2.default)(MTablePaginationInner, _React$Component);
+
+  var _super = _createSuper(MTablePaginationInner);
+
+  function MTablePaginationInner() {
+    var _this;
+
+    (0, _classCallCheck2.default)(this, MTablePaginationInner);
+
+    for (
+      var _len = arguments.length, args = new Array(_len), _key = 0;
+      _key < _len;
+      _key++
+    ) {
+      args[_key] = arguments[_key];
+    }
+
+    _this = _super.call.apply(_super, [this].concat(args));
+    (0, _defineProperty2.default)(
+      (0, _assertThisInitialized2.default)(_this),
+      "handleFirstPageButtonClick",
+      function (event) {
+        _this.props.onChangePage(event, 0);
+      }
+    );
+    (0, _defineProperty2.default)(
+      (0, _assertThisInitialized2.default)(_this),
+      "handleBackButtonClick",
+      function (event) {
+        _this.props.onChangePage(event, _this.props.page - 1);
+      }
+    );
+    (0, _defineProperty2.default)(
+      (0, _assertThisInitialized2.default)(_this),
+      "handleNextButtonClick",
+      function (event) {
+        _this.props.onChangePage(event, _this.props.page + 1);
+      }
+    );
+    (0, _defineProperty2.default)(
+      (0, _assertThisInitialized2.default)(_this),
+      "handleNumberButtonClick",
+      function (number) {
+        return function (event) {
+          _this.props.onChangePage(event, number);
+        };
+      }
+    );
+    (0, _defineProperty2.default)(
+      (0, _assertThisInitialized2.default)(_this),
+      "handleLastPageButtonClick",
+      function (event) {
+        _this.props.onChangePage(
+          event,
+          Math.max(
+            0,
+            Math.ceil(_this.props.count / _this.props.rowsPerPage) - 1
+          )
+        );
+      }
+    );
+    return _this;
+  }
+
+  (0, _createClass2.default)(MTablePaginationInner, [
+    {
+      key: "renderPagesButton",
+      value: function renderPagesButton(start, end) {
+        var buttons = [];
+
+        for (var p = start; p <= end; p++) {
+          var buttonVariant = p === this.props.page ? "contained" : "text";
+          buttons.push(
+            /*#__PURE__*/ React.createElement(
+              _Button.default,
+              {
+                size: "small",
+                style: {
+                  boxShadow: "none",
+                  maxWidth: "30px",
+                  maxHeight: "30px",
+                  minWidth: "30px",
+                  minHeight: "30px",
+                },
+                disabled: p === this.props.page,
+                variant: buttonVariant,
+                onClick: this.handleNumberButtonClick(p),
+                key: p,
+              },
+              p + 1
+            )
+          );
+        }
+
+        return /*#__PURE__*/ React.createElement("span", null, buttons);
+      },
+    },
+    {
+      key: "render",
+      value: function render() {
+        var _this$props = this.props,
+          classes = _this$props.classes,
+          count = _this$props.count,
+          page = _this$props.page,
+          rowsPerPage = _this$props.rowsPerPage,
+          theme = _this$props.theme,
+          showFirstLastPageButtons = _this$props.showFirstLastPageButtons;
+        var localization = (0, _objectSpread2.default)(
+          {},
+          MTablePaginationInner.defaultProps.localization,
+          this.props.localization
+        );
+        var maxPages = Math.ceil(count / rowsPerPage) - 1;
+        var pageStart = Math.max(page - 1, 0);
+        var pageEnd = Math.min(maxPages, page + 1);
+        return /*#__PURE__*/ React.createElement(
+          "div",
+          {
+            className: classes.root,
+          },
+          showFirstLastPageButtons &&
+            /*#__PURE__*/ React.createElement(
+              _Tooltip.default,
+              {
+                title: localization.firstTooltip,
+              },
+              /*#__PURE__*/ React.createElement(
+                "span",
+                null,
+                /*#__PURE__*/ React.createElement(
+                  _IconButton.default,
+                  {
+                    onClick: this.handleFirstPageButtonClick,
+                    disabled: page === 0,
+                    "aria-label": localization.firstAriaLabel,
+                  },
+                  theme.direction === "rtl"
+                    ? /*#__PURE__*/ React.createElement(
+                        this.props.icons.LastPage,
+                        null
+                      )
+                    : /*#__PURE__*/ React.createElement(
+                        this.props.icons.FirstPage,
+                        null
+                      )
+                )
+              )
+            ),
+          /*#__PURE__*/ React.createElement(
+            _Tooltip.default,
+            {
+              title: localization.previousTooltip,
+            },
+            /*#__PURE__*/ React.createElement(
+              "span",
+              null,
+              /*#__PURE__*/ React.createElement(
+                _IconButton.default,
+                {
+                  onClick: this.handleBackButtonClick,
+                  disabled: page === 0,
+                  "aria-label": localization.previousAriaLabel,
+                },
+                /*#__PURE__*/ React.createElement(
+                  this.props.icons.PreviousPage,
+                  null
+                )
+              )
+            )
+          ),
+          /*#__PURE__*/ React.createElement(
+            _Hidden.default,
+            {
+              smDown: true,
+            },
+            this.renderPagesButton(pageStart, pageEnd)
+          ),
+          /*#__PURE__*/ React.createElement(
+            _Tooltip.default,
+            {
+              title: localization.nextTooltip,
+            },
+            /*#__PURE__*/ React.createElement(
+              "span",
+              null,
+              /*#__PURE__*/ React.createElement(
+                _IconButton.default,
+                {
+                  onClick: this.handleNextButtonClick,
+                  disabled: page >= maxPages,
+                  "aria-label": localization.nextAriaLabel,
+                },
+                /*#__PURE__*/ React.createElement(
+                  this.props.icons.NextPage,
+                  null
+                )
+              )
+            )
+          ),
+          showFirstLastPageButtons &&
+            /*#__PURE__*/ React.createElement(
+              _Tooltip.default,
+              {
+                title: localization.lastTooltip,
+              },
+              /*#__PURE__*/ React.createElement(
+                "span",
+                null,
+                /*#__PURE__*/ React.createElement(
+                  _IconButton.default,
+                  {
+                    onClick: this.handleLastPageButtonClick,
+                    disabled: page >= Math.ceil(count / rowsPerPage) - 1,
+                    "aria-label": localization.lastAriaLabel,
+                  },
+                  theme.direction === "rtl"
+                    ? /*#__PURE__*/ React.createElement(
+                        this.props.icons.FirstPage,
+                        null
+                      )
+                    : /*#__PURE__*/ React.createElement(
+                        this.props.icons.LastPage,
+                        null
+                      )
+                )
+              )
+            )
+        );
+      },
+    },
+  ]);
+  return MTablePaginationInner;
+})(React.Component);
+
+var actionsStyles = function actionsStyles(theme) {
+  return {
+    root: {
+      flexShrink: 0,
+      color: theme.palette.text.secondary,
+      marginLeft: theme.spacing(2.5),
+    },
+  };
+};
+
+MTablePaginationInner.propTypes = {
+  onChangePage: _propTypes.default.func,
+  page: _propTypes.default.number,
+  count: _propTypes.default.number,
+  rowsPerPage: _propTypes.default.number,
+  classes: _propTypes.default.object,
+  localization: _propTypes.default.object,
+  theme: _propTypes.default.any,
+  showFirstLastPageButtons: _propTypes.default.bool,
+};
+MTablePaginationInner.defaultProps = {
+  showFirstLastPageButtons: true,
+  localization: {
+    firstTooltip: "First Page",
+    previousTooltip: "Previous Page",
+    nextTooltip: "Next Page",
+    lastTooltip: "Last Page",
+    labelDisplayedRows: "{from}-{to} of {count}",
+    labelRowsPerPage: "Rows per page:",
+  },
+};
+var MTableSteppedPagination = (0, _withStyles.default)(actionsStyles, {
+  withTheme: true,
+})(MTablePaginationInner);
+var _default = MTableSteppedPagination;
+exports.default = _default;

--- a/dist/components/m-table-toolbar.js
+++ b/dist/components/m-table-toolbar.js
@@ -1,0 +1,761 @@
+"use strict";
+
+var _interopRequireWildcard = require("@babel/runtime/helpers/interopRequireWildcard");
+
+var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
+
+Object.defineProperty(exports, "__esModule", {
+  value: true,
+});
+exports.default = exports.styles = exports.MTableToolbar = void 0;
+
+var _objectSpread2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/objectSpread")
+);
+
+var _slicedToArray2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/slicedToArray")
+);
+
+var _classCallCheck2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/classCallCheck")
+);
+
+var _createClass2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/createClass")
+);
+
+var _assertThisInitialized2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/assertThisInitialized")
+);
+
+var _inherits2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/inherits")
+);
+
+var _possibleConstructorReturn2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/possibleConstructorReturn")
+);
+
+var _getPrototypeOf2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/getPrototypeOf")
+);
+
+var _defineProperty2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/defineProperty")
+);
+
+var _Checkbox = _interopRequireDefault(require("@material-ui/core/Checkbox"));
+
+var _FormControlLabel = _interopRequireDefault(
+  require("@material-ui/core/FormControlLabel")
+);
+
+var _IconButton = _interopRequireDefault(
+  require("@material-ui/core/IconButton")
+);
+
+var _InputAdornment = _interopRequireDefault(
+  require("@material-ui/core/InputAdornment")
+);
+
+var _Menu = _interopRequireDefault(require("@material-ui/core/Menu"));
+
+var _MenuItem = _interopRequireDefault(require("@material-ui/core/MenuItem"));
+
+var _TextField = _interopRequireDefault(require("@material-ui/core/TextField"));
+
+var _Toolbar = _interopRequireDefault(require("@material-ui/core/Toolbar"));
+
+var _Tooltip = _interopRequireDefault(require("@material-ui/core/Tooltip"));
+
+var _Typography = _interopRequireDefault(
+  require("@material-ui/core/Typography")
+);
+
+var _withStyles = _interopRequireDefault(
+  require("@material-ui/core/styles/withStyles")
+);
+
+var _colorManipulator = require("@material-ui/core/styles/colorManipulator");
+
+var _classnames = _interopRequireDefault(require("classnames"));
+
+var _filefy = require("filefy");
+
+var _propTypes = _interopRequireWildcard(require("prop-types"));
+
+require("jspdf-autotable");
+
+var React = _interopRequireWildcard(require("react"));
+
+function _createSuper(Derived) {
+  var hasNativeReflectConstruct = _isNativeReflectConstruct();
+  return function _createSuperInternal() {
+    var Super = (0, _getPrototypeOf2.default)(Derived),
+      result;
+    if (hasNativeReflectConstruct) {
+      var NewTarget = (0, _getPrototypeOf2.default)(this).constructor;
+      result = Reflect.construct(Super, arguments, NewTarget);
+    } else {
+      result = Super.apply(this, arguments);
+    }
+    return (0, _possibleConstructorReturn2.default)(this, result);
+  };
+}
+
+function _isNativeReflectConstruct() {
+  if (typeof Reflect === "undefined" || !Reflect.construct) return false;
+  if (Reflect.construct.sham) return false;
+  if (typeof Proxy === "function") return true;
+  try {
+    Date.prototype.toString.call(Reflect.construct(Date, [], function () {}));
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
+var jsPDF = typeof window !== "undefined" ? require("jspdf").jsPDF : null;
+/* eslint-enable no-unused-vars */
+
+var MTableToolbar = /*#__PURE__*/ (function (_React$Component) {
+  (0, _inherits2.default)(MTableToolbar, _React$Component);
+
+  var _super = _createSuper(MTableToolbar);
+
+  function MTableToolbar(props) {
+    var _this;
+
+    (0, _classCallCheck2.default)(this, MTableToolbar);
+    _this = _super.call(this, props);
+    (0, _defineProperty2.default)(
+      (0, _assertThisInitialized2.default)(_this),
+      "onSearchChange",
+      function (searchText) {
+        _this.props.dataManager.changeSearchText(searchText);
+
+        _this.setState(
+          {
+            searchText: searchText,
+          },
+          _this.props.onSearchChanged(searchText)
+        );
+      }
+    );
+    (0, _defineProperty2.default)(
+      (0, _assertThisInitialized2.default)(_this),
+      "getTableData",
+      function () {
+        var columns = _this.props.columns
+          .filter(function (columnDef) {
+            return (
+              (!columnDef.hidden || columnDef.export === true) &&
+              columnDef.export !== false &&
+              columnDef.field
+            );
+          })
+          .sort(function (a, b) {
+            return a.tableData.columnOrder > b.tableData.columnOrder ? 1 : -1;
+          });
+
+        var data = (_this.props.exportAllData
+          ? _this.props.data
+          : _this.props.renderData
+        ).map(function (rowData) {
+          return columns.map(function (columnDef) {
+            return _this.props.getFieldValue(rowData, columnDef);
+          });
+        });
+        return [columns, data];
+      }
+    );
+    (0, _defineProperty2.default)(
+      (0, _assertThisInitialized2.default)(_this),
+      "defaultExportCsv",
+      function () {
+        var _this$getTableData = _this.getTableData(),
+          _this$getTableData2 = (0, _slicedToArray2.default)(
+            _this$getTableData,
+            2
+          ),
+          columns = _this$getTableData2[0],
+          data = _this$getTableData2[1];
+
+        var fileName = _this.props.title || "data";
+
+        if (_this.props.exportFileName) {
+          fileName =
+            typeof _this.props.exportFileName === "function"
+              ? _this.props.exportFileName()
+              : _this.props.exportFileName;
+        }
+
+        var builder = new _filefy.CsvBuilder(fileName + ".csv");
+        builder
+          .setDelimeter(_this.props.exportDelimiter)
+          .setColumns(
+            columns.map(function (columnDef) {
+              return columnDef.title;
+            })
+          )
+          .addRows(data)
+          .exportFile();
+      }
+    );
+    (0, _defineProperty2.default)(
+      (0, _assertThisInitialized2.default)(_this),
+      "defaultExportPdf",
+      function () {
+        if (jsPDF !== null) {
+          var _this$getTableData3 = _this.getTableData(),
+            _this$getTableData4 = (0, _slicedToArray2.default)(
+              _this$getTableData3,
+              2
+            ),
+            columns = _this$getTableData4[0],
+            data = _this$getTableData4[1];
+
+          var content = {
+            startY: 50,
+            head: [
+              columns.map(function (columnDef) {
+                return columnDef.title;
+              }),
+            ],
+            body: data,
+          };
+          var unit = "pt";
+          var size = "A4";
+          var orientation = "landscape";
+          var doc = new jsPDF(orientation, unit, size);
+          doc.setFontSize(15);
+          doc.text(_this.props.exportFileName || _this.props.title, 40, 40);
+          doc.autoTable(content);
+          doc.save(
+            (_this.props.exportFileName || _this.props.title || "data") + ".pdf"
+          );
+        }
+      }
+    );
+    (0, _defineProperty2.default)(
+      (0, _assertThisInitialized2.default)(_this),
+      "exportCsv",
+      function () {
+        if (_this.props.exportCsv) {
+          _this.props.exportCsv(_this.props.columns, _this.props.data);
+        } else {
+          _this.defaultExportCsv();
+        }
+
+        _this.setState({
+          exportButtonAnchorEl: null,
+        });
+      }
+    );
+    (0, _defineProperty2.default)(
+      (0, _assertThisInitialized2.default)(_this),
+      "exportPdf",
+      function () {
+        if (_this.props.exportPdf) {
+          _this.props.exportPdf(_this.props.columns, _this.props.data);
+        } else {
+          _this.defaultExportPdf();
+        }
+
+        _this.setState({
+          exportButtonAnchorEl: null,
+        });
+      }
+    );
+    _this.state = {
+      columnsButtonAnchorEl: null,
+      exportButtonAnchorEl: null,
+      searchText: props.searchText,
+    };
+    return _this;
+  }
+
+  (0, _createClass2.default)(MTableToolbar, [
+    {
+      key: "renderSearch",
+      value: function renderSearch() {
+        var _this2 = this;
+
+        var localization = (0, _objectSpread2.default)(
+          {},
+          MTableToolbar.defaultProps.localization,
+          this.props.localization
+        );
+
+        if (this.props.search) {
+          return /*#__PURE__*/ React.createElement(_TextField.default, {
+            autoFocus: this.props.searchAutoFocus,
+            className:
+              this.props.searchFieldAlignment === "left" &&
+              this.props.showTitle === false
+                ? null
+                : this.props.classes.searchField,
+            value: this.state.searchText,
+            onChange: function onChange(event) {
+              return _this2.onSearchChange(event.target.value);
+            },
+            placeholder: localization.searchPlaceholder,
+            variant: this.props.searchFieldVariant,
+            InputProps: {
+              startAdornment: /*#__PURE__*/ React.createElement(
+                _InputAdornment.default,
+                {
+                  position: "start",
+                },
+                /*#__PURE__*/ React.createElement(
+                  _Tooltip.default,
+                  {
+                    title: localization.searchTooltip,
+                  },
+                  /*#__PURE__*/ React.createElement(this.props.icons.Search, {
+                    fontSize: "small",
+                  })
+                )
+              ),
+              endAdornment: /*#__PURE__*/ React.createElement(
+                _InputAdornment.default,
+                {
+                  position: "end",
+                },
+                /*#__PURE__*/ React.createElement(
+                  _IconButton.default,
+                  {
+                    disabled: !this.state.searchText,
+                    onClick: function onClick() {
+                      return _this2.onSearchChange("");
+                    },
+                    "aria-label": localization.clearSearchAriaLabel,
+                  },
+                  /*#__PURE__*/ React.createElement(
+                    this.props.icons.ResetSearch,
+                    {
+                      fontSize: "small",
+                      "aria-label": "clear",
+                    }
+                  )
+                )
+              ),
+              style: this.props.searchFieldStyle,
+              inputProps: {
+                "aria-label": localization.searchAriaLabel,
+              },
+            },
+          });
+        } else {
+          return null;
+        }
+      },
+    },
+    {
+      key: "renderDefaultActions",
+      value: function renderDefaultActions() {
+        var _this3 = this;
+
+        var localization = (0, _objectSpread2.default)(
+          {},
+          MTableToolbar.defaultProps.localization,
+          this.props.localization
+        );
+        var classes = this.props.classes;
+        return /*#__PURE__*/ React.createElement(
+          "div",
+          null,
+          this.props.columnsButton &&
+            /*#__PURE__*/ React.createElement(
+              "span",
+              null,
+              /*#__PURE__*/ React.createElement(
+                _Tooltip.default,
+                {
+                  title: localization.showColumnsTitle,
+                },
+                /*#__PURE__*/ React.createElement(
+                  _IconButton.default,
+                  {
+                    color: "inherit",
+                    onClick: function onClick(event) {
+                      return _this3.setState({
+                        columnsButtonAnchorEl: event.currentTarget,
+                      });
+                    },
+                    "aria-label": localization.showColumnsAriaLabel,
+                  },
+                  /*#__PURE__*/ React.createElement(
+                    this.props.icons.ViewColumn,
+                    null
+                  )
+                )
+              ),
+              /*#__PURE__*/ React.createElement(
+                _Menu.default,
+                {
+                  anchorEl: this.state.columnsButtonAnchorEl,
+                  open: Boolean(this.state.columnsButtonAnchorEl),
+                  onClose: function onClose() {
+                    return _this3.setState({
+                      columnsButtonAnchorEl: null,
+                    });
+                  },
+                },
+                /*#__PURE__*/ React.createElement(
+                  _MenuItem.default,
+                  {
+                    key: "text",
+                    disabled: true,
+                    style: {
+                      opacity: 1,
+                      fontWeight: 600,
+                      fontSize: 12,
+                    },
+                  },
+                  localization.addRemoveColumns
+                ),
+                this.props.columns.map(function (col) {
+                  if (!col.hidden || col.hiddenByColumnsButton) {
+                    return /*#__PURE__*/ React.createElement(
+                      "li",
+                      {
+                        key: col.tableData.id,
+                      },
+                      /*#__PURE__*/ React.createElement(
+                        _MenuItem.default,
+                        {
+                          className: classes.formControlLabel,
+                          component: "label",
+                          htmlFor: "column-toggle-".concat(col.tableData.id),
+                          disabled: col.removable === false,
+                        },
+                        /*#__PURE__*/ React.createElement(_Checkbox.default, {
+                          checked: !col.hidden,
+                          id: "column-toggle-".concat(col.tableData.id),
+                          onChange: function onChange() {
+                            return _this3.props.onColumnsChanged(
+                              col,
+                              !col.hidden
+                            );
+                          },
+                        }),
+                        /*#__PURE__*/ React.createElement(
+                          "span",
+                          null,
+                          col.title
+                        )
+                      )
+                    );
+                  }
+
+                  return null;
+                })
+              )
+            ),
+          this.props.exportButton &&
+            /*#__PURE__*/ React.createElement(
+              "span",
+              null,
+              /*#__PURE__*/ React.createElement(
+                _Tooltip.default,
+                {
+                  title: localization.exportTitle,
+                },
+                /*#__PURE__*/ React.createElement(
+                  _IconButton.default,
+                  {
+                    color: "inherit",
+                    onClick: function onClick(event) {
+                      return _this3.setState({
+                        exportButtonAnchorEl: event.currentTarget,
+                      });
+                    },
+                    "aria-label": localization.exportAriaLabel,
+                  },
+                  /*#__PURE__*/ React.createElement(
+                    this.props.icons.Export,
+                    null
+                  )
+                )
+              ),
+              /*#__PURE__*/ React.createElement(
+                _Menu.default,
+                {
+                  anchorEl: this.state.exportButtonAnchorEl,
+                  open: Boolean(this.state.exportButtonAnchorEl),
+                  onClose: function onClose() {
+                    return _this3.setState({
+                      exportButtonAnchorEl: null,
+                    });
+                  },
+                },
+                (this.props.exportButton === true ||
+                  this.props.exportButton.csv) &&
+                  /*#__PURE__*/ React.createElement(
+                    _MenuItem.default,
+                    {
+                      key: "export-csv",
+                      onClick: this.exportCsv,
+                    },
+                    localization.exportCSVName
+                  ),
+                (this.props.exportButton === true ||
+                  this.props.exportButton.pdf) &&
+                  /*#__PURE__*/ React.createElement(
+                    _MenuItem.default,
+                    {
+                      key: "export-pdf",
+                      onClick: this.exportPdf,
+                    },
+                    localization.exportPDFName
+                  )
+              )
+            ),
+          /*#__PURE__*/ React.createElement(
+            "span",
+            null,
+            /*#__PURE__*/ React.createElement(this.props.components.Actions, {
+              actions:
+                this.props.actions &&
+                this.props.actions.filter(function (a) {
+                  return a.position === "toolbar";
+                }),
+              components: this.props.components,
+            })
+          )
+        );
+      },
+    },
+    {
+      key: "renderSelectedActions",
+      value: function renderSelectedActions() {
+        return /*#__PURE__*/ React.createElement(
+          React.Fragment,
+          null,
+          /*#__PURE__*/ React.createElement(this.props.components.Actions, {
+            actions: this.props.actions.filter(function (a) {
+              return a.position === "toolbarOnSelect";
+            }),
+            data: this.props.selectedRows,
+            components: this.props.components,
+          })
+        );
+      },
+    },
+    {
+      key: "renderActions",
+      value: function renderActions() {
+        var classes = this.props.classes;
+        return /*#__PURE__*/ React.createElement(
+          "div",
+          {
+            className: classes.actions,
+          },
+          /*#__PURE__*/ React.createElement(
+            "div",
+            null,
+            this.props.selectedRows && this.props.selectedRows.length > 0
+              ? this.renderSelectedActions()
+              : this.renderDefaultActions()
+          )
+        );
+      },
+    },
+    {
+      key: "renderToolbarTitle",
+      value: function renderToolbarTitle(title) {
+        var classes = this.props.classes;
+        var toolBarTitle =
+          typeof title === "string"
+            ? /*#__PURE__*/ React.createElement(
+                _Typography.default,
+                {
+                  variant: "h6",
+                  style: {
+                    whiteSpace: "nowrap",
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                  },
+                },
+                title
+              )
+            : title;
+        return /*#__PURE__*/ React.createElement(
+          "div",
+          {
+            className: classes.title,
+          },
+          toolBarTitle
+        );
+      },
+    },
+    {
+      key: "render",
+      value: function render() {
+        var classes = this.props.classes;
+        var localization = (0, _objectSpread2.default)(
+          {},
+          MTableToolbar.defaultProps.localization,
+          this.props.localization
+        );
+        var title =
+          this.props.showTextRowsSelected &&
+          this.props.selectedRows &&
+          this.props.selectedRows.length > 0
+            ? typeof localization.nRowsSelected === "function"
+              ? localization.nRowsSelected(this.props.selectedRows.length)
+              : localization.nRowsSelected.replace(
+                  "{0}",
+                  this.props.selectedRows.length
+                )
+            : this.props.showTitle
+            ? this.props.title
+            : null;
+        return /*#__PURE__*/ React.createElement(
+          _Toolbar.default,
+          {
+            className: (0, _classnames.default)(
+              classes.root,
+              (0, _defineProperty2.default)(
+                {},
+                classes.highlight,
+                this.props.showTextRowsSelected &&
+                  this.props.selectedRows &&
+                  this.props.selectedRows.length > 0
+              )
+            ),
+          },
+          title && this.renderToolbarTitle(title),
+          this.props.searchFieldAlignment === "left" && this.renderSearch(),
+          this.props.toolbarButtonAlignment === "left" && this.renderActions(),
+          /*#__PURE__*/ React.createElement("div", {
+            className: classes.spacer,
+          }),
+          this.props.searchFieldAlignment === "right" && this.renderSearch(),
+          this.props.toolbarButtonAlignment === "right" && this.renderActions()
+        );
+      },
+    },
+  ]);
+  return MTableToolbar;
+})(React.Component);
+
+exports.MTableToolbar = MTableToolbar;
+MTableToolbar.defaultProps = {
+  actions: [],
+  columns: [],
+  columnsButton: false,
+  localization: {
+    addRemoveColumns: "Add or remove columns",
+    nRowsSelected: "{0} row(s) selected",
+    showColumnsTitle: "Show Columns",
+    showColumnsAriaLabel: "Show Columns",
+    exportTitle: "Export",
+    exportAriaLabel: "Export",
+    exportCSVName: "Export as CSV",
+    exportPDFName: "Export as PDF",
+    searchTooltip: "Search",
+    searchPlaceholder: "Search",
+    searchAriaLabel: "Search",
+    clearSearchAriaLabel: "Clear Search",
+  },
+  search: true,
+  showTitle: true,
+  searchText: "",
+  showTextRowsSelected: true,
+  toolbarButtonAlignment: "right",
+  searchAutoFocus: false,
+  searchFieldAlignment: "right",
+  searchFieldVariant: "standard",
+  selectedRows: [],
+  title: "No Title!",
+};
+MTableToolbar.propTypes = {
+  actions: _propTypes.default.array,
+  columns: _propTypes.default.array,
+  columnsButton: _propTypes.default.bool,
+  components: _propTypes.default.object.isRequired,
+  getFieldValue: _propTypes.default.func.isRequired,
+  localization: _propTypes.default.object.isRequired,
+  onColumnsChanged: _propTypes.default.func.isRequired,
+  dataManager: _propTypes.default.object.isRequired,
+  searchText: _propTypes.default.string,
+  onSearchChanged: _propTypes.default.func.isRequired,
+  search: _propTypes.default.bool.isRequired,
+  searchFieldStyle: _propTypes.default.object,
+  searchFieldVariant: _propTypes.default.string,
+  selectedRows: _propTypes.default.array,
+  title: _propTypes.default.oneOfType([
+    _propTypes.default.element,
+    _propTypes.default.string,
+  ]),
+  showTitle: _propTypes.default.bool.isRequired,
+  showTextRowsSelected: _propTypes.default.bool.isRequired,
+  toolbarButtonAlignment: _propTypes.default.string.isRequired,
+  searchFieldAlignment: _propTypes.default.string.isRequired,
+  renderData: _propTypes.default.array,
+  data: _propTypes.default.array,
+  exportAllData: _propTypes.default.bool,
+  exportButton: _propTypes.default.oneOfType([
+    _propTypes.default.bool,
+    _propTypes.default.shape({
+      csv: _propTypes.default.bool,
+      pdf: _propTypes.default.bool,
+    }),
+  ]),
+  exportDelimiter: _propTypes.default.string,
+  exportFileName: _propTypes.default.oneOfType([
+    _propTypes.default.string,
+    _propTypes.default.func,
+  ]),
+  exportCsv: _propTypes.default.func,
+  exportPdf: _propTypes.default.func,
+  classes: _propTypes.default.object,
+  searchAutoFocus: _propTypes.default.bool,
+};
+
+var styles = function styles(theme) {
+  return {
+    root: {
+      paddingRight: theme.spacing(1),
+    },
+    highlight:
+      theme.palette.type === "light"
+        ? {
+            color: theme.palette.secondary.main,
+            backgroundColor: (0, _colorManipulator.lighten)(
+              theme.palette.secondary.light,
+              0.85
+            ),
+          }
+        : {
+            color: theme.palette.text.primary,
+            backgroundColor: theme.palette.secondary.dark,
+          },
+    spacer: {
+      flex: "1 1 10%",
+    },
+    actions: {
+      color: theme.palette.text.secondary,
+    },
+    title: {
+      overflow: "hidden",
+    },
+    searchField: {
+      minWidth: 150,
+      paddingLeft: theme.spacing(2),
+    },
+    formControlLabel: {
+      paddingLeft: theme.spacing(1),
+      paddingRight: theme.spacing(1),
+    },
+  };
+};
+
+exports.styles = styles;
+
+var _default = (0, _withStyles.default)(styles)(MTableToolbar);
+
+exports.default = _default;

--- a/dist/default-props.js
+++ b/dist/default-props.js
@@ -1,0 +1,420 @@
+"use strict";
+
+var _interopRequireWildcard = require("@babel/runtime/helpers/interopRequireWildcard");
+
+var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
+
+Object.defineProperty(exports, "__esModule", {
+  value: true,
+});
+exports.defaultProps = void 0;
+
+var _objectSpread2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/objectSpread")
+);
+
+var _extends2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/extends")
+);
+
+var _react = _interopRequireDefault(require("react"));
+
+var _CircularProgress = _interopRequireDefault(
+  require("@material-ui/core/CircularProgress")
+);
+
+var _Icon = _interopRequireDefault(require("@material-ui/core/Icon"));
+
+var _Paper = _interopRequireDefault(require("@material-ui/core/Paper"));
+
+var _TablePagination = _interopRequireDefault(
+  require("@material-ui/core/TablePagination")
+);
+
+var MComponents = _interopRequireWildcard(require("./components"));
+
+var _propTypes = _interopRequireDefault(require("prop-types"));
+
+var _colorManipulator = require("@material-ui/core/styles/colorManipulator");
+
+var OverlayLoading = function OverlayLoading(props) {
+  return /*#__PURE__*/ _react.default.createElement(
+    "div",
+    {
+      style: {
+        display: "table",
+        width: "100%",
+        height: "100%",
+        backgroundColor: (0, _colorManipulator.fade)(
+          props.theme.palette.background.paper,
+          0.7
+        ),
+      },
+    },
+    /*#__PURE__*/ _react.default.createElement(
+      "div",
+      {
+        style: {
+          display: "table-cell",
+          width: "100%",
+          height: "100%",
+          verticalAlign: "middle",
+          textAlign: "center",
+        },
+      },
+      /*#__PURE__*/ _react.default.createElement(
+        _CircularProgress.default,
+        null
+      )
+    )
+  );
+};
+
+OverlayLoading.propTypes = {
+  theme: _propTypes.default.any,
+};
+
+var OverlayError = function OverlayError(props) {
+  return /*#__PURE__*/ _react.default.createElement(
+    "div",
+    {
+      style: {
+        display: "table",
+        width: "100%",
+        height: "100%",
+        backgroundColor: (0, _colorManipulator.fade)(
+          props.theme.palette.background.paper,
+          0.7
+        ),
+      },
+    },
+    /*#__PURE__*/ _react.default.createElement(
+      "div",
+      {
+        style: {
+          display: "table-cell",
+          width: "100%",
+          height: "100%",
+          verticalAlign: "middle",
+          textAlign: "center",
+        },
+      },
+      /*#__PURE__*/ _react.default.createElement(
+        "span",
+        null,
+        props.error.message
+      ),
+      " ",
+      /*#__PURE__*/ _react.default.createElement(props.icon, {
+        onClick: props.retry,
+        style: {
+          cursor: "pointer",
+          position: "relative",
+          top: 5,
+        },
+      })
+    )
+  );
+};
+
+OverlayError.propTypes = {
+  error: _propTypes.default.oneOfType([
+    _propTypes.default.object,
+    _propTypes.default.string,
+  ]),
+  retry: _propTypes.default.func,
+  theme: _propTypes.default.any,
+  icon: _propTypes.default.any,
+};
+
+var Container = function Container(props) {
+  return /*#__PURE__*/ _react.default.createElement(
+    _Paper.default,
+    (0, _extends2.default)(
+      {
+        elevation: 2,
+      },
+      props
+    )
+  );
+};
+
+var defaultProps = {
+  actions: [],
+  classes: {},
+  columns: [],
+  components: {
+    Action: MComponents.MTableAction,
+    Actions: MComponents.MTableActions,
+    Body: MComponents.MTableBody,
+    Cell: MComponents.MTableCell,
+    Container: Container,
+    EditCell: MComponents.MTableEditCell,
+    EditField: MComponents.MTableEditField,
+    EditRow: MComponents.MTableEditRow,
+    FilterRow: MComponents.MTableFilterRow,
+    Groupbar: MComponents.MTableGroupbar,
+    GroupRow: MComponents.MTableGroupRow,
+    Header: MComponents.MTableHeader,
+    OverlayLoading: OverlayLoading,
+    OverlayError: OverlayError,
+    Pagination: _TablePagination.default,
+    Row: MComponents.MTableBodyRow,
+    Toolbar: MComponents.MTableToolbar,
+  },
+  data: [],
+  icons: {
+    /* eslint-disable react/display-name */
+    Add: _react.default.forwardRef(function (props, ref) {
+      return /*#__PURE__*/ _react.default.createElement(
+        _Icon.default,
+        (0, _extends2.default)({}, props, {
+          ref: ref,
+        }),
+        "add_box"
+      );
+    }),
+    Check: _react.default.forwardRef(function (props, ref) {
+      return /*#__PURE__*/ _react.default.createElement(
+        _Icon.default,
+        (0, _extends2.default)({}, props, {
+          ref: ref,
+        }),
+        "check"
+      );
+    }),
+    Clear: _react.default.forwardRef(function (props, ref) {
+      return /*#__PURE__*/ _react.default.createElement(
+        _Icon.default,
+        (0, _extends2.default)({}, props, {
+          ref: ref,
+        }),
+        "clear"
+      );
+    }),
+    Delete: _react.default.forwardRef(function (props, ref) {
+      return /*#__PURE__*/ _react.default.createElement(
+        _Icon.default,
+        (0, _extends2.default)({}, props, {
+          ref: ref,
+        }),
+        "delete_outline"
+      );
+    }),
+    DetailPanel: _react.default.forwardRef(function (props, ref) {
+      return /*#__PURE__*/ _react.default.createElement(
+        _Icon.default,
+        (0, _extends2.default)({}, props, {
+          ref: ref,
+        }),
+        "chevron_right"
+      );
+    }),
+    Edit: _react.default.forwardRef(function (props, ref) {
+      return /*#__PURE__*/ _react.default.createElement(
+        _Icon.default,
+        (0, _extends2.default)({}, props, {
+          ref: ref,
+        }),
+        "edit"
+      );
+    }),
+    Export: _react.default.forwardRef(function (props, ref) {
+      return /*#__PURE__*/ _react.default.createElement(
+        _Icon.default,
+        (0, _extends2.default)({}, props, {
+          ref: ref,
+        }),
+        "save_alt"
+      );
+    }),
+    Filter: _react.default.forwardRef(function (props, ref) {
+      return /*#__PURE__*/ _react.default.createElement(
+        _Icon.default,
+        (0, _extends2.default)({}, props, {
+          ref: ref,
+        }),
+        "filter_list"
+      );
+    }),
+    FirstPage: _react.default.forwardRef(function (props, ref) {
+      return /*#__PURE__*/ _react.default.createElement(
+        _Icon.default,
+        (0, _extends2.default)({}, props, {
+          ref: ref,
+        }),
+        "first_page"
+      );
+    }),
+    LastPage: _react.default.forwardRef(function (props, ref) {
+      return /*#__PURE__*/ _react.default.createElement(
+        _Icon.default,
+        (0, _extends2.default)({}, props, {
+          ref: ref,
+        }),
+        "last_page"
+      );
+    }),
+    NextPage: _react.default.forwardRef(function (props, ref) {
+      return /*#__PURE__*/ _react.default.createElement(
+        _Icon.default,
+        (0, _extends2.default)({}, props, {
+          ref: ref,
+        }),
+        "chevron_right"
+      );
+    }),
+    PreviousPage: _react.default.forwardRef(function (props, ref) {
+      return /*#__PURE__*/ _react.default.createElement(
+        _Icon.default,
+        (0, _extends2.default)({}, props, {
+          ref: ref,
+        }),
+        "chevron_left"
+      );
+    }),
+    ResetSearch: _react.default.forwardRef(function (props, ref) {
+      return /*#__PURE__*/ _react.default.createElement(
+        _Icon.default,
+        (0, _extends2.default)({}, props, {
+          ref: ref,
+        }),
+        "clear"
+      );
+    }),
+    Resize: _react.default.forwardRef(function (props, ref) {
+      return /*#__PURE__*/ _react.default.createElement(
+        _Icon.default,
+        (0, _extends2.default)({}, props, {
+          ref: ref,
+          style: (0, _objectSpread2.default)({}, props.style, {
+            transform: "rotate(90deg)",
+          }),
+        }),
+        "drag_handle"
+      );
+    }),
+    Search: _react.default.forwardRef(function (props, ref) {
+      return /*#__PURE__*/ _react.default.createElement(
+        _Icon.default,
+        (0, _extends2.default)({}, props, {
+          ref: ref,
+        }),
+        "search"
+      );
+    }),
+    SortArrow: _react.default.forwardRef(function (props, ref) {
+      return /*#__PURE__*/ _react.default.createElement(
+        _Icon.default,
+        (0, _extends2.default)({}, props, {
+          ref: ref,
+        }),
+        "arrow_downward"
+      );
+    }),
+    ThirdStateCheck: _react.default.forwardRef(function (props, ref) {
+      return /*#__PURE__*/ _react.default.createElement(
+        _Icon.default,
+        (0, _extends2.default)({}, props, {
+          ref: ref,
+        }),
+        "remove"
+      );
+    }),
+    ViewColumn: _react.default.forwardRef(function (props, ref) {
+      return /*#__PURE__*/ _react.default.createElement(
+        _Icon.default,
+        (0, _extends2.default)({}, props, {
+          ref: ref,
+        }),
+        "view_column"
+      );
+    }),
+    Retry: _react.default.forwardRef(function (props, ref) {
+      return /*#__PURE__*/ _react.default.createElement(
+        _Icon.default,
+        (0, _extends2.default)({}, props, {
+          ref: ref,
+        }),
+        "replay"
+      );
+    }),
+    /* eslint-enable react/display-name */
+  },
+  isLoading: false,
+  title: "Table Title",
+  options: {
+    actionsColumnIndex: 0,
+    addRowPosition: "last",
+    columnsButton: false,
+    detailPanelType: "multiple",
+    debounceInterval: 200,
+    doubleHorizontalScroll: false,
+    emptyRowsWhenPaging: true,
+    exportAllData: false,
+    exportButton: false,
+    exportDelimiter: ",",
+    filtering: false,
+    groupTitle: false,
+    header: true,
+    headerSelectionProps: {},
+    hideFilterIcons: false,
+    loadingType: "overlay",
+    padding: "default",
+    searchAutoFocus: false,
+    paging: true,
+    pageSize: 5,
+    pageSizeOptions: [5, 10, 20],
+    paginationType: "normal",
+    paginationPosition: "bottom",
+    showEmptyDataSourceMessage: true,
+    showFirstLastPageButtons: true,
+    showSelectAllCheckbox: true,
+    search: true,
+    showTitle: true,
+    showTextRowsSelected: true,
+    tableLayout: "auto",
+    toolbarButtonAlignment: "right",
+    searchFieldAlignment: "right",
+    searchFieldStyle: {},
+    searchFieldVariant: "standard",
+    selection: false,
+    selectionProps: {},
+    sorting: true,
+    toolbar: true,
+    defaultExpanded: false,
+    detailPanelColumnAlignment: "left",
+    thirdSortClick: true,
+    overflowY: "auto",
+  },
+  localization: {
+    error: "Data could not be retrieved",
+    grouping: {
+      groupedBy: "Grouped By:",
+      placeholder: "Drag headers here to group by",
+    },
+    pagination: {
+      labelDisplayedRows: "{from}-{to} of {count}",
+      labelRowsPerPage: "Rows per page:",
+      labelRowsSelect: "rows",
+    },
+    toolbar: {},
+    header: {},
+    body: {
+      filterRow: {},
+      editRow: {
+        saveTooltip: "Save",
+        cancelTooltip: "Cancel",
+        deleteText: "Are you sure you want to delete this row?",
+      },
+      addTooltip: "Add",
+      deleteTooltip: "Delete",
+      editTooltip: "Edit",
+      bulkEditTooltip: "Edit All",
+      bulkEditApprove: "Save all changes",
+      bulkEditCancel: "Discard all changes",
+    },
+  },
+  style: {},
+};
+exports.defaultProps = defaultProps;

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,0 +1,82 @@
+"use strict";
+
+var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
+
+Object.defineProperty(exports, "__esModule", {
+  value: true,
+});
+var _exportNames = {
+  MTable: true,
+};
+Object.defineProperty(exports, "MTable", {
+  enumerable: true,
+  get: function get() {
+    return _materialTable.default;
+  },
+});
+exports.default = void 0;
+
+var _extends2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/extends")
+);
+
+require("./utils/polyfill");
+
+var _react = _interopRequireDefault(require("react"));
+
+var _defaultProps = require("./default-props");
+
+var _propTypes = require("./prop-types");
+
+var _materialTable = _interopRequireDefault(require("./material-table"));
+
+var _withStyles = _interopRequireDefault(
+  require("@material-ui/core/styles/withStyles")
+);
+
+var _components = require("./components");
+
+Object.keys(_components).forEach(function (key) {
+  if (key === "default" || key === "__esModule") return;
+  if (Object.prototype.hasOwnProperty.call(_exportNames, key)) return;
+  if (key in exports && exports[key] === _components[key]) return;
+  Object.defineProperty(exports, key, {
+    enumerable: true,
+    get: function get() {
+      return _components[key];
+    },
+  });
+});
+_materialTable.default.defaultProps = _defaultProps.defaultProps;
+_materialTable.default.propTypes = _propTypes.propTypes;
+
+var styles = function styles(theme) {
+  return {
+    paginationRoot: {
+      width: "100%",
+    },
+    paginationToolbar: {
+      padding: 0,
+      width: "100%",
+    },
+    paginationCaption: {
+      display: "none",
+    },
+    paginationSelectRoot: {
+      margin: 0,
+    },
+  };
+};
+
+var _default = (0, _withStyles.default)(styles, {
+  withTheme: true,
+})(function (props) {
+  return /*#__PURE__*/ _react.default.createElement(
+    _materialTable.default,
+    (0, _extends2.default)({}, props, {
+      ref: props.tableRef,
+    })
+  );
+});
+
+exports.default = _default;

--- a/dist/material-table.js
+++ b/dist/material-table.js
@@ -1,0 +1,1710 @@
+"use strict";
+
+var _interopRequireWildcard = require("@babel/runtime/helpers/interopRequireWildcard");
+
+var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
+
+Object.defineProperty(exports, "__esModule", {
+  value: true,
+});
+exports.default = void 0;
+
+var _extends2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/extends")
+);
+
+var _toConsumableArray2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/toConsumableArray")
+);
+
+var _typeof2 = _interopRequireDefault(require("@babel/runtime/helpers/typeof"));
+
+var _objectSpread2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/objectSpread")
+);
+
+var _classCallCheck2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/classCallCheck")
+);
+
+var _createClass2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/createClass")
+);
+
+var _assertThisInitialized2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/assertThisInitialized")
+);
+
+var _inherits2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/inherits")
+);
+
+var _possibleConstructorReturn2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/possibleConstructorReturn")
+);
+
+var _getPrototypeOf2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/getPrototypeOf")
+);
+
+var _defineProperty2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/defineProperty")
+);
+
+var _Table = _interopRequireDefault(require("@material-ui/core/Table"));
+
+var _TableFooter = _interopRequireDefault(
+  require("@material-ui/core/TableFooter")
+);
+
+var _TableRow = _interopRequireDefault(require("@material-ui/core/TableRow"));
+
+var _LinearProgress = _interopRequireDefault(
+  require("@material-ui/core/LinearProgress")
+);
+
+var _reactDoubleScrollbar = _interopRequireDefault(
+  require("react-double-scrollbar")
+);
+
+var React = _interopRequireWildcard(require("react"));
+
+var _components = require("./components");
+
+var _reactBeautifulDnd = require("react-beautiful-dnd");
+
+var _dataManager = _interopRequireDefault(require("./utils/data-manager"));
+
+var _debounce = require("debounce");
+
+var _fastDeepEqual = _interopRequireDefault(require("fast-deep-equal"));
+
+var _core = require("@material-ui/core");
+
+var CommonValues = _interopRequireWildcard(require("./utils/common-values"));
+
+function _createSuper(Derived) {
+  var hasNativeReflectConstruct = _isNativeReflectConstruct();
+  return function _createSuperInternal() {
+    var Super = (0, _getPrototypeOf2.default)(Derived),
+      result;
+    if (hasNativeReflectConstruct) {
+      var NewTarget = (0, _getPrototypeOf2.default)(this).constructor;
+      result = Reflect.construct(Super, arguments, NewTarget);
+    } else {
+      result = Super.apply(this, arguments);
+    }
+    return (0, _possibleConstructorReturn2.default)(this, result);
+  };
+}
+
+function _isNativeReflectConstruct() {
+  if (typeof Reflect === "undefined" || !Reflect.construct) return false;
+  if (Reflect.construct.sham) return false;
+  if (typeof Proxy === "function") return true;
+  try {
+    Date.prototype.toString.call(Reflect.construct(Date, [], function () {}));
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
+/* eslint-enable no-unused-vars */
+var MaterialTable = /*#__PURE__*/ (function (_React$Component) {
+  (0, _inherits2.default)(MaterialTable, _React$Component);
+
+  var _super = _createSuper(MaterialTable);
+
+  function MaterialTable(_props) {
+    var _this;
+
+    (0, _classCallCheck2.default)(this, MaterialTable);
+    _this = _super.call(this, _props);
+    (0, _defineProperty2.default)(
+      (0, _assertThisInitialized2.default)(_this),
+      "dataManager",
+      new _dataManager.default()
+    );
+    (0, _defineProperty2.default)(
+      (0, _assertThisInitialized2.default)(_this),
+      "isRemoteData",
+      function (props) {
+        return !Array.isArray((props || _this.props).data);
+      }
+    );
+    (0, _defineProperty2.default)(
+      (0, _assertThisInitialized2.default)(_this),
+      "isOutsidePageNumbers",
+      function (props) {
+        return props.page !== undefined && props.totalCount !== undefined;
+      }
+    );
+    (0, _defineProperty2.default)(
+      (0, _assertThisInitialized2.default)(_this),
+      "onAllSelected",
+      function (checked) {
+        _this.dataManager.changeAllSelected(checked);
+
+        _this.setState(_this.dataManager.getRenderState(), function () {
+          return _this.onSelectionChange();
+        });
+      }
+    );
+    (0, _defineProperty2.default)(
+      (0, _assertThisInitialized2.default)(_this),
+      "onChangeColumnHidden",
+      function (column, hidden) {
+        _this.dataManager.changeColumnHidden(column, hidden);
+
+        _this.setState(_this.dataManager.getRenderState(), function () {
+          _this.props.onChangeColumnHidden &&
+            _this.props.onChangeColumnHidden(column, hidden);
+        });
+      }
+    );
+    (0, _defineProperty2.default)(
+      (0, _assertThisInitialized2.default)(_this),
+      "onChangeGroupOrder",
+      function (groupedColumn) {
+        _this.dataManager.changeGroupOrder(groupedColumn.tableData.id);
+
+        _this.setState(_this.dataManager.getRenderState());
+      }
+    );
+    (0, _defineProperty2.default)(
+      (0, _assertThisInitialized2.default)(_this),
+      "onChangeOrder",
+      function (orderBy, orderDirection) {
+        var newOrderBy = orderDirection === "" ? -1 : orderBy;
+
+        _this.dataManager.changeOrder(newOrderBy, orderDirection);
+
+        if (_this.isRemoteData()) {
+          var query = (0, _objectSpread2.default)({}, _this.state.query);
+          query.page = 0;
+          query.orderBy = _this.state.columns.find(function (a) {
+            return a.tableData.id === newOrderBy;
+          });
+          query.orderDirection = orderDirection;
+
+          _this.onQueryChange(query, function () {
+            _this.props.onOrderChange &&
+              _this.props.onOrderChange(newOrderBy, orderDirection);
+          });
+        } else {
+          _this.setState(_this.dataManager.getRenderState(), function () {
+            _this.props.onOrderChange &&
+              _this.props.onOrderChange(newOrderBy, orderDirection);
+          });
+        }
+      }
+    );
+    (0, _defineProperty2.default)(
+      (0, _assertThisInitialized2.default)(_this),
+      "onChangePage",
+      function (event, page) {
+        if (_this.isRemoteData()) {
+          var query = (0, _objectSpread2.default)({}, _this.state.query);
+          query.page = page;
+
+          _this.onQueryChange(query, function () {
+            _this.props.onChangePage &&
+              _this.props.onChangePage(page, query.pageSize);
+          });
+        } else {
+          if (!_this.isOutsidePageNumbers(_this.props)) {
+            _this.dataManager.changeCurrentPage(page);
+          }
+
+          _this.setState(_this.dataManager.getRenderState(), function () {
+            _this.props.onChangePage &&
+              _this.props.onChangePage(page, _this.state.pageSize);
+          });
+        }
+      }
+    );
+    (0, _defineProperty2.default)(
+      (0, _assertThisInitialized2.default)(_this),
+      "onChangeRowsPerPage",
+      function (event) {
+        var pageSize = event.target.value;
+
+        _this.dataManager.changePageSize(pageSize);
+
+        _this.props.onChangePage && _this.props.onChangePage(0, pageSize);
+
+        if (_this.isRemoteData()) {
+          var query = (0, _objectSpread2.default)({}, _this.state.query);
+          query.pageSize = event.target.value;
+          query.page = 0;
+
+          _this.onQueryChange(query, function () {
+            _this.props.onChangeRowsPerPage &&
+              _this.props.onChangeRowsPerPage(pageSize);
+          });
+        } else {
+          _this.dataManager.changeCurrentPage(0);
+
+          _this.setState(_this.dataManager.getRenderState(), function () {
+            _this.props.onChangeRowsPerPage &&
+              _this.props.onChangeRowsPerPage(pageSize);
+          });
+        }
+      }
+    );
+    (0, _defineProperty2.default)(
+      (0, _assertThisInitialized2.default)(_this),
+      "onDragEnd",
+      function (result) {
+        if (!result || !result.source || !result.destination) return;
+
+        _this.dataManager.changeByDrag(result);
+
+        _this.setState(_this.dataManager.getRenderState(), function () {
+          if (
+            _this.props.onColumnDragged &&
+            result.destination.droppableId === "headers" &&
+            result.source.droppableId === "headers"
+          ) {
+            _this.props.onColumnDragged(
+              result.source.index,
+              result.destination.index
+            );
+          }
+        });
+      }
+    );
+    (0, _defineProperty2.default)(
+      (0, _assertThisInitialized2.default)(_this),
+      "onGroupExpandChanged",
+      function (path) {
+        _this.dataManager.changeGroupExpand(path);
+
+        _this.setState(_this.dataManager.getRenderState());
+      }
+    );
+    (0, _defineProperty2.default)(
+      (0, _assertThisInitialized2.default)(_this),
+      "onGroupRemoved",
+      function (groupedColumn, index) {
+        var result = {
+          combine: null,
+          destination: {
+            droppableId: "headers",
+            index: 0,
+          },
+          draggableId: groupedColumn.tableData.id,
+          mode: "FLUID",
+          reason: "DROP",
+          source: {
+            index: index,
+            droppableId: "groups",
+          },
+          type: "DEFAULT",
+        };
+
+        _this.dataManager.changeByDrag(result);
+
+        _this.setState(_this.dataManager.getRenderState(), function () {
+          _this.props.onGroupRemoved &&
+            _this.props.onGroupRemoved(groupedColumn, index);
+        });
+      }
+    );
+    (0, _defineProperty2.default)(
+      (0, _assertThisInitialized2.default)(_this),
+      "onEditingApproved",
+      function (mode, newData, oldData) {
+        if (
+          mode === "add" &&
+          _this.props.editable &&
+          _this.props.editable.onRowAdd
+        ) {
+          _this.setState(
+            {
+              isLoading: true,
+            },
+            function () {
+              _this.props.editable
+                .onRowAdd(newData)
+                .then(function (result) {
+                  _this.setState(
+                    {
+                      isLoading: false,
+                      showAddRow: false,
+                    },
+                    function () {
+                      if (_this.isRemoteData()) {
+                        _this.onQueryChange(_this.state.query);
+                      }
+                    }
+                  );
+                })
+                .catch(function (reason) {
+                  var errorState = {
+                    message: reason,
+                    errorCause: "add",
+                  };
+
+                  _this.setState({
+                    isLoading: false,
+                    errorState: errorState,
+                  });
+                });
+            }
+          );
+        } else if (
+          mode === "update" &&
+          _this.props.editable &&
+          _this.props.editable.onRowUpdate
+        ) {
+          _this.setState(
+            {
+              isLoading: true,
+            },
+            function () {
+              _this.props.editable
+                .onRowUpdate(newData, oldData)
+                .then(function (result) {
+                  _this.dataManager.changeRowEditing(oldData);
+
+                  _this.setState(
+                    (0, _objectSpread2.default)(
+                      {
+                        isLoading: false,
+                      },
+                      _this.dataManager.getRenderState()
+                    ),
+                    function () {
+                      if (_this.isRemoteData()) {
+                        _this.onQueryChange(_this.state.query);
+                      }
+                    }
+                  );
+                })
+                .catch(function (reason) {
+                  var errorState = {
+                    message: reason,
+                    errorCause: "update",
+                  };
+
+                  _this.setState({
+                    isLoading: false,
+                    errorState: errorState,
+                  });
+                });
+            }
+          );
+        } else if (
+          mode === "delete" &&
+          _this.props.editable &&
+          _this.props.editable.onRowDelete
+        ) {
+          _this.setState(
+            {
+              isLoading: true,
+            },
+            function () {
+              _this.props.editable
+                .onRowDelete(oldData)
+                .then(function (result) {
+                  _this.dataManager.changeRowEditing(oldData);
+
+                  _this.setState(
+                    (0, _objectSpread2.default)(
+                      {
+                        isLoading: false,
+                      },
+                      _this.dataManager.getRenderState()
+                    ),
+                    function () {
+                      if (_this.isRemoteData()) {
+                        _this.onQueryChange(_this.state.query);
+                      }
+                    }
+                  );
+                })
+                .catch(function (reason) {
+                  var errorState = {
+                    message: reason,
+                    errorCause: "delete",
+                  };
+
+                  _this.setState({
+                    isLoading: false,
+                    errorState: errorState,
+                  });
+                });
+            }
+          );
+        } else if (
+          mode === "bulk" &&
+          _this.props.editable &&
+          _this.props.editable.onBulkUpdate
+        ) {
+          _this.setState(
+            {
+              isLoading: true,
+            },
+            function () {
+              _this.props.editable
+                .onBulkUpdate(_this.dataManager.bulkEditChangedRows)
+                .then(function (result) {
+                  _this.dataManager.changeBulkEditOpen(false);
+
+                  _this.dataManager.clearBulkEditChangedRows();
+
+                  _this.setState(
+                    (0, _objectSpread2.default)(
+                      {
+                        isLoading: false,
+                      },
+                      _this.dataManager.getRenderState()
+                    ),
+                    function () {
+                      if (_this.isRemoteData()) {
+                        _this.onQueryChange(_this.state.query);
+                      }
+                    }
+                  );
+                })
+                .catch(function (reason) {
+                  var errorState = {
+                    message: reason,
+                    errorCause: "bulk edit",
+                  };
+
+                  _this.setState({
+                    isLoading: false,
+                    errorState: errorState,
+                  });
+                });
+            }
+          );
+        }
+      }
+    );
+    (0, _defineProperty2.default)(
+      (0, _assertThisInitialized2.default)(_this),
+      "onEditingCanceled",
+      function (mode, rowData) {
+        if (mode === "add") {
+          _this.props.editable.onRowAddCancelled &&
+            _this.props.editable.onRowAddCancelled();
+
+          _this.setState({
+            showAddRow: false,
+          });
+        } else if (mode === "update") {
+          _this.props.editable.onRowUpdateCancelled &&
+            _this.props.editable.onRowUpdateCancelled();
+
+          _this.dataManager.changeRowEditing(rowData);
+
+          _this.setState(_this.dataManager.getRenderState());
+        } else if (mode === "delete") {
+          _this.dataManager.changeRowEditing(rowData);
+
+          _this.setState(_this.dataManager.getRenderState());
+        }
+      }
+    );
+    (0, _defineProperty2.default)(
+      (0, _assertThisInitialized2.default)(_this),
+      "retry",
+      function () {
+        _this.onQueryChange(_this.state.query);
+      }
+    );
+    (0, _defineProperty2.default)(
+      (0, _assertThisInitialized2.default)(_this),
+      "onQueryChange",
+      function (query, callback) {
+        query = (0, _objectSpread2.default)({}, _this.state.query, query, {
+          error: _this.state.errorState,
+        });
+
+        _this.setState(
+          {
+            isLoading: true,
+            errorState: undefined,
+          },
+          function () {
+            _this.props
+              .data(query)
+              .then(function (result) {
+                query.totalCount = result.totalCount;
+                query.page = result.page;
+
+                _this.dataManager.setData(result.data);
+
+                _this.setState(
+                  (0, _objectSpread2.default)(
+                    {
+                      isLoading: false,
+                      errorState: false,
+                    },
+                    _this.dataManager.getRenderState(),
+                    {
+                      query: query,
+                    }
+                  ),
+                  function () {
+                    callback && callback();
+                  }
+                );
+              })
+              .catch(function (error) {
+                var localization = (0, _objectSpread2.default)(
+                  {},
+                  MaterialTable.defaultProps.localization,
+                  _this.props.localization
+                );
+                var errorState = {
+                  message:
+                    (0, _typeof2.default)(error) === "object"
+                      ? error.message
+                      : error !== undefined
+                      ? error
+                      : localization.error,
+                  errorCause: "query",
+                };
+
+                _this.setState(
+                  (0, _objectSpread2.default)(
+                    {
+                      isLoading: false,
+                      errorState: errorState,
+                    },
+                    _this.dataManager.getRenderState()
+                  )
+                );
+              });
+          }
+        );
+      }
+    );
+    (0, _defineProperty2.default)(
+      (0, _assertThisInitialized2.default)(_this),
+      "onRowSelected",
+      function (event, path, dataClicked) {
+        _this.dataManager.changeRowSelected(event.target.checked, path);
+
+        _this.setState(_this.dataManager.getRenderState(), function () {
+          return _this.onSelectionChange(dataClicked);
+        });
+      }
+    );
+    (0, _defineProperty2.default)(
+      (0, _assertThisInitialized2.default)(_this),
+      "onSelectionChange",
+      function (dataClicked) {
+        if (_this.props.onSelectionChange) {
+          var selectedRows = [];
+
+          var findSelecteds = function findSelecteds(list) {
+            list.forEach(function (row) {
+              if (row.tableData.checked) {
+                selectedRows.push(row);
+              }
+            });
+          };
+
+          findSelecteds(_this.state.originalData);
+
+          _this.props.onSelectionChange(selectedRows, dataClicked);
+        }
+      }
+    );
+    (0, _defineProperty2.default)(
+      (0, _assertThisInitialized2.default)(_this),
+      "onSearchChangeDebounce",
+      (0, _debounce.debounce)(function (searchText) {
+        if (_this.isRemoteData()) {
+          var query = (0, _objectSpread2.default)({}, _this.state.query);
+          query.page = 0;
+          query.search = searchText;
+
+          _this.onQueryChange(query);
+        } else {
+          _this.setState(_this.dataManager.getRenderState(), function () {
+            _this.props.onSearchChange &&
+              _this.props.onSearchChange(searchText);
+          });
+        }
+      }, _this.props.options.debounceInterval)
+    );
+    (0, _defineProperty2.default)(
+      (0, _assertThisInitialized2.default)(_this),
+      "onFilterChange",
+      function (columnId, value) {
+        _this.dataManager.changeFilterValue(columnId, value);
+
+        _this.setState({}, _this.onFilterChangeDebounce);
+      }
+    );
+    (0, _defineProperty2.default)(
+      (0, _assertThisInitialized2.default)(_this),
+      "onFilterChangeDebounce",
+      (0, _debounce.debounce)(function () {
+        if (_this.isRemoteData()) {
+          var query = (0, _objectSpread2.default)({}, _this.state.query);
+          query.page = 0;
+          query.filters = _this.state.columns
+            .filter(function (a) {
+              return a.tableData.filterValue;
+            })
+            .map(function (a) {
+              return {
+                column: a,
+                operator: "=",
+                value: a.tableData.filterValue,
+              };
+            });
+
+          _this.onQueryChange(query);
+        } else {
+          _this.setState(_this.dataManager.getRenderState(), function () {
+            if (_this.props.onFilterChange) {
+              var appliedFilters = _this.state.columns
+                .filter(function (a) {
+                  return a.tableData.filterValue;
+                })
+                .map(function (a) {
+                  return {
+                    column: a,
+                    operator: "=",
+                    value: a.tableData.filterValue,
+                  };
+                });
+
+              _this.props.onFilterChange(appliedFilters);
+            }
+          });
+        }
+      }, _this.props.options.debounceInterval)
+    );
+    (0, _defineProperty2.default)(
+      (0, _assertThisInitialized2.default)(_this),
+      "onTreeExpandChanged",
+      function (path, data) {
+        _this.dataManager.changeTreeExpand(path);
+
+        _this.setState(_this.dataManager.getRenderState(), function () {
+          _this.props.onTreeExpandChange &&
+            _this.props.onTreeExpandChange(data, data.tableData.isTreeExpanded);
+        });
+      }
+    );
+    (0, _defineProperty2.default)(
+      (0, _assertThisInitialized2.default)(_this),
+      "onToggleDetailPanel",
+      function (path, render) {
+        _this.dataManager.changeDetailPanelVisibility(path, render);
+
+        _this.setState(_this.dataManager.getRenderState());
+      }
+    );
+    (0, _defineProperty2.default)(
+      (0, _assertThisInitialized2.default)(_this),
+      "onCellEditStarted",
+      function (rowData, columnDef) {
+        _this.dataManager.startCellEditable(rowData, columnDef);
+
+        _this.setState(_this.dataManager.getRenderState());
+      }
+    );
+    (0, _defineProperty2.default)(
+      (0, _assertThisInitialized2.default)(_this),
+      "onCellEditFinished",
+      function (rowData, columnDef) {
+        _this.dataManager.finishCellEditable(rowData, columnDef);
+
+        _this.setState(_this.dataManager.getRenderState());
+      }
+    );
+    (0, _defineProperty2.default)(
+      (0, _assertThisInitialized2.default)(_this),
+      "onEditRowDataChanged",
+      function (rowData, newData) {
+        _this.dataManager.setEditRowData(rowData, newData);
+
+        _this.setState(_this.dataManager.getRenderState());
+      }
+    );
+    (0, _defineProperty2.default)(
+      (0, _assertThisInitialized2.default)(_this),
+      "onColumnResized",
+      function (id, additionalWidth) {
+        _this.dataManager.onColumnResized(id, additionalWidth);
+
+        _this.setState(_this.dataManager.getRenderState());
+      }
+    );
+    (0, _defineProperty2.default)(
+      (0, _assertThisInitialized2.default)(_this),
+      "renderTable",
+      function (props) {
+        return /*#__PURE__*/ React.createElement(
+          _Table.default,
+          {
+            style: {
+              tableLayout:
+                props.options.fixedColumns &&
+                (props.options.fixedColumns.left ||
+                  props.options.fixedColumns.right)
+                  ? "fixed"
+                  : props.options.tableLayout,
+            },
+          },
+          props.options.header &&
+            /*#__PURE__*/ React.createElement(props.components.Header, {
+              actions: props.actions,
+              localization: (0, _objectSpread2.default)(
+                {},
+                MaterialTable.defaultProps.localization.header,
+                _this.props.localization.header
+              ),
+              columns: _this.state.columns,
+              hasSelection: props.options.selection,
+              headerStyle: props.options.headerStyle,
+              icons: props.icons,
+              selectedCount: _this.state.selectedCount,
+              dataCount: props.parentChildData
+                ? _this.state.treefiedDataLength
+                : _this.state.columns.filter(function (col) {
+                    return col.tableData.groupOrder > -1;
+                  }).length > 0
+                ? _this.state.groupedDataLength
+                : _this.state.data.length,
+              hasDetailPanel: !!props.detailPanel,
+              detailPanelColumnAlignment:
+                props.options.detailPanelColumnAlignment,
+              showActionsColumn:
+                props.actions &&
+                props.actions.filter(function (a) {
+                  return a.position === "row" || typeof a === "function";
+                }).length > 0,
+              showSelectAllCheckbox: props.options.showSelectAllCheckbox,
+              orderBy: _this.state.orderBy,
+              orderDirection: _this.state.orderDirection,
+              onAllSelected: _this.onAllSelected,
+              onOrderChange: _this.onChangeOrder,
+              actionsHeaderIndex: props.options.actionsColumnIndex,
+              sorting: props.options.sorting,
+              grouping: props.options.grouping,
+              isTreeData: _this.props.parentChildData !== undefined,
+              draggable: props.options.draggable,
+              thirdSortClick: props.options.thirdSortClick,
+              treeDataMaxLevel: _this.state.treeDataMaxLevel,
+              options: props.options,
+              onColumnResized: _this.onColumnResized,
+              scrollWidth: _this.state.width,
+            }),
+          /*#__PURE__*/ React.createElement(props.components.Body, {
+            actions: props.actions,
+            components: props.components,
+            icons: props.icons,
+            renderData: _this.state.renderData,
+            currentPage: _this.state.currentPage,
+            initialFormData: props.initialFormData,
+            pageSize: _this.state.pageSize,
+            columns: _this.state.columns,
+            errorState: _this.state.errorState,
+            detailPanel: props.detailPanel,
+            options: props.options,
+            getFieldValue: _this.dataManager.getFieldValue,
+            isTreeData: _this.props.parentChildData !== undefined,
+            onFilterChanged: _this.onFilterChange,
+            onRowSelected: _this.onRowSelected,
+            onToggleDetailPanel: _this.onToggleDetailPanel,
+            onGroupExpandChanged: _this.onGroupExpandChanged,
+            onTreeExpandChanged: _this.onTreeExpandChanged,
+            onEditingCanceled: _this.onEditingCanceled,
+            onEditingApproved: _this.onEditingApproved,
+            localization: (0, _objectSpread2.default)(
+              {},
+              MaterialTable.defaultProps.localization.body,
+              _this.props.localization.body
+            ),
+            onRowClick: _this.props.onRowClick,
+            showAddRow: _this.state.showAddRow,
+            hasAnyEditingRow: !!(
+              _this.state.lastEditingRow || _this.state.showAddRow
+            ),
+            hasDetailPanel: !!props.detailPanel,
+            treeDataMaxLevel: _this.state.treeDataMaxLevel,
+            cellEditable: props.cellEditable,
+            onCellEditStarted: _this.onCellEditStarted,
+            onCellEditFinished: _this.onCellEditFinished,
+            bulkEditOpen: _this.dataManager.bulkEditOpen,
+            onBulkEditRowChanged: _this.dataManager.onBulkEditRowChanged,
+            scrollWidth: _this.state.width,
+          })
+        );
+      }
+    );
+    (0, _defineProperty2.default)(
+      (0, _assertThisInitialized2.default)(_this),
+      "getColumnsWidth",
+      function (props, count) {
+        var result = [];
+        var actionsWidth = CommonValues.actionsColumnWidth(props);
+
+        if (actionsWidth > 0) {
+          if (
+            count > 0 &&
+            props.options.actionsColumnIndex >= 0 &&
+            props.options.actionsColumnIndex < count
+          ) {
+            result.push(actionsWidth + "px");
+          } else if (
+            count < 0 &&
+            props.options.actionsColumnIndex < 0 &&
+            props.options.actionsColumnIndex >= count
+          ) {
+            result.push(actionsWidth + "px");
+          }
+        } // add selection action width only for left container div
+
+        if (props.options.selection && count > 0) {
+          var selectionWidth = CommonValues.selectionMaxWidth(
+            props,
+            _this.state.treeDataMaxLevel
+          );
+          result.push(selectionWidth + "px");
+        }
+
+        for (var i = 0; i < Math.abs(count) && i < props.columns.length; i++) {
+          var colDef =
+            props.columns[count >= 0 ? i : props.columns.length - 1 - i];
+
+          if (colDef.tableData) {
+            if (typeof colDef.tableData.width === "number") {
+              result.push(colDef.tableData.width + "px");
+            } else {
+              result.push(colDef.tableData.width);
+            }
+          }
+        }
+
+        return "calc(" + result.join(" + ") + ")";
+      }
+    );
+
+    var calculatedProps = _this.getProps(_props);
+
+    _this.setDataManagerFields(calculatedProps, true);
+
+    var renderState = _this.dataManager.getRenderState();
+
+    _this.state = (0, _objectSpread2.default)(
+      {
+        data: [],
+        errorState: undefined,
+      },
+      renderState,
+      {
+        query: {
+          filters: renderState.columns
+            .filter(function (a) {
+              return a.tableData.filterValue;
+            })
+            .map(function (a) {
+              return {
+                column: a,
+                operator: "=",
+                value: a.tableData.filterValue,
+              };
+            }),
+          orderBy: renderState.columns.find(function (a) {
+            return a.tableData.id === renderState.orderBy;
+          }),
+          orderDirection: renderState.orderDirection,
+          page: 0,
+          pageSize: calculatedProps.options.pageSize,
+          search: renderState.searchText,
+          totalCount: 0,
+        },
+        showAddRow: false,
+        bulkEditOpen: false,
+        width: 0,
+      }
+    );
+    _this.tableContainerDiv = React.createRef();
+    return _this;
+  }
+
+  (0, _createClass2.default)(MaterialTable, [
+    {
+      key: "componentDidMount",
+      value: function componentDidMount() {
+        var _this2 = this;
+
+        this.setState(
+          (0, _objectSpread2.default)({}, this.dataManager.getRenderState(), {
+            width: this.tableContainerDiv.current.scrollWidth,
+          }),
+          function () {
+            if (_this2.isRemoteData()) {
+              _this2.onQueryChange(_this2.state.query);
+            }
+          }
+        );
+      },
+    },
+    {
+      key: "setDataManagerFields",
+      value: function setDataManagerFields(props, isInit) {
+        var defaultSortColumnIndex = -1;
+        var defaultSortDirection = "";
+
+        if (props && props.options.sorting !== false) {
+          defaultSortColumnIndex = props.columns.findIndex(function (a) {
+            return a.defaultSort && a.sorting !== false;
+          });
+          defaultSortDirection =
+            defaultSortColumnIndex > -1
+              ? props.columns[defaultSortColumnIndex].defaultSort
+              : "";
+        }
+
+        this.dataManager.setColumns(props.columns);
+        this.dataManager.setDefaultExpanded(props.options.defaultExpanded);
+        this.dataManager.changeRowEditing();
+
+        if (this.isRemoteData(props)) {
+          this.dataManager.changeApplySearch(false);
+          this.dataManager.changeApplyFilters(false);
+          this.dataManager.changeApplySort(false);
+        } else {
+          this.dataManager.changeApplySearch(true);
+          this.dataManager.changeApplyFilters(true);
+          this.dataManager.changeApplySort(true);
+          this.dataManager.setData(props.data);
+        } // If the columns changed and the defaultSorting differs from the current sorting, it will trigger a new sorting
+
+        var shouldReorder =
+          isInit ||
+          (defaultSortColumnIndex !== this.dataManager.orderBy &&
+            !this.isRemoteData() &&
+            defaultSortDirection !== this.dataManager.orderDirection);
+        shouldReorder &&
+          this.dataManager.changeOrder(
+            defaultSortColumnIndex,
+            defaultSortDirection
+          );
+        isInit &&
+          this.dataManager.changeSearchText(props.options.searchText || "");
+        isInit &&
+          this.dataManager.changeCurrentPage(
+            props.options.initialPage ? props.options.initialPage : 0
+          );
+        (isInit || this.isRemoteData()) &&
+          this.dataManager.changePageSize(props.options.pageSize);
+        this.dataManager.changePaging(props.options.paging);
+        isInit && this.dataManager.changeParentFunc(props.parentChildData);
+        this.dataManager.changeDetailPanelType(props.options.detailPanelType);
+      },
+    },
+    {
+      key: "cleanColumns",
+      value: function cleanColumns(columns) {
+        return columns.map(function (col) {
+          var colClone = (0, _objectSpread2.default)({}, col);
+          delete colClone.tableData;
+          return colClone;
+        });
+      },
+    },
+    {
+      key: "componentDidUpdate",
+      value: function componentDidUpdate(prevProps) {
+        // const propsChanged = Object.entries(this.props).reduce((didChange, prop) => didChange || prop[1] !== prevProps[prop[0]], false);
+        var fixedPrevColumns = this.cleanColumns(prevProps.columns);
+        var fixedPropsColumns = this.cleanColumns(this.props.columns);
+        var propsChanged = !(0, _fastDeepEqual.default)(
+          fixedPrevColumns,
+          fixedPropsColumns
+        );
+        propsChanged =
+          propsChanged ||
+          !(0, _fastDeepEqual.default)(prevProps.options, this.props.options);
+
+        if (!this.isRemoteData()) {
+          propsChanged =
+            propsChanged ||
+            !(0, _fastDeepEqual.default)(prevProps.data, this.props.data);
+        }
+
+        if (propsChanged) {
+          var props = this.getProps(this.props);
+          this.setDataManagerFields(props);
+          this.setState(this.dataManager.getRenderState());
+        }
+
+        var count = this.isRemoteData()
+          ? this.state.query.totalCount
+          : this.state.data.length;
+        var currentPage = this.isRemoteData()
+          ? this.state.query.page
+          : this.state.currentPage;
+        var pageSize = this.isRemoteData()
+          ? this.state.query.pageSize
+          : this.state.pageSize;
+
+        if (count <= pageSize * currentPage && currentPage !== 0) {
+          this.onChangePage(null, Math.max(0, Math.ceil(count / pageSize) - 1));
+        }
+      },
+    },
+    {
+      key: "getProps",
+      value: function getProps(props) {
+        var _this3 = this;
+
+        var calculatedProps = (0, _objectSpread2.default)(
+          {},
+          props || this.props
+        );
+        calculatedProps.components = (0, _objectSpread2.default)(
+          {},
+          MaterialTable.defaultProps.components,
+          calculatedProps.components
+        );
+        calculatedProps.icons = (0, _objectSpread2.default)(
+          {},
+          MaterialTable.defaultProps.icons,
+          calculatedProps.icons
+        );
+        calculatedProps.options = (0, _objectSpread2.default)(
+          {},
+          MaterialTable.defaultProps.options,
+          calculatedProps.options
+        );
+        var localization = (0, _objectSpread2.default)(
+          {},
+          MaterialTable.defaultProps.localization.body,
+          calculatedProps.localization.body
+        );
+        calculatedProps.actions = (0, _toConsumableArray2.default)(
+          calculatedProps.actions || []
+        );
+        if (calculatedProps.options.selection)
+          calculatedProps.actions = calculatedProps.actions
+            .filter(function (a) {
+              return a;
+            })
+            .map(function (action) {
+              if (
+                action.position === "auto" ||
+                action.isFreeAction === false ||
+                (action.position === undefined &&
+                  action.isFreeAction === undefined)
+              ) {
+                if (typeof action === "function")
+                  return {
+                    action: action,
+                    position: "toolbarOnSelect",
+                  };
+                else
+                  return (0, _objectSpread2.default)({}, action, {
+                    position: "toolbarOnSelect",
+                  });
+              } else if (action.isFreeAction) {
+                if (typeof action === "function")
+                  return {
+                    action: action,
+                    position: "toolbar",
+                  };
+                else
+                  return (0, _objectSpread2.default)({}, action, {
+                    position: "toolbar",
+                  });
+              } else return action;
+            });
+        else
+          calculatedProps.actions = calculatedProps.actions
+            .filter(function (a) {
+              return a;
+            })
+            .map(function (action) {
+              if (
+                action.position === "auto" ||
+                action.isFreeAction === false ||
+                (action.position === undefined &&
+                  action.isFreeAction === undefined)
+              ) {
+                if (typeof action === "function")
+                  return {
+                    action: action,
+                    position: "row",
+                  };
+                else
+                  return (0, _objectSpread2.default)({}, action, {
+                    position: "row",
+                  });
+              } else if (action.isFreeAction) {
+                if (typeof action === "function")
+                  return {
+                    action: action,
+                    position: "toolbar",
+                  };
+                else
+                  return (0, _objectSpread2.default)({}, action, {
+                    position: "toolbar",
+                  });
+              } else return action;
+            });
+
+        if (calculatedProps.editable) {
+          if (calculatedProps.editable.onRowAdd) {
+            calculatedProps.actions.push({
+              icon: calculatedProps.icons.Add,
+              tooltip: localization.addTooltip,
+              position: "toolbar",
+              disabled: !!this.dataManager.lastEditingRow,
+              onClick: function onClick() {
+                _this3.dataManager.changeRowEditing();
+
+                _this3.setState(
+                  (0, _objectSpread2.default)(
+                    {},
+                    _this3.dataManager.getRenderState(),
+                    {
+                      showAddRow: !_this3.state.showAddRow,
+                    }
+                  )
+                );
+              },
+            });
+          }
+
+          if (calculatedProps.editable.onRowUpdate) {
+            calculatedProps.actions.push(function (rowData) {
+              return {
+                icon: calculatedProps.icons.Edit,
+                tooltip: calculatedProps.editable.editTooltip
+                  ? calculatedProps.editable.editTooltip(rowData)
+                  : localization.editTooltip,
+                disabled:
+                  calculatedProps.editable.isEditable &&
+                  !calculatedProps.editable.isEditable(rowData),
+                hidden:
+                  calculatedProps.editable.isEditHidden &&
+                  calculatedProps.editable.isEditHidden(rowData),
+                onClick: function onClick(e, rowData) {
+                  _this3.dataManager.changeRowEditing(rowData, "update");
+
+                  _this3.setState(
+                    (0, _objectSpread2.default)(
+                      {},
+                      _this3.dataManager.getRenderState(),
+                      {
+                        showAddRow: false,
+                      }
+                    )
+                  );
+                },
+              };
+            });
+          }
+
+          if (calculatedProps.editable.onRowDelete) {
+            calculatedProps.actions.push(function (rowData) {
+              return {
+                icon: calculatedProps.icons.Delete,
+                tooltip: calculatedProps.editable.deleteTooltip
+                  ? calculatedProps.editable.deleteTooltip(rowData)
+                  : localization.deleteTooltip,
+                disabled:
+                  calculatedProps.editable.isDeletable &&
+                  !calculatedProps.editable.isDeletable(rowData),
+                hidden:
+                  calculatedProps.editable.isDeleteHidden &&
+                  calculatedProps.editable.isDeleteHidden(rowData),
+                onClick: function onClick(e, rowData) {
+                  _this3.dataManager.changeRowEditing(rowData, "delete");
+
+                  _this3.setState(
+                    (0, _objectSpread2.default)(
+                      {},
+                      _this3.dataManager.getRenderState(),
+                      {
+                        showAddRow: false,
+                      }
+                    )
+                  );
+                },
+              };
+            });
+          }
+
+          if (calculatedProps.editable.onBulkUpdate) {
+            calculatedProps.actions.push({
+              icon: calculatedProps.icons.Edit,
+              tooltip: localization.bulkEditTooltip,
+              position: "toolbar",
+              hidden: this.dataManager.bulkEditOpen,
+              onClick: function onClick() {
+                _this3.dataManager.changeBulkEditOpen(true);
+
+                _this3.setState(_this3.dataManager.getRenderState());
+              },
+            });
+            calculatedProps.actions.push({
+              icon: calculatedProps.icons.Check,
+              tooltip: localization.bulkEditApprove,
+              position: "toolbar",
+              hidden: !this.dataManager.bulkEditOpen,
+              onClick: function onClick() {
+                return _this3.onEditingApproved("bulk");
+              },
+            });
+            calculatedProps.actions.push({
+              icon: calculatedProps.icons.Clear,
+              tooltip: localization.bulkEditCancel,
+              position: "toolbar",
+              hidden: !this.dataManager.bulkEditOpen,
+              onClick: function onClick() {
+                _this3.dataManager.changeBulkEditOpen(false);
+
+                _this3.dataManager.clearBulkEditChangedRows();
+
+                _this3.setState(_this3.dataManager.getRenderState());
+              },
+            });
+          }
+        }
+
+        return calculatedProps;
+      },
+    },
+    {
+      key: "renderFooter",
+      value: function renderFooter() {
+        var props = this.getProps();
+
+        if (props.options.paging) {
+          var localization = (0, _objectSpread2.default)(
+            {},
+            MaterialTable.defaultProps.localization.pagination,
+            this.props.localization.pagination
+          );
+          var isOutsidePageNumbers = this.isOutsidePageNumbers(props);
+          var currentPage = isOutsidePageNumbers
+            ? Math.min(
+                props.page,
+                Math.floor(props.totalCount / this.state.pageSize)
+              )
+            : this.state.currentPage;
+          var totalCount = isOutsidePageNumbers
+            ? props.totalCount
+            : this.state.data.length;
+          return /*#__PURE__*/ React.createElement(
+            _Table.default,
+            null,
+            /*#__PURE__*/ React.createElement(
+              _TableFooter.default,
+              {
+                style: {
+                  display: "grid",
+                },
+              },
+              /*#__PURE__*/ React.createElement(
+                _TableRow.default,
+                null,
+                /*#__PURE__*/ React.createElement(props.components.Pagination, {
+                  classes: {
+                    root: props.classes.paginationRoot,
+                    toolbar: props.classes.paginationToolbar,
+                    caption: props.classes.paginationCaption,
+                    selectRoot: props.classes.paginationSelectRoot,
+                  },
+                  style: {
+                    float: props.theme.direction === "rtl" ? "" : "right",
+                    overflowX: "auto",
+                  },
+                  colSpan: 3,
+                  count: this.isRemoteData()
+                    ? this.state.query.totalCount
+                    : totalCount,
+                  icons: props.icons,
+                  rowsPerPage: this.state.pageSize,
+                  rowsPerPageOptions: props.options.pageSizeOptions,
+                  SelectProps: {
+                    renderValue: function renderValue(value) {
+                      return /*#__PURE__*/ React.createElement(
+                        "div",
+                        {
+                          style: {
+                            padding: "0px 5px",
+                          },
+                        },
+                        value + " " + localization.labelRowsSelect + " "
+                      );
+                    },
+                  },
+                  page: this.isRemoteData()
+                    ? this.state.query.page
+                    : currentPage,
+                  onChangePage: this.onChangePage,
+                  onChangeRowsPerPage: this.onChangeRowsPerPage,
+                  ActionsComponent: function ActionsComponent(subProps) {
+                    return props.options.paginationType === "normal"
+                      ? /*#__PURE__*/ React.createElement(
+                          _components.MTablePagination,
+                          (0, _extends2.default)({}, subProps, {
+                            icons: props.icons,
+                            localization: localization,
+                            showFirstLastPageButtons:
+                              props.options.showFirstLastPageButtons,
+                          })
+                        )
+                      : /*#__PURE__*/ React.createElement(
+                          _components.MTableSteppedPagination,
+                          (0, _extends2.default)({}, subProps, {
+                            icons: props.icons,
+                            localization: localization,
+                            showFirstLastPageButtons:
+                              props.options.showFirstLastPageButtons,
+                          })
+                        );
+                  },
+                  labelDisplayedRows: function labelDisplayedRows(row) {
+                    return localization.labelDisplayedRows
+                      .replace("{from}", row.from)
+                      .replace("{to}", row.to)
+                      .replace("{count}", row.count);
+                  },
+                  labelRowsPerPage: localization.labelRowsPerPage,
+                })
+              )
+            )
+          );
+        }
+      },
+    },
+    {
+      key: "render",
+      value: function render() {
+        var _this4 = this;
+
+        var props = this.getProps();
+        return /*#__PURE__*/ React.createElement(
+          _reactBeautifulDnd.DragDropContext,
+          {
+            onDragEnd: this.onDragEnd,
+            nonce: props.options.cspNonce,
+          },
+          /*#__PURE__*/ React.createElement(
+            props.components.Container,
+            {
+              style: (0, _objectSpread2.default)(
+                {
+                  position: "relative",
+                },
+                props.style
+              ),
+            },
+            props.options.paginationPosition === "top" ||
+              props.options.paginationPosition === "both"
+              ? this.renderFooter()
+              : null,
+            props.options.toolbar &&
+              /*#__PURE__*/ React.createElement(props.components.Toolbar, {
+                actions: props.actions,
+                components: props.components,
+                selectedRows:
+                  this.state.selectedCount > 0
+                    ? this.state.originalData.filter(function (a) {
+                        return a.tableData.checked;
+                      })
+                    : [],
+                columns: this.state.columns,
+                columnsButton: props.options.columnsButton,
+                icons: props.icons,
+                exportAllData: props.options.exportAllData,
+                exportButton: props.options.exportButton,
+                exportDelimiter: props.options.exportDelimiter,
+                exportFileName: props.options.exportFileName,
+                exportCsv: props.options.exportCsv,
+                exportPdf: props.options.exportPdf,
+                getFieldValue: this.dataManager.getFieldValue,
+                data: this.state.data,
+                renderData: this.state.renderData,
+                search: props.options.search,
+                showTitle: props.options.showTitle,
+                showTextRowsSelected: props.options.showTextRowsSelected,
+                toolbarButtonAlignment: props.options.toolbarButtonAlignment,
+                searchFieldAlignment: props.options.searchFieldAlignment,
+                searchAutoFocus: props.options.searchAutoFocus,
+                searchFieldStyle: props.options.searchFieldStyle,
+                searchFieldVariant: props.options.searchFieldVariant,
+                title: props.title,
+                searchText: this.dataManager.searchText,
+                onSearchChanged: this.onSearchChangeDebounce,
+                dataManager: this.dataManager,
+                onColumnsChanged: this.onChangeColumnHidden,
+                localization: (0, _objectSpread2.default)(
+                  {},
+                  MaterialTable.defaultProps.localization.toolbar,
+                  this.props.localization.toolbar
+                ),
+              }),
+            props.options.grouping &&
+              /*#__PURE__*/ React.createElement(props.components.Groupbar, {
+                icons: props.icons,
+                localization: (0, _objectSpread2.default)(
+                  {},
+                  MaterialTable.defaultProps.localization.grouping,
+                  props.localization.grouping
+                ),
+                groupColumns: this.state.columns
+                  .filter(function (col) {
+                    return col.tableData.groupOrder > -1;
+                  })
+                  .sort(function (col1, col2) {
+                    return (
+                      col1.tableData.groupOrder - col2.tableData.groupOrder
+                    );
+                  }),
+                onSortChanged: this.onChangeGroupOrder,
+                onGroupRemoved: this.onGroupRemoved,
+              }),
+            /*#__PURE__*/ React.createElement(
+              ScrollBar,
+              {
+                double: props.options.doubleHorizontalScroll,
+              },
+              /*#__PURE__*/ React.createElement(
+                _reactBeautifulDnd.Droppable,
+                {
+                  droppableId: "headers",
+                  direction: "horizontal",
+                },
+                function (provided, snapshot) {
+                  var table = _this4.renderTable(props);
+
+                  return /*#__PURE__*/ React.createElement(
+                    "div",
+                    {
+                      ref: provided.innerRef,
+                    },
+                    /*#__PURE__*/ React.createElement(
+                      "div",
+                      {
+                        ref: _this4.tableContainerDiv,
+                        style: {
+                          maxHeight: props.options.maxBodyHeight,
+                          minHeight: props.options.minBodyHeight,
+                          overflowY: props.options.overflowY,
+                        },
+                      },
+                      _this4.state.width &&
+                        props.options.fixedColumns &&
+                        props.options.fixedColumns.right
+                        ? /*#__PURE__*/ React.createElement(
+                            "div",
+                            {
+                              style: {
+                                width: _this4.getColumnsWidth(
+                                  props,
+                                  -1 * props.options.fixedColumns.right
+                                ),
+                                position: "absolute",
+                                top: 0,
+                                right: 0,
+                                boxShadow:
+                                  "-2px 0px 15px rgba(125,147,178,.25)",
+                                overflowX: "hidden",
+                                zIndex: 11,
+                              },
+                            },
+                            /*#__PURE__*/ React.createElement(
+                              "div",
+                              {
+                                style: {
+                                  width: _this4.state.width,
+                                  background: "white",
+                                  transform: "translateX(calc(".concat(
+                                    _this4.getColumnsWidth(
+                                      props,
+                                      -1 * props.options.fixedColumns.right
+                                    ),
+                                    " - 100%))"
+                                  ),
+                                },
+                              },
+                              table
+                            )
+                          )
+                        : null,
+                      /*#__PURE__*/ React.createElement("div", null, table),
+                      _this4.state.width &&
+                        props.options.fixedColumns &&
+                        props.options.fixedColumns.left
+                        ? /*#__PURE__*/ React.createElement(
+                            "div",
+                            {
+                              style: {
+                                width: _this4.getColumnsWidth(
+                                  props,
+                                  props.options.fixedColumns.left
+                                ),
+                                position: "absolute",
+                                top: 0,
+                                left: 0,
+                                boxShadow: "2px 0px 15px rgba(125,147,178,.25)",
+                                overflowX: "hidden",
+                                zIndex: 11,
+                              },
+                            },
+                            /*#__PURE__*/ React.createElement(
+                              "div",
+                              {
+                                style: {
+                                  width: _this4.state.width,
+                                  background: "white",
+                                },
+                              },
+                              table
+                            )
+                          )
+                        : null
+                    ),
+                    provided.placeholder
+                  );
+                }
+              )
+            ),
+            (this.state.isLoading || props.isLoading) &&
+              props.options.loadingType === "linear" &&
+              /*#__PURE__*/ React.createElement(
+                "div",
+                {
+                  style: {
+                    position: "relative",
+                    width: "100%",
+                  },
+                },
+                /*#__PURE__*/ React.createElement(
+                  "div",
+                  {
+                    style: {
+                      position: "absolute",
+                      top: 0,
+                      left: 0,
+                      height: "100%",
+                      width: "100%",
+                    },
+                  },
+                  /*#__PURE__*/ React.createElement(
+                    _LinearProgress.default,
+                    null
+                  )
+                )
+              ),
+            props.options.paginationPosition === "bottom" ||
+              props.options.paginationPosition === "both"
+              ? this.renderFooter()
+              : null,
+            (this.state.isLoading || props.isLoading) &&
+              props.options.loadingType === "overlay" &&
+              /*#__PURE__*/ React.createElement(
+                "div",
+                {
+                  style: {
+                    position: "absolute",
+                    top: 0,
+                    left: 0,
+                    height: "100%",
+                    width: "100%",
+                    zIndex: 11,
+                  },
+                },
+                /*#__PURE__*/ React.createElement(
+                  props.components.OverlayLoading,
+                  {
+                    theme: props.theme,
+                  }
+                )
+              ),
+            this.state.errorState &&
+              this.state.errorState.errorCause === "query" &&
+              /*#__PURE__*/ React.createElement(
+                "div",
+                {
+                  style: {
+                    position: "absolute",
+                    top: 0,
+                    left: 0,
+                    height: "100%",
+                    width: "100%",
+                    zIndex: 11,
+                  },
+                },
+                /*#__PURE__*/ React.createElement(
+                  props.components.OverlayError,
+                  {
+                    error: this.state.errorState,
+                    retry: this.retry,
+                    theme: props.theme,
+                    icon: props.icons.Retry,
+                  }
+                )
+              )
+          )
+        );
+      },
+    },
+  ]);
+  return MaterialTable;
+})(React.Component);
+
+exports.default = MaterialTable;
+
+var style = function style() {
+  return {
+    horizontalScrollContainer: {
+      "& ::-webkit-scrollbar": {
+        "-webkit-appearance": "none",
+      },
+      "& ::-webkit-scrollbar:horizontal": {
+        height: 8,
+      },
+      "& ::-webkit-scrollbar-thumb": {
+        borderRadius: 4,
+        border: "2px solid white",
+        backgroundColor: "rgba(0, 0, 0, .3)",
+      },
+    },
+  };
+};
+
+var ScrollBar = (0, _core.withStyles)(style)(function (_ref) {
+  var double = _ref.double,
+    children = _ref.children,
+    classes = _ref.classes;
+
+  if (double) {
+    return /*#__PURE__*/ React.createElement(
+      _reactDoubleScrollbar.default,
+      null,
+      children
+    );
+  } else {
+    return /*#__PURE__*/ React.createElement(
+      "div",
+      {
+        className: classes.horizontalScrollContainer,
+        style: {
+          overflowX: "auto",
+          position: "relative",
+        },
+      },
+      children
+    );
+  }
+});

--- a/dist/prop-types.js
+++ b/dist/prop-types.js
@@ -1,0 +1,446 @@
+"use strict";
+
+var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
+
+Object.defineProperty(exports, "__esModule", {
+  value: true,
+});
+exports.propTypes = void 0;
+
+var _propTypes = _interopRequireDefault(require("prop-types"));
+
+var RefComponent = _propTypes.default.shape({
+  current: _propTypes.default.element,
+});
+
+var StyledComponent = _propTypes.default.shape({
+  classes: _propTypes.default.object,
+  innerRef: RefComponent,
+});
+
+var propTypes = {
+  actions: _propTypes.default.arrayOf(
+    _propTypes.default.oneOfType([
+      _propTypes.default.func,
+      _propTypes.default.shape({
+        icon: _propTypes.default.oneOfType([
+          _propTypes.default.element,
+          _propTypes.default.func,
+          _propTypes.default.string,
+          RefComponent,
+        ]).isRequired,
+        isFreeAction: _propTypes.default.bool,
+        position: _propTypes.default.oneOf([
+          "auto",
+          "toolbar",
+          "toolbarOnSelect",
+          "row",
+        ]),
+        tooltip: _propTypes.default.string,
+        onClick: _propTypes.default.func.isRequired,
+        iconProps: _propTypes.default.object,
+        disabled: _propTypes.default.bool,
+        hidden: _propTypes.default.bool,
+      }),
+    ])
+  ),
+  columns: _propTypes.default.arrayOf(
+    _propTypes.default.shape({
+      cellStyle: _propTypes.default.oneOfType([
+        _propTypes.default.object,
+        _propTypes.default.func,
+      ]),
+      currencySetting: _propTypes.default.shape({
+        locale: _propTypes.default.string,
+        currencyCode: _propTypes.default.string,
+        minimumFractionDigits: _propTypes.default.number,
+        maximumFractionDigits: _propTypes.default.number,
+      }),
+      customFilterAndSearch: _propTypes.default.func,
+      customSort: _propTypes.default.func,
+      defaultFilter: _propTypes.default.any,
+      defaultSort: _propTypes.default.oneOf(["asc", "desc"]),
+      editComponent: _propTypes.default.oneOfType([
+        _propTypes.default.element,
+        _propTypes.default.func,
+      ]),
+      emptyValue: _propTypes.default.oneOfType([
+        _propTypes.default.string,
+        _propTypes.default.node,
+        _propTypes.default.func,
+      ]),
+      export: _propTypes.default.bool,
+      field: _propTypes.default.string,
+      filtering: _propTypes.default.bool,
+      filterCellStyle: _propTypes.default.object,
+      filterPlaceholder: _propTypes.default.string,
+      filterComponent: _propTypes.default.oneOfType([
+        _propTypes.default.element,
+        _propTypes.default.func,
+      ]),
+      grouping: _propTypes.default.bool,
+      headerStyle: _propTypes.default.object,
+      hidden: _propTypes.default.bool,
+      hideFilterIcon: _propTypes.default.bool,
+      initialEditValue: _propTypes.default.any,
+      lookup: _propTypes.default.object,
+      editable: _propTypes.default.oneOfType([
+        _propTypes.default.func,
+        _propTypes.default.oneOf(["always", "onUpdate", "onAdd", "never"]),
+      ]),
+      removable: _propTypes.default.bool,
+      render: _propTypes.default.func,
+      searchable: _propTypes.default.bool,
+      sorting: _propTypes.default.bool,
+      title: _propTypes.default.oneOfType([
+        _propTypes.default.element,
+        _propTypes.default.string,
+      ]),
+      type: _propTypes.default.oneOf([
+        "string",
+        "boolean",
+        "numeric",
+        "date",
+        "datetime",
+        "time",
+        "currency",
+      ]),
+    })
+  ).isRequired,
+  components: _propTypes.default.shape({
+    Action: _propTypes.default.oneOfType([
+      _propTypes.default.element,
+      _propTypes.default.func,
+      StyledComponent,
+    ]),
+    Actions: _propTypes.default.oneOfType([
+      _propTypes.default.element,
+      _propTypes.default.func,
+      StyledComponent,
+    ]),
+    Body: _propTypes.default.oneOfType([
+      _propTypes.default.element,
+      _propTypes.default.func,
+      StyledComponent,
+    ]),
+    Cell: _propTypes.default.oneOfType([
+      _propTypes.default.element,
+      _propTypes.default.func,
+      StyledComponent,
+    ]),
+    Container: _propTypes.default.oneOfType([
+      _propTypes.default.element,
+      _propTypes.default.func,
+      StyledComponent,
+    ]),
+    EditField: _propTypes.default.oneOfType([
+      _propTypes.default.element,
+      _propTypes.default.func,
+      StyledComponent,
+    ]),
+    EditRow: _propTypes.default.oneOfType([
+      _propTypes.default.element,
+      _propTypes.default.func,
+      StyledComponent,
+    ]),
+    FilterRow: _propTypes.default.oneOfType([
+      _propTypes.default.element,
+      _propTypes.default.func,
+      StyledComponent,
+    ]),
+    Groupbar: _propTypes.default.oneOfType([
+      _propTypes.default.element,
+      _propTypes.default.func,
+      StyledComponent,
+    ]),
+    GroupRow: _propTypes.default.oneOfType([
+      _propTypes.default.element,
+      _propTypes.default.func,
+      StyledComponent,
+    ]),
+    Header: _propTypes.default.oneOfType([
+      _propTypes.default.element,
+      _propTypes.default.func,
+      StyledComponent,
+    ]),
+    OverlayLoading: _propTypes.default.oneOfType([
+      _propTypes.default.element,
+      _propTypes.default.func,
+      StyledComponent,
+    ]),
+    OverlayError: _propTypes.default.oneOfType([
+      _propTypes.default.element,
+      _propTypes.default.func,
+      StyledComponent,
+    ]),
+    Pagination: _propTypes.default.oneOfType([
+      _propTypes.default.element,
+      _propTypes.default.func,
+      StyledComponent,
+    ]),
+    Row: _propTypes.default.oneOfType([
+      _propTypes.default.element,
+      _propTypes.default.func,
+      StyledComponent,
+    ]),
+    Toolbar: _propTypes.default.oneOfType([
+      _propTypes.default.element,
+      _propTypes.default.func,
+      StyledComponent,
+    ]),
+  }),
+  data: _propTypes.default.oneOfType([
+    _propTypes.default.arrayOf(_propTypes.default.object),
+    _propTypes.default.func,
+  ]).isRequired,
+  editable: _propTypes.default.shape({
+    isEditable: _propTypes.default.func,
+    isDeletable: _propTypes.default.func,
+    onRowAdd: _propTypes.default.func,
+    onRowUpdate: _propTypes.default.func,
+    onRowDelete: _propTypes.default.func,
+    onRowAddCancelled: _propTypes.default.func,
+    onRowUpdateCancelled: _propTypes.default.func,
+    isEditHidden: _propTypes.default.func,
+    isDeleteHidden: _propTypes.default.func,
+  }),
+  detailPanel: _propTypes.default.oneOfType([
+    _propTypes.default.func,
+    _propTypes.default.arrayOf(
+      _propTypes.default.oneOfType([
+        _propTypes.default.func,
+        _propTypes.default.shape({
+          disabled: _propTypes.default.bool,
+          icon: _propTypes.default.oneOfType([
+            _propTypes.default.element,
+            _propTypes.default.func,
+            _propTypes.default.string,
+            RefComponent,
+          ]),
+          openIcon: _propTypes.default.oneOfType([
+            _propTypes.default.element,
+            _propTypes.default.func,
+            _propTypes.default.string,
+            RefComponent,
+          ]),
+          tooltip: _propTypes.default.string,
+          render: _propTypes.default.func.isRequired,
+        }),
+      ])
+    ),
+  ]),
+  icons: _propTypes.default.shape({
+    Add: _propTypes.default.oneOfType([
+      _propTypes.default.element,
+      _propTypes.default.func,
+      RefComponent,
+    ]),
+    Check: _propTypes.default.oneOfType([
+      _propTypes.default.element,
+      _propTypes.default.func,
+      RefComponent,
+    ]),
+    Clear: _propTypes.default.oneOfType([
+      _propTypes.default.element,
+      _propTypes.default.func,
+      RefComponent,
+    ]),
+    Delete: _propTypes.default.oneOfType([
+      _propTypes.default.element,
+      _propTypes.default.func,
+      RefComponent,
+    ]),
+    DetailPanel: _propTypes.default.oneOfType([
+      _propTypes.default.element,
+      _propTypes.default.func,
+      RefComponent,
+    ]),
+    Edit: _propTypes.default.oneOfType([
+      _propTypes.default.element,
+      _propTypes.default.func,
+      RefComponent,
+    ]),
+    Export: _propTypes.default.oneOfType([
+      _propTypes.default.element,
+      _propTypes.default.func,
+      RefComponent,
+    ]),
+    Filter: _propTypes.default.oneOfType([
+      _propTypes.default.element,
+      _propTypes.default.func,
+      RefComponent,
+    ]),
+    FirstPage: _propTypes.default.oneOfType([
+      _propTypes.default.element,
+      _propTypes.default.func,
+      RefComponent,
+    ]),
+    LastPage: _propTypes.default.oneOfType([
+      _propTypes.default.element,
+      _propTypes.default.func,
+      RefComponent,
+    ]),
+    NextPage: _propTypes.default.oneOfType([
+      _propTypes.default.element,
+      _propTypes.default.func,
+      RefComponent,
+    ]),
+    PreviousPage: _propTypes.default.oneOfType([
+      _propTypes.default.element,
+      _propTypes.default.func,
+      RefComponent,
+    ]),
+    Refresh: _propTypes.default.oneOfType([
+      _propTypes.default.element,
+      _propTypes.default.func,
+      RefComponent,
+    ]),
+    ResetSearch: _propTypes.default.oneOfType([
+      _propTypes.default.element,
+      _propTypes.default.func,
+      RefComponent,
+    ]),
+    Search: _propTypes.default.oneOfType([
+      _propTypes.default.element,
+      _propTypes.default.func,
+      RefComponent,
+    ]),
+    SortArrow: _propTypes.default.oneOfType([
+      _propTypes.default.element,
+      _propTypes.default.func,
+      RefComponent,
+    ]),
+    ThirdStateCheck: _propTypes.default.oneOfType([
+      _propTypes.default.element,
+      _propTypes.default.func,
+      RefComponent,
+    ]),
+    ViewColumn: _propTypes.default.oneOfType([
+      _propTypes.default.element,
+      _propTypes.default.func,
+      RefComponent,
+    ]),
+  }),
+  isLoading: _propTypes.default.bool,
+  title: _propTypes.default.oneOfType([
+    _propTypes.default.element,
+    _propTypes.default.string,
+  ]),
+  options: _propTypes.default.shape({
+    actionsCellStyle: _propTypes.default.object,
+    editCellStyle: _propTypes.default.object,
+    detailPanelColumnStyle: _propTypes.default.object,
+    actionsColumnIndex: _propTypes.default.number,
+    addRowPosition: _propTypes.default.oneOf(["first", "last"]),
+    columnsButton: _propTypes.default.bool,
+    defaultExpanded: _propTypes.default.oneOfType([
+      _propTypes.default.bool,
+      _propTypes.default.func,
+    ]),
+    debounceInterval: _propTypes.default.number,
+    detailPanelType: _propTypes.default.oneOf(["single", "multiple"]),
+    doubleHorizontalScroll: _propTypes.default.bool,
+    emptyRowsWhenPaging: _propTypes.default.bool,
+    exportAllData: _propTypes.default.bool,
+    exportButton: _propTypes.default.oneOfType([
+      _propTypes.default.bool,
+      _propTypes.default.shape({
+        csv: _propTypes.default.bool,
+        pdf: _propTypes.default.bool,
+      }),
+    ]),
+    exportDelimiter: _propTypes.default.string,
+    exportFileName: _propTypes.default.oneOfType([
+      _propTypes.default.string,
+      _propTypes.default.func,
+    ]),
+    exportCsv: _propTypes.default.func,
+    filtering: _propTypes.default.bool,
+    filterCellStyle: _propTypes.default.object,
+    filterRowStyle: _propTypes.default.object,
+    header: _propTypes.default.bool,
+    headerSelectionProps: _propTypes.default.object,
+    headerStyle: _propTypes.default.object,
+    hideFilterIcons: _propTypes.default.bool,
+    initialPage: _propTypes.default.number,
+    maxBodyHeight: _propTypes.default.oneOfType([
+      _propTypes.default.number,
+      _propTypes.default.string,
+    ]),
+    minBodyHeight: _propTypes.default.oneOfType([
+      _propTypes.default.number,
+      _propTypes.default.string,
+    ]),
+    loadingType: _propTypes.default.oneOf(["overlay", "linear"]),
+    overflowY: _propTypes.default.oneOf([
+      "visible",
+      "hidden",
+      "scroll",
+      "auto",
+      "initial",
+      "inherit",
+    ]),
+    padding: _propTypes.default.oneOf(["default", "dense"]),
+    paging: _propTypes.default.bool,
+    pageSize: _propTypes.default.number,
+    pageSizeOptions: _propTypes.default.arrayOf(_propTypes.default.number),
+    paginationType: _propTypes.default.oneOf(["normal", "stepped"]),
+    paginationPosition: _propTypes.default.oneOf(["bottom", "top", "both"]),
+    rowStyle: _propTypes.default.oneOfType([
+      _propTypes.default.object,
+      _propTypes.default.func,
+    ]),
+    search: _propTypes.default.bool,
+    searchText: _propTypes.default.string,
+    toolbarButtonAlignment: _propTypes.default.oneOf(["left", "right"]),
+    searchFieldAlignment: _propTypes.default.oneOf(["left", "right"]),
+    searchFieldStyle: _propTypes.default.object,
+    searchAutoFocus: _propTypes.default.bool,
+    searchFieldVariant: _propTypes.default.oneOf([
+      "standard",
+      "filled",
+      "outlined",
+    ]),
+    selection: _propTypes.default.bool,
+    selectionProps: _propTypes.default.oneOfType([
+      _propTypes.default.object,
+      _propTypes.default.func,
+    ]),
+    showEmptyDataSourceMessage: _propTypes.default.bool,
+    showFirstLastPageButtons: _propTypes.default.bool,
+    showSelectAllCheckbox: _propTypes.default.bool,
+    showTitle: _propTypes.default.bool,
+    showTextRowsSelected: _propTypes.default.bool,
+    sorting: _propTypes.default.bool,
+    toolbar: _propTypes.default.bool,
+    thirdSortClick: _propTypes.default.bool,
+  }),
+  localization: _propTypes.default.shape({
+    grouping: _propTypes.default.shape({
+      groupedBy: _propTypes.default.string,
+      placeholder: _propTypes.default.string,
+    }),
+    pagination: _propTypes.default.object,
+    toolbar: _propTypes.default.object,
+    header: _propTypes.default.object,
+    body: _propTypes.default.object,
+  }),
+  initialFormData: _propTypes.default.object,
+  onSearchChange: _propTypes.default.func,
+  onFilterChange: _propTypes.default.func,
+  onColumnDragged: _propTypes.default.func,
+  onGroupRemoved: _propTypes.default.func,
+  onSelectionChange: _propTypes.default.func,
+  onChangeRowsPerPage: _propTypes.default.func,
+  onChangePage: _propTypes.default.func,
+  onChangeColumnHidden: _propTypes.default.func,
+  onOrderChange: _propTypes.default.func,
+  onRowClick: _propTypes.default.func,
+  onTreeExpandChange: _propTypes.default.func,
+  onQueryChange: _propTypes.default.func,
+  tableRef: _propTypes.default.any,
+  style: _propTypes.default.object,
+  page: _propTypes.default.number,
+  totalCount: _propTypes.default.number,
+};
+exports.propTypes = propTypes;

--- a/dist/utils/common-values.js
+++ b/dist/utils/common-values.js
@@ -1,0 +1,54 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true,
+});
+exports.reducePercentsInCalc = exports.selectionMaxWidth = exports.actionsColumnWidth = exports.rowActions = exports.baseIconSize = exports.elementSize = void 0;
+
+var elementSize = function elementSize(props) {
+  return props.options.padding === "default" ? "medium" : "small";
+};
+
+exports.elementSize = elementSize;
+
+var baseIconSize = function baseIconSize(props) {
+  return elementSize(props) === "medium" ? 48 : 32;
+};
+
+exports.baseIconSize = baseIconSize;
+
+var rowActions = function rowActions(props) {
+  return props.actions.filter(function (a) {
+    return a.position === "row" || typeof a === "function";
+  });
+};
+
+exports.rowActions = rowActions;
+
+var actionsColumnWidth = function actionsColumnWidth(props) {
+  return rowActions(props).length * baseIconSize(props);
+};
+
+exports.actionsColumnWidth = actionsColumnWidth;
+
+var selectionMaxWidth = function selectionMaxWidth(props, maxTreeLevel) {
+  return baseIconSize(props) + 9 * maxTreeLevel;
+};
+
+exports.selectionMaxWidth = selectionMaxWidth;
+
+var reducePercentsInCalc = function reducePercentsInCalc(calc, fullValue) {
+  var captureGroups = calc.match(/(\d*)%/);
+
+  if (captureGroups && captureGroups.length > 1) {
+    var percentage = captureGroups[1];
+    return calc.replace(
+      /\d*%/,
+      "".concat(fullValue * (percentage / 100), "px")
+    );
+  }
+
+  return calc.replace(/\d*%/, "".concat(fullValue, "px"));
+};
+
+exports.reducePercentsInCalc = reducePercentsInCalc;

--- a/dist/utils/data-manager.js
+++ b/dist/utils/data-manager.js
@@ -1,0 +1,1251 @@
+"use strict";
+
+var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
+
+Object.defineProperty(exports, "__esModule", {
+  value: true,
+});
+exports.default = void 0;
+
+var _objectSpread2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/objectSpread")
+);
+
+var _toConsumableArray2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/toConsumableArray")
+);
+
+var _classCallCheck2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/classCallCheck")
+);
+
+var _createClass2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/createClass")
+);
+
+var _defineProperty2 = _interopRequireDefault(
+  require("@babel/runtime/helpers/defineProperty")
+);
+
+var _format = _interopRequireDefault(require("date-fns/format"));
+
+var _2 = require("./");
+
+var DataManager = /*#__PURE__*/ (function () {
+  function DataManager() {
+    var _this = this;
+
+    (0, _classCallCheck2.default)(this, DataManager);
+    (0, _defineProperty2.default)(this, "applyFilters", false);
+    (0, _defineProperty2.default)(this, "applySearch", false);
+    (0, _defineProperty2.default)(this, "applySort", false);
+    (0, _defineProperty2.default)(this, "currentPage", 0);
+    (0, _defineProperty2.default)(this, "detailPanelType", "multiple");
+    (0, _defineProperty2.default)(this, "lastDetailPanelRow", undefined);
+    (0, _defineProperty2.default)(this, "lastEditingRow", undefined);
+    (0, _defineProperty2.default)(this, "orderBy", -1);
+    (0, _defineProperty2.default)(this, "orderDirection", "");
+    (0, _defineProperty2.default)(this, "pageSize", 5);
+    (0, _defineProperty2.default)(this, "paging", true);
+    (0, _defineProperty2.default)(this, "parentFunc", null);
+    (0, _defineProperty2.default)(this, "searchText", "");
+    (0, _defineProperty2.default)(this, "selectedCount", 0);
+    (0, _defineProperty2.default)(this, "treefiedDataLength", 0);
+    (0, _defineProperty2.default)(this, "treeDataMaxLevel", 0);
+    (0, _defineProperty2.default)(this, "groupedDataLength", 0);
+    (0, _defineProperty2.default)(this, "defaultExpanded", false);
+    (0, _defineProperty2.default)(this, "bulkEditOpen", false);
+    (0, _defineProperty2.default)(this, "bulkEditChangedRows", {});
+    (0, _defineProperty2.default)(this, "data", []);
+    (0, _defineProperty2.default)(this, "columns", []);
+    (0, _defineProperty2.default)(this, "filteredData", []);
+    (0, _defineProperty2.default)(this, "searchedData", []);
+    (0, _defineProperty2.default)(this, "groupedData", []);
+    (0, _defineProperty2.default)(this, "treefiedData", []);
+    (0, _defineProperty2.default)(this, "sortedData", []);
+    (0, _defineProperty2.default)(this, "pagedData", []);
+    (0, _defineProperty2.default)(this, "renderData", []);
+    (0, _defineProperty2.default)(this, "filtered", false);
+    (0, _defineProperty2.default)(this, "searched", false);
+    (0, _defineProperty2.default)(this, "grouped", false);
+    (0, _defineProperty2.default)(this, "treefied", false);
+    (0, _defineProperty2.default)(this, "sorted", false);
+    (0, _defineProperty2.default)(this, "paged", false);
+    (0, _defineProperty2.default)(this, "rootGroupsIndex", {});
+    (0, _defineProperty2.default)(this, "startCellEditable", function (
+      rowData,
+      columnDef
+    ) {
+      rowData.tableData.editCellList = [].concat(
+        (0, _toConsumableArray2.default)(rowData.tableData.editCellList || []),
+        [columnDef]
+      );
+    });
+    (0, _defineProperty2.default)(this, "finishCellEditable", function (
+      rowData,
+      columnDef
+    ) {
+      if (rowData.tableData.editCellList) {
+        var index = rowData.tableData.editCellList.findIndex(function (c) {
+          return c.tableData.id === columnDef.tableData.id;
+        });
+
+        if (index !== -1) {
+          rowData.tableData.editCellList.splice(index, 1);
+        }
+      }
+    });
+    (0, _defineProperty2.default)(
+      this,
+      "clearBulkEditChangedRows",
+      function () {
+        _this.bulkEditChangedRows = {};
+      }
+    );
+    (0, _defineProperty2.default)(this, "onBulkEditRowChanged", function (
+      oldData,
+      newData
+    ) {
+      _this.bulkEditChangedRows[oldData.tableData.id] = {
+        oldData: oldData,
+        newData: newData,
+      };
+    });
+    (0, _defineProperty2.default)(this, "expandTreeForNodes", function (data) {
+      data.forEach(function (row) {
+        var currentRow = row;
+
+        while (_this.parentFunc(currentRow, _this.data)) {
+          var parent = _this.parentFunc(currentRow, _this.data);
+
+          if (parent) {
+            parent.tableData.isTreeExpanded = true;
+          }
+
+          currentRow = parent;
+        }
+      });
+    });
+    (0, _defineProperty2.default)(this, "findDataByPath", function (
+      renderData,
+      path
+    ) {
+      if (_this.isDataType("tree")) {
+        var node = path.reduce(
+          function (result, current) {
+            return (
+              result &&
+              result.tableData &&
+              result.tableData.childRows &&
+              result.tableData.childRows[current]
+            );
+          },
+          {
+            tableData: {
+              childRows: renderData,
+            },
+          }
+        );
+        return node;
+      } else {
+        var data = {
+          groups: renderData,
+        };
+
+        var _node = path.reduce(function (result, current) {
+          if (result.groups.length > 0) {
+            return result.groups[current];
+          } else if (result.data) {
+            return result.data[current];
+          } else {
+            return undefined;
+          }
+        }, data);
+
+        return _node;
+      }
+    });
+    (0, _defineProperty2.default)(this, "getFieldValue", function (
+      rowData,
+      columnDef
+    ) {
+      var lookup =
+        arguments.length > 2 && arguments[2] !== undefined
+          ? arguments[2]
+          : true;
+      var value =
+        typeof rowData[columnDef.field] !== "undefined"
+          ? rowData[columnDef.field]
+          : (0, _2.byString)(rowData, columnDef.field);
+
+      if (columnDef.lookup && lookup) {
+        value = columnDef.lookup[value];
+      }
+
+      return value;
+    });
+    (0, _defineProperty2.default)(this, "getRenderState", function () {
+      if (_this.filtered === false) {
+        _this.filterData();
+      }
+
+      if (_this.searched === false) {
+        _this.searchData();
+      }
+
+      if (_this.grouped === false && _this.isDataType("group")) {
+        _this.groupData();
+      }
+
+      if (_this.treefied === false && _this.isDataType("tree")) {
+        _this.treefyData();
+      }
+
+      if (_this.sorted === false) {
+        _this.sortData();
+      }
+
+      if (_this.paged === false) {
+        _this.pageData();
+      }
+
+      return {
+        columns: _this.columns,
+        currentPage: _this.currentPage,
+        data: _this.sortedData,
+        lastEditingRow: _this.lastEditingRow,
+        orderBy: _this.orderBy,
+        orderDirection: _this.orderDirection,
+        originalData: _this.data,
+        pageSize: _this.pageSize,
+        renderData: _this.pagedData,
+        searchText: _this.searchText,
+        selectedCount: _this.selectedCount,
+        treefiedDataLength: _this.treefiedDataLength,
+        treeDataMaxLevel: _this.treeDataMaxLevel,
+        groupedDataLength: _this.groupedDataLength,
+      };
+    });
+    (0, _defineProperty2.default)(this, "filterData", function () {
+      _this.searched = _this.grouped = _this.treefied = _this.sorted = _this.paged = false;
+      _this.filteredData = (0, _toConsumableArray2.default)(_this.data);
+
+      if (_this.applyFilters) {
+        _this.columns
+          .filter(function (columnDef) {
+            return columnDef.tableData.filterValue;
+          })
+          .forEach(function (columnDef) {
+            var lookup = columnDef.lookup,
+              type = columnDef.type,
+              tableData = columnDef.tableData;
+
+            if (columnDef.customFilterAndSearch) {
+              _this.filteredData = _this.filteredData.filter(function (row) {
+                return !!columnDef.customFilterAndSearch(
+                  tableData.filterValue,
+                  row,
+                  columnDef
+                );
+              });
+            } else {
+              if (lookup) {
+                _this.filteredData = _this.filteredData.filter(function (row) {
+                  var value = _this.getFieldValue(row, columnDef, false);
+
+                  return (
+                    !tableData.filterValue ||
+                    tableData.filterValue.length === 0 ||
+                    tableData.filterValue.indexOf(
+                      value !== undefined && value !== null && value.toString()
+                    ) > -1
+                  );
+                });
+              } else if (type === "numeric") {
+                _this.filteredData = _this.filteredData.filter(function (row) {
+                  var value = _this.getFieldValue(row, columnDef);
+
+                  return value + "" === tableData.filterValue;
+                });
+              } else if (type === "boolean" && tableData.filterValue) {
+                _this.filteredData = _this.filteredData.filter(function (row) {
+                  var value = _this.getFieldValue(row, columnDef);
+
+                  return (
+                    (value && tableData.filterValue === "checked") ||
+                    (!value && tableData.filterValue === "unchecked")
+                  );
+                });
+              } else if (["date", "datetime"].includes(type)) {
+                _this.filteredData = _this.filteredData.filter(function (row) {
+                  var value = _this.getFieldValue(row, columnDef);
+
+                  var currentDate = value ? new Date(value) : null;
+
+                  if (
+                    currentDate &&
+                    currentDate.toString() !== "Invalid Date"
+                  ) {
+                    var selectedDate = tableData.filterValue;
+                    var currentDateToCompare = "";
+                    var selectedDateToCompare = "";
+
+                    if (type === "date") {
+                      currentDateToCompare = (0, _format.default)(
+                        currentDate,
+                        "MM/dd/yyyy"
+                      );
+                      selectedDateToCompare = (0, _format.default)(
+                        selectedDate,
+                        "MM/dd/yyyy"
+                      );
+                    } else if (type === "datetime") {
+                      currentDateToCompare = (0, _format.default)(
+                        currentDate,
+                        "MM/dd/yyyy - HH:mm"
+                      );
+                      selectedDateToCompare = (0, _format.default)(
+                        selectedDate,
+                        "MM/dd/yyyy - HH:mm"
+                      );
+                    }
+
+                    return currentDateToCompare === selectedDateToCompare;
+                  }
+
+                  return true;
+                });
+              } else if (type === "time") {
+                _this.filteredData = _this.filteredData.filter(function (row) {
+                  var value = _this.getFieldValue(row, columnDef);
+
+                  var currentHour = value || null;
+
+                  if (currentHour) {
+                    var selectedHour = tableData.filterValue;
+                    var currentHourToCompare = (0, _format.default)(
+                      selectedHour,
+                      "HH:mm"
+                    );
+                    return currentHour === currentHourToCompare;
+                  }
+
+                  return true;
+                });
+              } else {
+                _this.filteredData = _this.filteredData.filter(function (row) {
+                  var value = _this.getFieldValue(row, columnDef);
+
+                  return (
+                    value &&
+                    value
+                      .toString()
+                      .toUpperCase()
+                      .includes(tableData.filterValue.toUpperCase())
+                  );
+                });
+              }
+            }
+          });
+      }
+
+      _this.filtered = true;
+    });
+    (0, _defineProperty2.default)(this, "searchData", function () {
+      _this.grouped = _this.treefied = _this.sorted = _this.paged = false;
+      _this.searchedData = (0, _toConsumableArray2.default)(_this.filteredData);
+
+      if (_this.searchText && _this.applySearch) {
+        var trimmedSearchText = _this.searchText.trim();
+
+        _this.searchedData = _this.searchedData.filter(function (row) {
+          return _this.columns
+            .filter(function (columnDef) {
+              return columnDef.searchable === undefined
+                ? !columnDef.hidden
+                : columnDef.searchable;
+            })
+            .some(function (columnDef) {
+              if (columnDef.customFilterAndSearch) {
+                return !!columnDef.customFilterAndSearch(
+                  trimmedSearchText,
+                  row,
+                  columnDef
+                );
+              } else if (columnDef.field) {
+                var value = _this.getFieldValue(row, columnDef);
+
+                if (value) {
+                  return value
+                    .toString()
+                    .toUpperCase()
+                    .includes(trimmedSearchText.toUpperCase());
+                }
+              }
+            });
+        });
+      }
+
+      _this.searched = true;
+    });
+  }
+
+  (0, _createClass2.default)(DataManager, [
+    {
+      key: "setData",
+      value: function setData(data) {
+        var _this2 = this;
+
+        this.selectedCount = 0;
+        this.data = data.map(function (row, index) {
+          row.tableData = (0, _objectSpread2.default)({}, row.tableData, {
+            id: index,
+          });
+
+          if (row.tableData.checked) {
+            _this2.selectedCount++;
+          }
+
+          return row;
+        });
+        this.filtered = false;
+      },
+    },
+    {
+      key: "setColumns",
+      value: function setColumns(columns) {
+        var undefinedWidthColumns = columns.filter(function (c) {
+          return c.width === undefined && c.columnDef
+            ? c.columnDef.tableData.width === undefined
+            : true && !c.hidden;
+        });
+        var usedWidth = ["0px"];
+        this.columns = columns.map(function (columnDef, index) {
+          columnDef.tableData = (0, _objectSpread2.default)(
+            {
+              columnOrder: index,
+              filterValue: columnDef.defaultFilter,
+              groupOrder: columnDef.defaultGroupOrder,
+              groupSort: columnDef.defaultGroupSort || "asc",
+              width:
+                typeof columnDef.width === "number"
+                  ? columnDef.width + "px"
+                  : columnDef.width,
+              initialWidth:
+                typeof columnDef.width === "number"
+                  ? columnDef.width + "px"
+                  : columnDef.width,
+              additionalWidth: 0,
+            },
+            columnDef.tableData,
+            {
+              id: index,
+            }
+          );
+
+          if (columnDef.tableData.width !== undefined) {
+            usedWidth.push(columnDef.tableData.width);
+          }
+
+          return columnDef;
+        });
+        usedWidth = "(" + usedWidth.join(" + ") + ")";
+        undefinedWidthColumns.forEach(function (columnDef) {
+          columnDef.tableData.width = columnDef.tableData.initialWidth = "calc((100% - "
+            .concat(usedWidth, ") / ")
+            .concat(undefinedWidthColumns.length, ")");
+        });
+      },
+    },
+    {
+      key: "setDefaultExpanded",
+      value: function setDefaultExpanded(expanded) {
+        this.defaultExpanded = expanded;
+      },
+    },
+    {
+      key: "changeApplySearch",
+      value: function changeApplySearch(applySearch) {
+        this.applySearch = applySearch;
+        this.searched = false;
+      },
+    },
+    {
+      key: "changeApplyFilters",
+      value: function changeApplyFilters(applyFilters) {
+        this.applyFilters = applyFilters;
+        this.filtered = false;
+      },
+    },
+    {
+      key: "changeApplySort",
+      value: function changeApplySort(applySort) {
+        this.applySort = applySort;
+        this.sorted = false;
+      },
+    },
+    {
+      key: "changePaging",
+      value: function changePaging(paging) {
+        this.paging = paging;
+        this.paged = false;
+      },
+    },
+    {
+      key: "changeCurrentPage",
+      value: function changeCurrentPage(currentPage) {
+        this.currentPage = currentPage;
+        this.paged = false;
+      },
+    },
+    {
+      key: "changePageSize",
+      value: function changePageSize(pageSize) {
+        this.pageSize = pageSize;
+        this.paged = false;
+      },
+    },
+    {
+      key: "changeParentFunc",
+      value: function changeParentFunc(parentFunc) {
+        this.parentFunc = parentFunc;
+      },
+    },
+    {
+      key: "changeFilterValue",
+      value: function changeFilterValue(columnId, value) {
+        this.columns[columnId].tableData.filterValue = value;
+        this.filtered = false;
+      },
+    },
+    {
+      key: "changeRowSelected",
+      value: function changeRowSelected(checked, path) {
+        var _this3 = this;
+
+        var rowData = this.findDataByPath(this.sortedData, path);
+        rowData.tableData.checked = checked;
+        this.selectedCount = this.selectedCount + (checked ? 1 : -1);
+
+        var checkChildRows = function checkChildRows(rowData) {
+          if (rowData.tableData.childRows) {
+            rowData.tableData.childRows.forEach(function (childRow) {
+              if (childRow.tableData.checked !== checked) {
+                childRow.tableData.checked = checked;
+                _this3.selectedCount =
+                  _this3.selectedCount + (checked ? 1 : -1);
+              }
+
+              checkChildRows(childRow);
+            });
+          }
+        };
+
+        checkChildRows(rowData);
+        this.filtered = false;
+      },
+    },
+    {
+      key: "changeDetailPanelVisibility",
+      value: function changeDetailPanelVisibility(path, render) {
+        var rowData = this.findDataByPath(this.sortedData, path);
+
+        if (
+          (rowData.tableData.showDetailPanel || "").toString() ===
+          render.toString()
+        ) {
+          rowData.tableData.showDetailPanel = undefined;
+        } else {
+          rowData.tableData.showDetailPanel = render;
+        }
+
+        if (
+          this.detailPanelType === "single" &&
+          this.lastDetailPanelRow &&
+          this.lastDetailPanelRow != rowData
+        ) {
+          this.lastDetailPanelRow.tableData.showDetailPanel = undefined;
+        }
+
+        this.lastDetailPanelRow = rowData;
+      },
+    },
+    {
+      key: "changeGroupExpand",
+      value: function changeGroupExpand(path) {
+        var rowData = this.findDataByPath(this.sortedData, path);
+        rowData.isExpanded = !rowData.isExpanded;
+      },
+    },
+    {
+      key: "changeSearchText",
+      value: function changeSearchText(searchText) {
+        this.searchText = searchText;
+        this.searched = false;
+        this.currentPage = 0;
+      },
+    },
+    {
+      key: "changeRowEditing",
+      value: function changeRowEditing(rowData, mode) {
+        if (rowData) {
+          rowData.tableData.editing = mode;
+
+          if (this.lastEditingRow && this.lastEditingRow != rowData) {
+            this.lastEditingRow.tableData.editing = undefined;
+          }
+
+          if (mode) {
+            this.lastEditingRow = rowData;
+          } else {
+            this.lastEditingRow = undefined;
+          }
+        } else if (this.lastEditingRow) {
+          this.lastEditingRow.tableData.editing = undefined;
+          this.lastEditingRow = undefined;
+        }
+      },
+    },
+    {
+      key: "changeBulkEditOpen",
+      value: function changeBulkEditOpen(bulkEditOpen) {
+        this.bulkEditOpen = bulkEditOpen;
+      },
+    },
+    {
+      key: "changeAllSelected",
+      value: function changeAllSelected(checked) {
+        var selectedCount = 0;
+
+        if (this.isDataType("group")) {
+          var setCheck = function setCheck(data) {
+            data.forEach(function (element) {
+              if (element.groups.length > 0) {
+                setCheck(element.groups);
+              } else {
+                element.data.forEach(function (d) {
+                  d.tableData.checked = d.tableData.disabled ? false : checked;
+                  selectedCount++;
+                });
+              }
+            });
+          };
+
+          setCheck(this.groupedData);
+        } else {
+          this.searchedData.map(function (row) {
+            row.tableData.checked = row.tableData.disabled ? false : checked;
+            return row;
+          });
+          selectedCount = this.searchedData.length;
+        }
+
+        this.selectedCount = checked ? selectedCount : 0;
+      },
+    },
+    {
+      key: "changeOrder",
+      value: function changeOrder(orderBy, orderDirection) {
+        this.orderBy = orderBy;
+        this.orderDirection = orderDirection;
+        this.currentPage = 0;
+        this.sorted = false;
+      },
+    },
+    {
+      key: "changeGroupOrder",
+      value: function changeGroupOrder(columnId) {
+        var column = this.columns.find(function (c) {
+          return c.tableData.id === columnId;
+        });
+
+        if (column.tableData.groupSort === "asc") {
+          column.tableData.groupSort = "desc";
+        } else {
+          column.tableData.groupSort = "asc";
+        }
+
+        this.sorted = false;
+      },
+    },
+    {
+      key: "changeColumnHidden",
+      value: function changeColumnHidden(column, hidden) {
+        column.hidden = hidden;
+        column.hiddenByColumnsButton = hidden;
+      },
+    },
+    {
+      key: "changeTreeExpand",
+      value: function changeTreeExpand(path) {
+        var rowData = this.findDataByPath(this.sortedData, path);
+        rowData.tableData.isTreeExpanded = !rowData.tableData.isTreeExpanded;
+      },
+    },
+    {
+      key: "changeDetailPanelType",
+      value: function changeDetailPanelType(type) {
+        this.detailPanelType = type;
+      },
+    },
+    {
+      key: "changeByDrag",
+      value: function changeByDrag(result) {
+        var start = 0;
+        var groups = this.columns
+          .filter(function (col) {
+            return col.tableData.groupOrder > -1;
+          })
+          .sort(function (col1, col2) {
+            return col1.tableData.groupOrder - col2.tableData.groupOrder;
+          });
+
+        if (
+          result.destination.droppableId === "groups" &&
+          result.source.droppableId === "groups"
+        ) {
+          start = Math.min(result.destination.index, result.source.index);
+          var end = Math.max(result.destination.index, result.source.index);
+          groups = groups.slice(start, end + 1);
+
+          if (result.destination.index < result.source.index) {
+            // Take last and add as first
+            var last = groups.pop();
+            groups.unshift(last);
+          } else {
+            // Take first and add as last
+            var _last = groups.shift();
+
+            groups.push(_last);
+          }
+        } else if (
+          result.destination.droppableId === "groups" &&
+          result.source.droppableId === "headers"
+        ) {
+          var newGroup = this.columns.find(function (c) {
+            return c.tableData.id == result.draggableId;
+          });
+
+          if (newGroup.grouping === false || !newGroup.field) {
+            return;
+          }
+
+          groups.splice(result.destination.index, 0, newGroup);
+        } else if (
+          result.destination.droppableId === "headers" &&
+          result.source.droppableId === "groups"
+        ) {
+          var removeGroup = this.columns.find(function (c) {
+            return c.tableData.id == result.draggableId;
+          });
+          removeGroup.tableData.groupOrder = undefined;
+          groups.splice(result.source.index, 1);
+        } else if (
+          result.destination.droppableId === "headers" &&
+          result.source.droppableId === "headers"
+        ) {
+          start = Math.min(result.destination.index, result.source.index);
+
+          var _end = Math.max(result.destination.index, result.source.index); // get the effective start and end considering hidden columns
+
+          var sorted = this.columns
+            .sort(function (a, b) {
+              return a.tableData.columnOrder - b.tableData.columnOrder;
+            })
+            .filter(function (column) {
+              return column.tableData.groupOrder === undefined;
+            });
+          var numHiddenBeforeStart = 0;
+          var numVisibleBeforeStart = 0;
+
+          for (
+            var i = 0;
+            i < sorted.length && numVisibleBeforeStart <= start;
+            i++
+          ) {
+            if (sorted[i].hidden) {
+              numHiddenBeforeStart++;
+            } else {
+              numVisibleBeforeStart++;
+            }
+          }
+
+          var effectiveStart = start + numHiddenBeforeStart;
+          var effectiveEnd = effectiveStart;
+
+          for (
+            var numVisibleInRange = 0;
+            numVisibleInRange < _end - start && effectiveEnd < sorted.length;
+            effectiveEnd++
+          ) {
+            if (!sorted[effectiveEnd].hidden) {
+              numVisibleInRange++;
+            }
+          }
+
+          var colsToMov = sorted.slice(effectiveStart, effectiveEnd + 1);
+
+          if (result.destination.index < result.source.index) {
+            // Take last and add as first
+            var _last2 = colsToMov.pop();
+
+            colsToMov.unshift(_last2);
+          } else {
+            // Take first and add as last
+            var _last3 = colsToMov.shift();
+
+            colsToMov.push(_last3);
+          }
+
+          for (var _i = 0; _i < colsToMov.length; _i++) {
+            colsToMov[_i].tableData.columnOrder = effectiveStart + _i;
+          }
+
+          return;
+        } else {
+          return;
+        }
+
+        for (var _i2 = 0; _i2 < groups.length; _i2++) {
+          groups[_i2].tableData.groupOrder = start + _i2;
+        }
+
+        this.sorted = this.grouped = false;
+      },
+    },
+    {
+      key: "onColumnResized",
+      value: function onColumnResized(id, additionalWidth) {
+        var column = this.columns.find(function (c) {
+          return c.tableData.id === id;
+        });
+        if (!column) return;
+        var nextColumn = this.columns.find(function (c) {
+          return c.tableData.id === id + 1;
+        });
+        if (!nextColumn) return; // console.log("S i: " + column.tableData.initialWidth);
+        // console.log("S a: " + column.tableData.additionalWidth);
+        // console.log("S w: " + column.tableData.width);
+
+        column.tableData.additionalWidth = additionalWidth;
+        column.tableData.width = "calc("
+          .concat(column.tableData.initialWidth, " + ")
+          .concat(column.tableData.additionalWidth, "px)"); // nextColumn.tableData.additionalWidth = -1 * additionalWidth;
+        // nextColumn.tableData.width = `calc(${nextColumn.tableData.initialWidth} + ${nextColumn.tableData.additionalWidth}px)`;
+        // console.log("F i: " + column.tableData.initialWidth);
+        // console.log("F a: " + column.tableData.additionalWidth);
+        // console.log("F w: " + column.tableData.width);
+      },
+    },
+    {
+      key: "findGroupByGroupPath",
+      value: function findGroupByGroupPath(renderData, path) {
+        var data = {
+          groups: renderData,
+          groupsIndex: this.rootGroupsIndex,
+        };
+        var node = path.reduce(function (result, current) {
+          if (!result) {
+            return undefined;
+          }
+
+          if (result.groupsIndex[current] !== undefined) {
+            return result.groups[result.groupsIndex[current]];
+          }
+
+          return undefined; // const group = result.groups.find(a => a.value === current);
+          // return group;
+        }, data);
+        return node;
+      },
+    },
+    {
+      key: "isDataType",
+      value: function isDataType(type) {
+        var dataType = "normal";
+
+        if (this.parentFunc) {
+          dataType = "tree";
+        } else if (
+          this.columns.find(function (a) {
+            return a.tableData.groupOrder > -1;
+          })
+        ) {
+          dataType = "group";
+        }
+
+        return type === dataType;
+      },
+    },
+    {
+      key: "sort",
+      value: function sort(a, b, type) {
+        if (type === "numeric") {
+          return a - b;
+        } else {
+          if (a !== b) {
+            // to find nulls
+            if (!a) return -1;
+            if (!b) return 1;
+          }
+
+          return a < b ? -1 : a > b ? 1 : 0;
+        }
+      },
+    },
+    {
+      key: "sortList",
+      value: function sortList(list) {
+        var _this4 = this;
+
+        var columnDef = this.columns.find(function (_) {
+          return _.tableData.id === _this4.orderBy;
+        });
+        var result = list;
+
+        if (columnDef.customSort) {
+          if (this.orderDirection === "desc") {
+            result = list.sort(function (a, b) {
+              return columnDef.customSort(b, a, "row", "desc");
+            });
+          } else {
+            result = list.sort(function (a, b) {
+              return columnDef.customSort(a, b, "row");
+            });
+          }
+        } else {
+          result = list.sort(
+            this.orderDirection === "desc"
+              ? function (a, b) {
+                  return _this4.sort(
+                    _this4.getFieldValue(b, columnDef),
+                    _this4.getFieldValue(a, columnDef),
+                    columnDef.type
+                  );
+                }
+              : function (a, b) {
+                  return _this4.sort(
+                    _this4.getFieldValue(a, columnDef),
+                    _this4.getFieldValue(b, columnDef),
+                    columnDef.type
+                  );
+                }
+          );
+        }
+
+        return result;
+      },
+    },
+    {
+      key: "groupData",
+      value: function groupData() {
+        var _this5 = this;
+
+        this.sorted = this.paged = false;
+        this.groupedDataLength = 0;
+        var tmpData = (0, _toConsumableArray2.default)(this.searchedData);
+        var groups = this.columns
+          .filter(function (col) {
+            return col.tableData.groupOrder > -1;
+          })
+          .sort(function (col1, col2) {
+            return col1.tableData.groupOrder - col2.tableData.groupOrder;
+          });
+        var subData = tmpData.reduce(
+          function (result, currentRow) {
+            var object = result;
+            object = groups.reduce(function (o, colDef) {
+              var value =
+                currentRow[colDef.field] ||
+                (0, _2.byString)(currentRow, colDef.field);
+              var group;
+
+              if (o.groupsIndex[value] !== undefined) {
+                group = o.groups[o.groupsIndex[value]];
+              }
+
+              if (!group) {
+                var path = [].concat(
+                  (0, _toConsumableArray2.default)(o.path || []),
+                  [value]
+                );
+                var oldGroup = _this5.findGroupByGroupPath(
+                  _this5.groupedData,
+                  path
+                ) || {
+                  isExpanded:
+                    typeof _this5.defaultExpanded === "boolean"
+                      ? _this5.defaultExpanded
+                      : false,
+                };
+                group = {
+                  value: value,
+                  groups: [],
+                  groupsIndex: {},
+                  data: [],
+                  isExpanded: oldGroup.isExpanded,
+                  path: path,
+                };
+                o.groups.push(group);
+                o.groupsIndex[value] = o.groups.length - 1;
+              }
+
+              return group;
+            }, object);
+            object.data.push(currentRow);
+            _this5.groupedDataLength++;
+            return result;
+          },
+          {
+            groups: [],
+            groupsIndex: {},
+          }
+        );
+        this.groupedData = subData.groups;
+        this.grouped = true;
+        this.rootGroupsIndex = subData.groupsIndex;
+      },
+    },
+    {
+      key: "treefyData",
+      value: function treefyData() {
+        var _this6 = this;
+
+        this.sorted = this.paged = false;
+        this.data.forEach(function (a) {
+          return (a.tableData.childRows = null);
+        });
+        this.treefiedData = [];
+        this.treefiedDataLength = 0;
+        this.treeDataMaxLevel = 0; // if filter or search is enabled, collapse the tree
+
+        if (
+          this.searchText ||
+          this.columns.some(function (columnDef) {
+            return columnDef.tableData.filterValue;
+          })
+        ) {
+          this.data.forEach(function (row) {
+            row.tableData.isTreeExpanded = false;
+          }); // expand the tree for all nodes present after filtering and searching
+
+          this.expandTreeForNodes(this.searchedData);
+        }
+
+        var addRow = function addRow(rowData) {
+          rowData.tableData.markedForTreeRemove = false;
+
+          var parent = _this6.parentFunc(rowData, _this6.data);
+
+          if (parent) {
+            parent.tableData.childRows = parent.tableData.childRows || [];
+
+            if (!parent.tableData.childRows.includes(rowData)) {
+              parent.tableData.childRows.push(rowData);
+              _this6.treefiedDataLength++;
+            }
+
+            addRow(parent);
+            rowData.tableData.path = [].concat(
+              (0, _toConsumableArray2.default)(parent.tableData.path),
+              [parent.tableData.childRows.length - 1]
+            );
+            _this6.treeDataMaxLevel = Math.max(
+              _this6.treeDataMaxLevel,
+              rowData.tableData.path.length
+            );
+          } else {
+            if (!_this6.treefiedData.includes(rowData)) {
+              _this6.treefiedData.push(rowData);
+
+              _this6.treefiedDataLength++;
+              rowData.tableData.path = [_this6.treefiedData.length - 1];
+            }
+          }
+        }; // Add all rows initially
+
+        this.data.forEach(function (rowData) {
+          addRow(rowData);
+        });
+
+        var markForTreeRemove = function markForTreeRemove(rowData) {
+          var pointer = _this6.treefiedData;
+          rowData.tableData.path.forEach(function (pathPart) {
+            if (pointer.tableData && pointer.tableData.childRows) {
+              pointer = pointer.tableData.childRows;
+            }
+
+            pointer = pointer[pathPart];
+          });
+          pointer.tableData.markedForTreeRemove = true;
+        };
+
+        var traverseChildrenAndUnmark = function traverseChildrenAndUnmark(
+          rowData
+        ) {
+          if (rowData.tableData.childRows) {
+            rowData.tableData.childRows.forEach(function (row) {
+              traverseChildrenAndUnmark(row);
+            });
+          }
+
+          rowData.tableData.markedForTreeRemove = false;
+        }; // for all data rows, restore initial expand if no search term is available and remove items that shouldn't be there
+
+        this.data.forEach(function (rowData) {
+          if (
+            !_this6.searchText &&
+            !_this6.columns.some(function (columnDef) {
+              return columnDef.tableData.filterValue;
+            })
+          ) {
+            if (rowData.tableData.isTreeExpanded === undefined) {
+              var isExpanded =
+                typeof _this6.defaultExpanded === "boolean"
+                  ? _this6.defaultExpanded
+                  : _this6.defaultExpanded(rowData);
+              rowData.tableData.isTreeExpanded = isExpanded;
+            }
+          }
+
+          var hasSearchMatchedChildren = rowData.tableData.isTreeExpanded;
+
+          if (
+            !hasSearchMatchedChildren &&
+            _this6.searchedData.indexOf(rowData) < 0
+          ) {
+            markForTreeRemove(rowData);
+          }
+        }); // preserve all children of nodes that are matched by search or filters
+
+        this.data.forEach(function (rowData) {
+          if (_this6.searchedData.indexOf(rowData) > -1) {
+            traverseChildrenAndUnmark(rowData);
+          }
+        });
+
+        var traverseTreeAndDeleteMarked = function traverseTreeAndDeleteMarked(
+          rowDataArray
+        ) {
+          for (var i = rowDataArray.length - 1; i >= 0; i--) {
+            var item = rowDataArray[i];
+
+            if (item.tableData.childRows) {
+              traverseTreeAndDeleteMarked(item.tableData.childRows);
+            }
+
+            if (item.tableData.markedForTreeRemove) rowDataArray.splice(i, 1);
+          }
+        };
+
+        traverseTreeAndDeleteMarked(this.treefiedData);
+        this.treefied = true;
+      },
+    },
+    {
+      key: "sortData",
+      value: function sortData() {
+        var _this7 = this;
+
+        this.paged = false;
+
+        if (this.isDataType("group")) {
+          this.sortedData = (0, _toConsumableArray2.default)(this.groupedData);
+          var groups = this.columns
+            .filter(function (col) {
+              return col.tableData.groupOrder > -1;
+            })
+            .sort(function (col1, col2) {
+              return col1.tableData.groupOrder - col2.tableData.groupOrder;
+            });
+
+          var sortGroups = function sortGroups(list, columnDef) {
+            if (columnDef.customSort) {
+              return list.sort(
+                columnDef.tableData.groupSort === "desc"
+                  ? function (a, b) {
+                      return columnDef.customSort(b.value, a.value, "group");
+                    }
+                  : function (a, b) {
+                      return columnDef.customSort(a.value, b.value, "group");
+                    }
+              );
+            } else {
+              return list.sort(
+                columnDef.tableData.groupSort === "desc"
+                  ? function (a, b) {
+                      return _this7.sort(b.value, a.value, columnDef.type);
+                    }
+                  : function (a, b) {
+                      return _this7.sort(a.value, b.value, columnDef.type);
+                    }
+              );
+            }
+          };
+
+          this.sortedData = sortGroups(this.sortedData, groups[0]);
+
+          var sortGroupData = function sortGroupData(list, level) {
+            list.forEach(function (element) {
+              if (element.groups.length > 0) {
+                var column = groups[level];
+                element.groups = sortGroups(element.groups, column);
+                sortGroupData(element.groups, level + 1);
+              } else {
+                if (_this7.orderBy >= 0 && _this7.orderDirection) {
+                  element.data = _this7.sortList(element.data);
+                }
+              }
+            });
+          };
+
+          sortGroupData(this.sortedData, 1);
+        } else if (this.isDataType("tree")) {
+          this.sortedData = (0, _toConsumableArray2.default)(this.treefiedData);
+
+          if (this.orderBy != -1) {
+            this.sortedData = this.sortList(this.sortedData);
+
+            var sortTree = function sortTree(list) {
+              list.forEach(function (item) {
+                if (item.tableData.childRows) {
+                  item.tableData.childRows = _this7.sortList(
+                    item.tableData.childRows
+                  );
+                  sortTree(item.tableData.childRows);
+                }
+              });
+            };
+
+            sortTree(this.sortedData);
+          }
+        } else if (this.isDataType("normal")) {
+          this.sortedData = (0, _toConsumableArray2.default)(this.searchedData);
+
+          if (this.orderBy != -1 && this.applySort) {
+            this.sortedData = this.sortList(this.sortedData);
+          }
+        }
+
+        this.sorted = true;
+      },
+    },
+    {
+      key: "pageData",
+      value: function pageData() {
+        this.pagedData = (0, _toConsumableArray2.default)(this.sortedData);
+
+        if (this.paging) {
+          var startIndex = this.currentPage * this.pageSize;
+          var endIndex = startIndex + this.pageSize;
+          this.pagedData = this.pagedData.slice(startIndex, endIndex);
+        }
+
+        this.paged = true;
+      },
+    },
+  ]);
+  return DataManager;
+})();
+
+exports.default = DataManager;

--- a/dist/utils/index.js
+++ b/dist/utils/index.js
@@ -1,0 +1,53 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true,
+});
+exports.setByString = exports.byString = void 0;
+
+var byString = function byString(o, s) {
+  if (!s) {
+    return;
+  }
+
+  s = s.replace(/\[(\w+)\]/g, ".$1"); // convert indexes to properties
+
+  s = s.replace(/^\./, ""); // strip a leading dot
+
+  var a = s.split(".");
+
+  for (var i = 0, n = a.length; i < n; ++i) {
+    var x = a[i];
+
+    if (o && x in o) {
+      o = o[x];
+    } else {
+      return;
+    }
+  }
+
+  return o;
+};
+
+exports.byString = byString;
+
+var setByString = function setByString(obj, path, value) {
+  var schema = obj; // a moving reference to internal objects within obj
+
+  path = path.replace(/\[(\w+)\]/g, ".$1"); // convert indexes to properties
+
+  path = path.replace(/^\./, ""); // strip a leading dot
+
+  var pList = path.split(".");
+  var len = pList.length;
+
+  for (var i = 0; i < len - 1; i++) {
+    var elem = pList[i];
+    if (!schema[elem]) schema[elem] = {};
+    schema = schema[elem];
+  }
+
+  schema[pList[len - 1]] = value;
+};
+
+exports.setByString = setByString;

--- a/dist/utils/polyfill/array.find.js
+++ b/dist/utils/polyfill/array.find.js
@@ -1,0 +1,31 @@
+"use strict";
+
+Object.defineProperty(Array.prototype, "find", {
+  value: function value(predicate) {
+    if (this == null) {
+      throw new TypeError('"this" is null or not defined');
+    }
+
+    var o = Object(this);
+    var len = o.length >>> 0;
+
+    if (typeof predicate !== "function") {
+      throw new TypeError("predicate must be a function");
+    }
+
+    var thisArg = arguments[1];
+    var k = 0;
+
+    while (k < len) {
+      var kValue = o[k];
+
+      if (predicate.call(thisArg, kValue, k, o)) {
+        return kValue;
+      }
+
+      k++;
+    }
+
+    return undefined;
+  },
+});

--- a/dist/utils/polyfill/index.js
+++ b/dist/utils/polyfill/index.js
@@ -1,0 +1,5 @@
+"use strict";
+
+if (!Array.prototype.find) {
+  require("./array.find");
+}

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/mbrn/material-table.git"
+    "url": "git+https://github.com/cursedmagician/material-table.git"
   },
   "keywords": [
     "react",

--- a/package.json
+++ b/package.json
@@ -2,10 +2,10 @@
   "name": "material-table",
   "version": "1.69.2",
   "description": "Datatable for React based on https://material-ui.com/api/table/ with additional features",
-  "main": "src/index.js",
+  "main": "dist/index.js",
   "types": "types/index.d.ts",
   "files": [
-    "src",
+    "dist",
     "types"
   ],
   "babel": {

--- a/package.json
+++ b/package.json
@@ -2,10 +2,10 @@
   "name": "material-table",
   "version": "1.69.2",
   "description": "Datatable for React based on https://material-ui.com/api/table/ with additional features",
-  "main": "dist/index.js",
+  "main": "src/index.js",
   "types": "types/index.d.ts",
   "files": [
-    "dist",
+    "src",
     "types"
   ],
   "babel": {

--- a/src/components/m-table-edit-row.js
+++ b/src/components/m-table-edit-row.js
@@ -80,7 +80,7 @@ export default class MTableEditRow extends React.Component {
           allowEditing = true;
         }
         if (typeof columnDef.editable === "function") {
-          allowEditing = columnDef.editable(columnDef, this.props.data);
+          allowEditing = columnDef.editable(columnDef, this.props.data, this.state.data);
         }
         if (!columnDef.field || !allowEditing) {
           const readonlyValue = this.props.getFieldValue(


### PR DESCRIPTION
Easily enable/disable editing of a column based on other related columns values as they change.

## Related Issue

Relate the Github issue with this PR using `#`

## Description

Currently the editable function only has access to the row data available when starting editing, by allowing access to the state, you can very easily have dynamic enable/disable of editable columns based on a related value like a checkbox changing.

## Related PRs

List related PRs against other branches:

| branch              | PR       |
| ------------------- | -------- |
| other_pr_production | [link]() |
| other_pr_master     | [link]() |

## Impacted Areas in Application

List general components of the application that this PR will affect:

\*

## Additional Notes

The change makes the state available as an additional parameter to the editable function, this is to ensure it is a non breaking change in case someone relies on the row data being the original values. While I think this may be overkill, it is safer.

Currently to accomplish something similar, you have to track and maintain a state with custom edit components and then use that state in the editable component, this simplifies the whole process. 
