### PR TITLE
Clear columns after component unmount

### DIFF
--- a/src/material-table.js
+++ b/src/material-table.js
@@ -69,6 +69,10 @@ export default class MaterialTable extends React.Component {
     );
   }
 
+  componentWillUnmount() {
+    this.props.columns.forEach(col => delete col.tableData);
+  }
+
   setDataManagerFields(props, isInit) {
     let defaultSortColumnIndex = -1;
     let defaultSortDirection = "";


### PR DESCRIPTION
## Description

This PR resolved bug related to crushing cell width after remount table.