### PR TITLE
Restore peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,9 +89,9 @@
     "react-double-scrollbar": "0.0.15"
   },
   "peerDependencies": {
-    "@date-io/core": "1.3.6",
-    "@material-ui/core": "4.0.1",
-    "react": "16.8.4",
-    "react-dom": "16.8.4"
+    "@date-io/core": "^1.3.6",
+    "@material-ui/core": "^4.0.1",
+    "react": "^16.8.4",
+    "react-dom": "^16.8.4"
   }
 }


### PR DESCRIPTION
## Related Issue

This fixes #2817

## Description

Restore peer dependencies to support newer semantic versions.  This was lost in mbrn/material-table#2510 but prevents interoperation with many other tools.

## Related PRs

| branch              | PR       |
| ------------------- | -------- |
| master     | #2510  |

## Impacted Areas in Application

Building/Installing