### PR TITLE
Fix: edit row state cloning on init

### DIFF
--- a/src/components/m-table-edit-row.js
+++ b/src/components/m-table-edit-row.js
@@ -14,7 +14,7 @@ export default class MTableEditRow extends React.Component {
 
     this.state = {
       data: props.data
-        ? JSON.parse(JSON.stringify(props.data))
+        ? { ...props.data }
         : this.createRowData(),
     };
   }


### PR DESCRIPTION
## Description

Improve performance to avoid misbehaving when passing complex objects


## Additional Notes

This is optional, feel free to follow your hearth and write here :)
