### PR TITLE
fix: exportPdf options prop typing

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -312,6 +312,7 @@ export interface Options<RowData extends object> {
     | string
     | ((columns: Column<RowData>, data: string[][]) => string);
   exportCsv?: (columns: any[], renderData: any[]) => void;
+  exportPdf?: (columns: any[], renderData: any[]) => void;
   filtering?: boolean;
   filterCellStyle?: React.CSSProperties;
   filterRowStyle?: React.CSSProperties;


### PR DESCRIPTION
## Related Issue

#2883

## Description

Adds the `exportPdf` function typing, similar to `exportCsv` for overriding the default pdf export.

## Additional Notes

This is optional, feel free to follow your hearth and write here :)
