### PR TITLE
Fix NPM7 Peer Dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,9 +89,9 @@
     "react-double-scrollbar": "0.0.15"
   },
   "peerDependencies": {
-    "@date-io/core": "1.3.6",
-    "@material-ui/core": "4.0.1",
-    "react": "16.8.4",
-    "react-dom": "16.8.4"
+    "@date-io/core": "^1.3.6",
+    "@material-ui/core": "^4.0.1",
+    "react": "^16.8.4 || ^17.0.0",
+    "react-dom": "^16.8.4 || ^17.0.0"
   }
 }


### PR DESCRIPTION
## Related Issue

#2720 #2730

## Description

Add major version pin for `@date-io/core` and `@material-ui/core` plus `^16.8.4 || ^17.0.0` for `react` and `react-dom`.