### PR TITLE
multiline and rows props :smile:

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ class App extends Component {
           columns={[
             { title: "Adı", field: "name" },
             { title: "Soyadı", field: "surname" },
+            { title: "Desc1", field: "description", multiline: true, rows: 2 }, // generate a textarea input
             { title: "Doğum Yılı", field: "birthYear", type: "numeric" },
             {
               title: "Doğum Yeri",
@@ -195,6 +196,7 @@ class App extends Component {
             {
               name: "Mehmet",
               surname: "Baran",
+              description: "Lorem Ipsum is simply dummy text of the printing and typesetting industry.",
               birthYear: 1987,
               birthCity: 63,
             },

--- a/src/components/m-table-edit-cell.js
+++ b/src/components/m-table-edit-cell.js
@@ -56,7 +56,7 @@ class MTableEditCell extends React.Component {
   };
 
   handleKeyDown = (e) => {
-    if (e.keyCode === 13) {
+    if ((e.keyCode === 13 && e.target.type !== 'textarea') || (e.keyCode === 13 && e.shiftKey)) {
       this.onApprove();
     } else if (e.keyCode === 27) {
       this.onCancel();

--- a/src/components/m-table-edit-field.js
+++ b/src/components/m-table-edit-field.js
@@ -160,6 +160,10 @@ class MTableEditField extends React.Component {
       <TextField
         {...this.getProps()}
         fullWidth
+        multiline={
+          this.props.columnDef.multiline === true ? true : false
+        }
+        rows={this.props.columnDef.rows || 1}
         style={
           this.props.columnDef.type === "numeric" ? { float: "right" } : {}
         }


### PR DESCRIPTION
## Multiline is required😢 

TextField has a nice prop - multiline that turns the text field into the auto enlarging textarea.  [#934](https://github.com/mbrn/material-table/issues/934)

## Description

The above issue solution doesn't work with  ["cell editable table"](https://material-table.com/#/docs/features/editable).

I added a `multiline` and` rows` props to the column fixtures which convert input to textarea element naturally. These do not conflict with the 'enterKey' feature defined in [pull#2008](https://github.com/mbrn/material-table/pull/2008)

## Impacted Areas in Application

`multiline` and `rows` properties can be used with all editable tables (input type text) and both are optional 😊 

```javascript
 <MaterialTable
      columns={[
          { title: "Desc1", field: "description", multiline: true, rows: 2 }, // generate a textarea input
      ]}
      data={[
        {
          description: "A long text 2 rows high. a long text 2 rows high. a long text 2 rows high. a long text 2 rows high"
        },
      ]}
      title="Demo Title"
   />
```

### Default values

`multiline: false`     
`rows: 1`
