### PR TITLE
Fixed empty string not a valid groupRowSeparator

### DIFF
--- a/src/components/m-table-group-row.js
+++ b/src/components/m-table-group-row.js
@@ -124,7 +124,7 @@ export default class MTableGroupRow extends React.Component {
       title = React.cloneElement(title);
     }
 
-    let separator = this.props.options.groupRowSeparator || ": ";
+    let separator = this.props.options.groupRowSeparator ?? ": ";
 
     return (
       <>


### PR DESCRIPTION
## Related Issue

Relate the Github issue with this PR using `#`

#2897

## Description

Fixes groupRowSeparator not accepting an empty string.

## Impacted Areas in Application

This is a one line change