### PR TITLE
allow to render false Boolean values in type group

### DIFF
--- a/src/components/m-table-cell.js
+++ b/src/components/m-table-cell.js
@@ -27,7 +27,7 @@ export default class MTableCell extends React.Component {
     if (this.props.columnDef.render) {
       if (this.props.rowData) {
         return this.props.columnDef.render(this.props.rowData, "row");
-      } else if (this.props.value) {
+      } else if (this.props.value || typeof this.props.value === 'boolean') {
         return this.props.columnDef.render(this.props.value, "group");
       }
     } else if (this.props.columnDef.type === "boolean") {


### PR DESCRIPTION
## Related Issue

Related with #466 

## Description

I have a Boolean column and I want the label "Sim" to true and "Não" to false, but when doing:

```
render: (rowData, type) => {
        if (type === 'row') return rowData.hasPages ? 'Sim' : 'Não'
        return !rowData ? 'Não' : 'Sim'
},
```
I would like to allow Boolean values ​​to have a render in case the value is false. Works well for rendering in the table, but when grouping the value is lost if false.. I don't know if this was on purpose or a bug.

## Impacted Areas in Application

m-table-cell

