### PR TITLE
deprecated @material-ui/core prop-type updates

### DIFF
--- a/src/components/m-table-pagination.js
+++ b/src/components/m-table-pagination.js
@@ -9,19 +9,19 @@ import * as React from "react";
 
 class MTablePaginationInner extends React.Component {
   handleFirstPageButtonClick = (event) => {
-    this.props.onChangePage(event, 0);
+    this.props.onPageChange(event, 0);
   };
 
   handleBackButtonClick = (event) => {
-    this.props.onChangePage(event, this.props.page - 1);
+    this.props.onPageChange(event, this.props.page - 1);
   };
 
   handleNextButtonClick = (event) => {
-    this.props.onChangePage(event, this.props.page + 1);
+    this.props.onPageChange(event, this.props.page + 1);
   };
 
   handleLastPageButtonClick = (event) => {
-    this.props.onChangePage(
+    this.props.onPageChange(
       event,
       Math.max(0, Math.ceil(this.props.count / this.props.rowsPerPage) - 1)
     );
@@ -147,7 +147,7 @@ const actionsStyles = (theme) => ({
 });
 
 MTablePaginationInner.propTypes = {
-  onChangePage: PropTypes.func,
+  onPageChange: PropTypes.func,
   page: PropTypes.number,
   count: PropTypes.number,
   rowsPerPage: PropTypes.number,

--- a/src/components/m-table-stepped-pagination.js
+++ b/src/components/m-table-stepped-pagination.js
@@ -10,23 +10,23 @@ import * as React from "react";
 
 class MTablePaginationInner extends React.Component {
   handleFirstPageButtonClick = (event) => {
-    this.props.onChangePage(event, 0);
+    this.props.onPageChange(event, 0);
   };
 
   handleBackButtonClick = (event) => {
-    this.props.onChangePage(event, this.props.page - 1);
+    this.props.onPageChange(event, this.props.page - 1);
   };
 
   handleNextButtonClick = (event) => {
-    this.props.onChangePage(event, this.props.page + 1);
+    this.props.onPageChange(event, this.props.page + 1);
   };
 
   handleNumberButtonClick = (number) => (event) => {
-    this.props.onChangePage(event, number);
+    this.props.onPageChange(event, number);
   };
 
   handleLastPageButtonClick = (event) => {
-    this.props.onChangePage(
+    this.props.onPageChange(
       event,
       Math.max(0, Math.ceil(this.props.count / this.props.rowsPerPage) - 1)
     );
@@ -154,7 +154,7 @@ const actionsStyles = (theme) => ({
 });
 
 MTablePaginationInner.propTypes = {
-  onChangePage: PropTypes.func,
+  onPageChange: PropTypes.func,
   page: PropTypes.number,
   count: PropTypes.number,
   rowsPerPage: PropTypes.number,

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -381,7 +381,7 @@ export default class MaterialTable extends React.Component {
     }
   };
 
-  onChangeRowsPerPage = (event) => {
+  onRowsPerPageChange = (event) => {
     const pageSize = event.target.value;
 
     this.dataManager.changePageSize(pageSize);
@@ -393,14 +393,14 @@ export default class MaterialTable extends React.Component {
       query.pageSize = event.target.value;
       query.page = 0;
       this.onQueryChange(query, () => {
-        this.props.onChangeRowsPerPage &&
-          this.props.onChangeRowsPerPage(pageSize);
+        this.props.onRowsPerPageChange &&
+          this.props.onRowsPerPageChange(pageSize);
       });
     } else {
       this.dataManager.changeCurrentPage(0);
       this.setState(this.dataManager.getRenderState(), () => {
-        this.props.onChangeRowsPerPage &&
-          this.props.onChangeRowsPerPage(pageSize);
+        this.props.onRowsPerPageChange &&
+          this.props.onRowsPerPageChange(pageSize);
       });
     }
   };
@@ -775,7 +775,7 @@ export default class MaterialTable extends React.Component {
                 }}
                 page={this.isRemoteData() ? this.state.query.page : currentPage}
                 onPageChange={this.onPageChange}
-                onChangeRowsPerPage={this.onChangeRowsPerPage}
+                onRowsPerPageChange={this.onRowsPerPageChange}
                 ActionsComponent={(subProps) =>
                   props.options.paginationType === "normal" ? (
                     <MTablePagination

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -158,7 +158,7 @@ export default class MaterialTable extends React.Component {
       : this.state.pageSize;
 
     if (count <= pageSize * currentPage && currentPage !== 0) {
-      this.onChangePage(null, Math.max(0, Math.ceil(count / pageSize) - 1));
+      this.onPageChange(null, Math.max(0, Math.ceil(count / pageSize) - 1));
     }
   }
 
@@ -362,21 +362,21 @@ export default class MaterialTable extends React.Component {
     }
   };
 
-  onChangePage = (event, page) => {
+  onPageChange = (event, page) => {
     if (this.isRemoteData()) {
       const query = { ...this.state.query };
       query.page = page;
       this.onQueryChange(query, () => {
-        this.props.onChangePage &&
-          this.props.onChangePage(page, query.pageSize);
+        this.props.onPageChange &&
+          this.props.onPageChange(page, query.pageSize);
       });
     } else {
       if (!this.isOutsidePageNumbers(this.props)) {
         this.dataManager.changeCurrentPage(page);
       }
       this.setState(this.dataManager.getRenderState(), () => {
-        this.props.onChangePage &&
-          this.props.onChangePage(page, this.state.pageSize);
+        this.props.onPageChange &&
+          this.props.onPageChange(page, this.state.pageSize);
       });
     }
   };
@@ -386,7 +386,7 @@ export default class MaterialTable extends React.Component {
 
     this.dataManager.changePageSize(pageSize);
 
-    this.props.onChangePage && this.props.onChangePage(0, pageSize);
+    this.props.onPageChange && this.props.onPageChange(0, pageSize);
 
     if (this.isRemoteData()) {
       const query = { ...this.state.query };
@@ -774,7 +774,7 @@ export default class MaterialTable extends React.Component {
                   ),
                 }}
                 page={this.isRemoteData() ? this.state.query.page : currentPage}
-                onChangePage={this.onChangePage}
+                onPageChange={this.onPageChange}
                 onChangeRowsPerPage={this.onChangeRowsPerPage}
                 ActionsComponent={(subProps) =>
                   props.options.paginationType === "normal" ? (

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -376,7 +376,7 @@ export const propTypes = {
   onGroupRemoved: PropTypes.func,
   onSelectionChange: PropTypes.func,
   onChangeRowsPerPage: PropTypes.func,
-  onChangePage: PropTypes.func,
+  onPageChange: PropTypes.func,
   onChangeColumnHidden: PropTypes.func,
   onOrderChange: PropTypes.func,
   onRowClick: PropTypes.func,

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -375,7 +375,7 @@ export const propTypes = {
   onColumnDragged: PropTypes.func,
   onGroupRemoved: PropTypes.func,
   onSelectionChange: PropTypes.func,
-  onChangeRowsPerPage: PropTypes.func,
+  onRowsPerPageChange: PropTypes.func,
   onPageChange: PropTypes.func,
   onChangeColumnHidden: PropTypes.func,
   onOrderChange: PropTypes.func,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -46,7 +46,7 @@ export interface MaterialTableProps<RowData extends object> {
   parentChildData?: (row: RowData, rows: RowData[]) => RowData | undefined;
   localization?: Localization;
   onChangeRowsPerPage?: (pageSize: number) => void;
-  onChangePage?: (page: number, pageSize: number) => void;
+  onPageChange?: (page: number, pageSize: number) => void;
   onChangeColumnHidden?: (column: Column<RowData>, hidden: boolean) => void;
   onColumnDragged?: (sourceIndex: number, destinationIndex: number) => void;
   onOrderChange?: (orderBy: number, orderDirection: "asc" | "desc") => void;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -45,7 +45,7 @@ export interface MaterialTableProps<RowData extends object> {
   options?: Options<RowData>;
   parentChildData?: (row: RowData, rows: RowData[]) => RowData | undefined;
   localization?: Localization;
-  onChangeRowsPerPage?: (pageSize: number) => void;
+  onRowsPerPageChange?: (pageSize: number) => void;
   onPageChange?: (page: number, pageSize: number) => void;
   onChangeColumnHidden?: (column: Column<RowData>, hidden: boolean) => void;
   onColumnDragged?: (sourceIndex: number, destinationIndex: number) => void;


### PR DESCRIPTION
## Related Issue

#2935 

## Description

Prop type updates from @material-ui/core deprecated prop types:

* Updates onChangePage  to onPageChange
* Updates onChangeRowsPerPage to onRowsPerPageChange