### PR TITLE
Fix functional `cellStyle` type on `Column`

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -143,7 +143,10 @@ export interface Column<RowData extends object> {
   align?: "center" | "inherit" | "justify" | "left" | "right";
   cellStyle?:
     | React.CSSProperties
-    | ((data: RowData[], rowData: RowData) => React.CSSProperties);
+    | ((
+        value: RowData[keyof RowData],
+        rowData: RowData
+      ) => React.CSSProperties);
   currencySetting?: {
     locale?: string;
     currencyCode?: string;


### PR DESCRIPTION
## Related Issue

None

## Description

The implementation passes a cell value rather than an array of rows, so `data: RowData[]` should be `value: RowData[keyof RowData]`. 

## Related PRs

None

## Impacted Areas in Application

None, it's just a type change.

## Additional Notes

To keep the type of `value` equal to `Column<RowData>['field']` an extra key type parameter could be added to `Column`, but this would introduce a lot of changes.