### PR TITLE
Add missing type definitions for bulk edit tooltips

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -575,6 +575,7 @@ class App extends Component {
                         filterTooltip: "Filter",
                         filterPlaceHolder: "Filtaaer",
                       },
+                      // bulkEditTooltip: 'Edit all',
                     },
                   }}
                   onSearchChange={(e) => console.log("search changed: " + e)}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -376,6 +376,9 @@ export interface Localization {
     addTooltip?: React.ReactNode;
     deleteTooltip?: React.ReactNode;
     editTooltip?: React.ReactNode;
+    bulkEditTooltip?: React.ReactNode;
+    bulkEditApprove?: React.ReactNode;
+    bulkEditCancel?: React.ReactNode;
   };
   header?: {
     actions?: React.ReactNode;


### PR DESCRIPTION
## Related Issue


## Description

Just type definitions added

## Related PRs

## Impacted Areas in Application
types/index.d.ts 

List general components of the application that this PR will affect:

\*

## Additional Notes

This is my first pull request. Hope, everythings is fine.
