### PR TITLE
Update customSort typing with optional sortDirection

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -159,7 +159,8 @@ export interface Column<RowData extends object> {
   customSort?: (
     data1: RowData,
     data2: RowData,
-    type: "row" | "group"
+    type: "row" | "group",
+    sortDirection?: "desc"
   ) => number;
   defaultFilter?: any;
   defaultGroupOrder?: number;


### PR DESCRIPTION
Minor update to the typings, to support use of a sortDirection in customSort functions: https://github.com/mbrn/material-table/blob/b7474ca0f5497f04ff3a3d50e709d86de7c639b0/src/utils/data-manager.js#L554 