### PR TITLE
Fixed bad icon types

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -253,42 +253,33 @@ export const MTableToolbar: (props: any) => React.ReactElement<any>;
 export const MTable: (props: any) => React.ReactElement<any>;
 
 export interface Icons {
-  Add?: React.ForwardRefExoticComponent<React.RefAttributes<SVGSVGElement>>;
-  Check?: React.ForwardRefExoticComponent<React.RefAttributes<SVGSVGElement>>;
-  Clear?: React.ForwardRefExoticComponent<React.RefAttributes<SVGSVGElement>>;
-  Delete?: React.ForwardRefExoticComponent<React.RefAttributes<SVGSVGElement>>;
-  DetailPanel?: React.ForwardRefExoticComponent<
-    React.RefAttributes<SVGSVGElement>
-  >;
-  Edit?: React.ForwardRefExoticComponent<React.RefAttributes<SVGSVGElement>>;
-  Export?: React.ForwardRefExoticComponent<React.RefAttributes<SVGSVGElement>>;
-  Filter?: React.ForwardRefExoticComponent<React.RefAttributes<SVGSVGElement>>;
-  FirstPage?: React.ForwardRefExoticComponent<
-    React.RefAttributes<SVGSVGElement>
-  >;
-  SortArrow?: React.ForwardRefExoticComponent<
-    React.RefAttributes<SVGSVGElement>
-  >;
-  LastPage?: React.ForwardRefExoticComponent<
-    React.RefAttributes<SVGSVGElement>
-  >;
-  NextPage?: React.ForwardRefExoticComponent<
-    React.RefAttributes<SVGSVGElement>
-  >;
-  PreviousPage?: React.ForwardRefExoticComponent<
-    React.RefAttributes<SVGSVGElement>
-  >;
-  ResetSearch?: React.ForwardRefExoticComponent<
-    React.RefAttributes<SVGSVGElement>
-  >;
-  Search?: React.ForwardRefExoticComponent<React.RefAttributes<SVGSVGElement>>;
-  ThirdStateCheck?: React.ForwardRefExoticComponent<
-    React.RefAttributes<SVGSVGElement>
-  >;
-  ViewColumn?: React.ForwardRefExoticComponent<
-    React.RefAttributes<SVGSVGElement>
-  >;
-  Retry?: React.ForwardRefExoticComponent<React.RefAttributes<SVGSVGElement>>;
+  Add?: React.ForwardRefExoticComponent<any> & React.RefAttributes<SVGSVGElement>;
+  Check?: React.ForwardRefExoticComponent<any> & React.RefAttributes<SVGSVGElement>;
+  Clear?: React.ForwardRefExoticComponent<any> & React.RefAttributes<SVGSVGElement>;
+  Delete?: React.ForwardRefExoticComponent<any> & React.RefAttributes<SVGSVGElement>;
+  DetailPanel?: React.ForwardRefExoticComponent<any> & 
+    React.RefAttributes<SVGSVGElement>;
+  Edit?: React.ForwardRefExoticComponent<any> & React.RefAttributes<SVGSVGElement>;
+  Export?: React.ForwardRefExoticComponent<any> & React.RefAttributes<SVGSVGElement>;
+  Filter?: React.ForwardRefExoticComponent<any> & React.RefAttributes<SVGSVGElement>;
+  FirstPage?: React.ForwardRefExoticComponent<any> & 
+    React.RefAttributes<SVGSVGElement>;
+  SortArrow?: React.ForwardRefExoticComponent<any> & 
+    React.RefAttributes<SVGSVGElement>;
+  LastPage?: React.ForwardRefExoticComponent<any> & 
+    React.RefAttributes<SVGSVGElement>;
+  NextPage?: React.ForwardRefExoticComponent<any> & 
+    React.RefAttributes<SVGSVGElement>;
+  PreviousPage?: React.ForwardRefExoticComponent<any> & 
+    React.RefAttributes<SVGSVGElement>;
+  ResetSearch?: React.ForwardRefExoticComponent<any> & 
+    React.RefAttributes<SVGSVGElement>;
+  Search?: React.ForwardRefExoticComponent<any> & React.RefAttributes<SVGSVGElement>;
+  ThirdStateCheck?: React.ForwardRefExoticComponent<any> & 
+    React.RefAttributes<SVGSVGElement>;
+  ViewColumn?: React.ForwardRefExoticComponent<any> & 
+    React.RefAttributes<SVGSVGElement>;
+  Retry?: React.ForwardRefExoticComponent<any> & React.RefAttributes<SVGSVGElement>;
 }
 
 export interface Options<RowData extends object> {


### PR DESCRIPTION
The typings on the icons are incorrect and should match what `forwardRef` returns

## Related Issue

This is based on details I raised in issue #1553

## Description

These types are incorrect:
```
Add?: React.ForwardRefExoticComponent<React.RefAttributes<SVGSVGElement>>;
```

They should match what `forwardRef` returns:

```
Add?: React.ForwardRefExoticComponent<any> & React.RefAttributes<SVGSVGElement>;
```

## Impacted Areas in Application

Typescript

## Additional Notes

Consider simplifying these icon types even further, since the code doesn't appear to be using those refs that the types require.
