### PR TITLE
update import from @material-ui/core

### DIFF
--- a/src/material-table.js
+++ b/src/material-table.js
@@ -10,7 +10,7 @@ import { DragDropContext, Droppable } from "react-beautiful-dnd";
 import DataManager from "./utils/data-manager";
 import { debounce } from "debounce";
 import equal from "fast-deep-equal";
-import { withStyles } from "@material-ui/core";
+import withStyles from "@material-ui/core/styles/withStyles";
 import * as CommonValues from "./utils/common-values";
 
 /* eslint-enable no-unused-vars */


### PR DESCRIPTION
## Description

One import from @material-ui/core imported all the library and made the bundle size pretty big
This simple line of code could represent 400kb in my app :)