### PR TITLE
Fixes/remote on search change

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "eslint": "eslint src/** -c ./configs/.eslintrc",
     "tsc": "tsc --noEmit --lib es6,dom --skipLibCheck types/index.d.ts",
     "lint:fix": "eslint src/** --fix",
-    "prettify": "prettier --write **/*.js"
+    "prettify": "prettier --write **/*.js",
+    "prepare": "npm run build"
   },
   "husky": {
     "hooks": {

--- a/src/components/m-table-cell.js
+++ b/src/components/m-table-cell.js
@@ -175,6 +175,7 @@ export default class MTableCell extends React.Component {
             borderBottom: "1px dashed grey",
             cursor: "pointer",
             width: "max-content",
+            display: "inline",
           }}
           onClick={(e) => {
             e.stopPropagation();

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -650,7 +650,9 @@ export default class MaterialTable extends React.Component {
       query.page = 0;
       query.search = searchText;
 
-      this.onQueryChange(query);
+      this.onQueryChange(query, () => {
+        this.props.onSearchChange && this.props.onSearchChange(searchText);
+      });
     } else {
       this.setState(this.dataManager.getRenderState(), () => {
         this.props.onSearchChange && this.props.onSearchChange(searchText);


### PR DESCRIPTION
## Description

While onChangePage, onOrderChange, onChangeRowsPerPage are all invoked when data is remote, onSearchChange is not, making it difficult to do paging.

## Impacted Areas in Application

Paging, remote data.
