### PR TITLE
build(deps): bump jspdf from 2.1.0 to 2.3.1 to resolve CVE-2021-23353

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "debounce": "1.2.0",
     "fast-deep-equal": "2.0.1",
     "filefy": "0.1.10",
-    "jspdf": "2.1.0",
+    "jspdf": "2.3.1",
     "jspdf-autotable": "3.5.9",
     "prop-types": "15.6.2",
     "react-beautiful-dnd": "13.0.0",


### PR DESCRIPTION
## Related Issue

- #2933 

## Description

Bump to `jspdf@2.3.1` to resolve [CVE-2021-23353](https://github.com/advisories/GHSA-57f3-gghm-9mhc).
