### PR TITLE
This solves the problem of action either showing when checkbox is on/off

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -509,7 +509,9 @@ class App extends Component {
                     headerSelectionProps: {
                       color: "primary",
                     },
-                    selection: false,
+                    selection: true,
+                    showTextRowsSelected: true,
+
                     selectionProps: (rowData) => {
                       rowData.tableData.disabled = rowData.name === "A1";
 
@@ -519,6 +521,19 @@ class App extends Component {
                       };
                     },
                   }}
+                  actions={[
+                    {
+                      icon: "add_box",
+                      tooltip:
+                        "This button is always visible regardless if checkbox is selected or not",
+                      position: "toolbarAlways",
+                      onClick: () => {
+                        console.log(
+                          "This button is always visible regardless if checkbox is selected or not"
+                        );
+                      },
+                    },
+                  ]}
                   // editable={{
                   //   onBulkUpdate: (changedRows) =>
                   //     new Promise((resolve, reject) => {

--- a/src/components/m-table-toolbar.js
+++ b/src/components/m-table-toolbar.js
@@ -275,7 +275,10 @@ export class MTableToolbar extends React.Component {
           <this.props.components.Actions
             actions={
               this.props.actions &&
-              this.props.actions.filter((a) => a.position === "toolbar")
+              this.props.actions.filter(
+                (a) =>
+                  a.position === "toolbar" || a.position === "toolbarAlways"
+              )
             }
             components={this.props.components}
           />
@@ -289,7 +292,8 @@ export class MTableToolbar extends React.Component {
       <React.Fragment>
         <this.props.components.Actions
           actions={this.props.actions.filter(
-            (a) => a.position === "toolbarOnSelect"
+            (a) =>
+              a.position === "toolbarOnSelect" || a.position === "toolbarAlways"
           )}
           data={this.props.selectedRows}
           components={this.props.components}

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -23,6 +23,7 @@ export const propTypes = {
           "toolbar",
           "toolbarOnSelect",
           "row",
+          "toolbarAlways",
         ]),
         tooltip: PropTypes.string,
         onClick: PropTypes.func.isRequired,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -110,7 +110,7 @@ export interface Action<RowData extends object> {
   disabled?: boolean;
   icon: string | (() => React.ReactElement<any>) | SvgIconComponent;
   isFreeAction?: boolean;
-  position?: "auto" | "toolbar" | "toolbarOnSelect" | "row";
+  position?: "auto" | "toolbar" | "toolbarOnSelect" | "row" | "toolbarAlways";
   tooltip?: string;
   onClick: (event: any, data: RowData | RowData[]) => void;
   iconProps?: IconProps;


### PR DESCRIPTION
## Related Issue
The issue below was incorrectly closed in my understanding, the bug described there is quite a common requirement.
#980

## Description
The intention of this PR is to add another action toolbar position option that always shows the action in the toolbar.

## Related PRs

no other PRs

## Impacted Areas in Application

It has zero impact on existing applications using material-table


the only component change is:
m-table-toolbar.js

\*

## Additional Notes

This change saved my life, I think it will help other people too. I hope it gets approved, thanks.
