### PR TITLE
Add initial tests

### DIFF
--- a/configs/.eslintrc
+++ b/configs/.eslintrc
@@ -1,5 +1,11 @@
 {
-  "extends": ["standard", "eslint:recommended", "plugin:react/recommended"],
+  "plugins": ["jest"],
+  "extends": [
+    "standard",
+    "eslint:recommended",
+    "plugin:react/recommended",
+    "plugin:jest/recommended"
+  ],
   "rules": {
     "one-var": "off",
     "semi": ["error", "always", {

--- a/jest-setup.js
+++ b/jest-setup.js
@@ -1,0 +1,2 @@
+import "@testing-library/jest-dom";
+import "jest-canvas-mock";

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  setupFilesAfterEnv: ["<rootDir>/jest-setup.js"],
+};

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "eslint": "eslint src/** -c ./configs/.eslintrc",
     "tsc": "tsc --noEmit --lib es6,dom --skipLibCheck types/index.d.ts",
     "lint:fix": "eslint src/** --fix",
-    "prettify": "prettier --write **/*.js"
+    "prettify": "prettier --write **/*.js",
+    "test": "jest"
   },
   "husky": {
     "hooks": {
@@ -51,6 +52,8 @@
     "@babel/preset-env": "7.2.0",
     "@babel/preset-react": "7.0.0",
     "@material-ui/core": "4.0.1",
+    "@testing-library/jest-dom": "^5.11.9",
+    "@testing-library/react": "^11.2.5",
     "babel-eslint": "10.0.1",
     "babel-loader": "8.0.4",
     "babel-polyfill": "6.26.0",
@@ -59,11 +62,14 @@
     "eslint-config-defaults": "9.0.0",
     "eslint-config-standard": "12.0.0",
     "eslint-plugin-import": "2.14.0",
+    "eslint-plugin-jest": "^24.1.3",
     "eslint-plugin-node": "7.0.1",
     "eslint-plugin-promise": "4.0.1",
     "eslint-plugin-react": "7.11.1",
     "eslint-plugin-standard": "4.0.0",
     "husky": "1.2.0",
+    "jest": "^26.6.3",
+    "jest-canvas-mock": "^2.3.1",
     "prettier": "2.0.5",
     "pretty-quick": "2.0.1",
     "react": "16.8.6",

--- a/src/tests/index.test.js
+++ b/src/tests/index.test.js
@@ -1,0 +1,99 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import MaterialTable from "../index";
+import { getData, getColumns } from "./test-utils";
+
+describe("MaterialTable", () => {
+  it("renders the empty table", () => {
+    render(<MaterialTable />);
+
+    // Checks for table body
+    expect(screen.getAllByRole("table")).toHaveLength(2);
+
+    // Header
+    expect(
+      screen.getByRole("heading", { name: "Table Title" })
+    ).toBeInTheDocument();
+
+    // Searchbar
+    expect(
+      screen.getByRole("textbox", { name: /search/i })
+    ).toBeInTheDocument();
+
+    // Rows
+    expect(screen.getAllByRole("rowgroup")).toHaveLength(3);
+    expect(screen.getAllByRole("row")).toHaveLength(3);
+    expect(screen.getByRole("row", { name: "" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("row", { name: "No records to display" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("row", {
+        name: "5 rows First Page Previous Page 0-0 of 0 Next Page Last Page",
+      })
+    ).toBeInTheDocument();
+
+    // Pagination
+    expect(screen.getAllByText("0-0 of 0")).toHaveLength(2);
+    expect(screen.getByRole("button", { name: /5 rows/i })).toBeInTheDocument();
+  });
+
+  it("renders the table with empty columns and data", () => {
+    render(<MaterialTable data={[]} columns={[]} />);
+
+    // Checks for table body
+    expect(screen.getAllByRole("table")).toHaveLength(2);
+
+    // Header
+    expect(
+      screen.getByRole("heading", { name: "Table Title" })
+    ).toBeInTheDocument();
+
+    // Searchbar
+    expect(
+      screen.getByRole("textbox", { name: /search/i })
+    ).toBeInTheDocument();
+
+    // Rows
+    expect(screen.getAllByRole("rowgroup")).toHaveLength(3);
+    expect(screen.getAllByRole("row")).toHaveLength(3);
+    expect(screen.getByRole("row", { name: "" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("row", { name: "No records to display" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("row", {
+        name: "5 rows First Page Previous Page 0-0 of 0 Next Page Last Page",
+      })
+    ).toBeInTheDocument();
+
+    // Pagination
+    expect(screen.getAllByText("0-0 of 0")).toHaveLength(2);
+    expect(screen.getByRole("button", { name: /5 rows/i })).toBeInTheDocument();
+  });
+
+  it("renders the rows with columns", () => {
+    render(<MaterialTable data={getData()} columns={getColumns()} />);
+
+    expect(screen.getAllByRole("rowgroup")).toHaveLength(3);
+    expect(screen.getAllByRole("row")).toHaveLength(8);
+
+    expect(screen.getAllByRole("columnheader")).toHaveLength(7);
+
+    expect(
+      screen.getByRole("row", {
+        name: "Name Birthcity Age Birthyear Birthdate Money Is available",
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("row", {
+        name: /Baran Istanbul/,
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("row", {
+        name: /Dominik Aachen/,
+      })
+    ).toBeInTheDocument();
+  });
+});

--- a/src/tests/test-utils.js
+++ b/src/tests/test-utils.js
@@ -1,0 +1,38 @@
+const columns = [
+  { title: "Name", field: "name" },
+  { title: "Birthcity", field: "city", type: "string" },
+  { title: "Age", field: "age", type: "numeric" },
+  { title: "Birthyear", field: "date", type: "date" },
+  { title: "Birthdate", field: "date", type: "datetime" },
+  { title: "Money", field: "money", type: "currency" },
+  { title: "Is available", field: "available", type: "boolean" },
+];
+
+const data = [
+  {
+    name: "Baran",
+    city: "Istanbul",
+    age: 30,
+    date: new Date(0),
+    money: 500,
+    available: true,
+  },
+  {
+    name: "Dominik",
+    city: "Aachen",
+    age: 26,
+    date: new Date("2020-11-11"),
+    money: 0,
+    available: false,
+  },
+];
+
+function getColumns(count = columns.length) {
+  return columns.slice(0, count);
+}
+
+function getData(count = data.length) {
+  return data.slice(0, count);
+}
+
+export { columns, data, getColumns, getData };


### PR DESCRIPTION
## Related Issue
#1196

## Description

Adds test scaffolding.
 - Adds @testing-library/react.
 - Adds @testing-library/jest-dom custom matchers.
 - Adds eslint-plugin-jest.
 - Adds baseline tests, inheriting from [existing test-setup branch](https://github.com/mbrn/material-table/tree/testing).

## Impacted Areas in Application

- Adds devDependencies
- Adds new test directory
- No production code affected