### PR TITLE
Update jspdf minor version to resolve security issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "debounce": "1.2.0",
     "fast-deep-equal": "2.0.1",
     "filefy": "0.1.10",
-    "jspdf": "2.1.0",
+    "jspdf": "2.3.2",
     "jspdf-autotable": "3.5.9",
     "prop-types": "15.6.2",
     "react-beautiful-dnd": "13.0.0",


### PR DESCRIPTION
## Related Issue

Details

[CVE-2021-23353](https://github.com/advisories/GHSA-57f3-gghm-9mhc) 

high severity
Vulnerable versions: < 2.3.1
Patched version: 2.3.1
This affects the package jspdf before 2.3.1. ReDoS is possible via the addImage function.

## Description

Updated jspdf to the highest minor version to avoid any code collisions, but still fix the vulnerability.

## Related PRs
I'm waiting to fix the vulnerability locally.

## Additional Notes

This is optional, feel free to follow your hearth and write here :)
