### PR TITLE
Update Vulnerable version of jspdf package

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "debounce": "1.2.0",
     "fast-deep-equal": "2.0.1",
     "filefy": "0.1.10",
-    "jspdf": "2.1.0",
+    "jspdf": "2.3.1",
     "jspdf-autotable": "3.5.9",
     "prop-types": "15.6.2",
     "react-beautiful-dnd": "13.0.0",


### PR DESCRIPTION
## Description

Versions previous to`2.3.1` introduce a Regular Expression Denial of Service (ReDoS) Vulnerability.
This PR updates to version `2.3.1` of the library `jspdf` in order to mitigate that. 

## Additional Notes

More info here: https://snyk.io/vuln/SNYK-JS-JSPDF-1073626
