### PR TITLE
Update m-table-header.js

### DIFF
--- a/src/components/m-table-header.js
+++ b/src/components/m-table-header.js
@@ -80,12 +80,12 @@ export class MTableHeader extends React.Component {
     );
 
     const style = {
-      ...this.props.headerStyle,
-      ...columnDef.headerStyle,
       boxSizing: "border-box",
       width,
       maxWidth: columnDef.maxWidth,
       minWidth: columnDef.minWidth,
+      ...this.props.headerStyle,
+      ...columnDef.headerStyle,
     };
 
     if (


### PR DESCRIPTION
Allowing headerstyle (Columndef / Props) to override cell width style

## Related Issue

#2823 

## Description

Since width is overriding while creating styles, headerstyle's width is getting ignored
