### PR TITLE
added parameter 'numberOfPagesAround' to stepped pagination

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -510,6 +510,8 @@ class App extends Component {
                       color: "primary",
                     },
                     selection: false,
+                    paginationType: "stepped",
+                    numberOfPagesAround: 2,
                     selectionProps: (rowData) => {
                       rowData.tableData.disabled = rowData.name === "A1";
 

--- a/src/components/m-table-stepped-pagination.js
+++ b/src/components/m-table-stepped-pagination.js
@@ -32,10 +32,17 @@ class MTablePaginationInner extends React.Component {
     );
   };
 
-  renderPagesButton(start, end) {
+  renderPagesButton(start, end, maxPages, numberOfPagesAround = 1) {
     const buttons = [];
 
-    for (let p = start; p <= end; p++) {
+    for (
+      let p = start - numberOfPagesAround + 1;
+      p <= end + numberOfPagesAround - 1;
+      p++
+    ) {
+      if (p < 0 || p > maxPages) {
+        continue;
+      }
       const buttonVariant = p === this.props.page ? "contained" : "text";
       buttons.push(
         <Button
@@ -68,6 +75,7 @@ class MTablePaginationInner extends React.Component {
       rowsPerPage,
       theme,
       showFirstLastPageButtons,
+      numberOfPagesAround,
     } = this.props;
 
     const localization = {
@@ -110,7 +118,12 @@ class MTablePaginationInner extends React.Component {
           </span>
         </Tooltip>
         <Hidden smDown={true}>
-          {this.renderPagesButton(pageStart, pageEnd)}
+          {this.renderPagesButton(
+            pageStart,
+            pageEnd,
+            maxPages,
+            numberOfPagesAround
+          )}
         </Hidden>
         <Tooltip title={localization.nextTooltip}>
           <span>
@@ -162,6 +175,17 @@ MTablePaginationInner.propTypes = {
   localization: PropTypes.object,
   theme: PropTypes.any,
   showFirstLastPageButtons: PropTypes.bool,
+  numberOfPagesAround: (props, propName) => {
+    if (props[propName] < 0) {
+      throw Error("numberOfPagesAround can't be negative number!");
+      //todo: to discuss: what will be the max user can set?
+      // I tried to set numberOfPagesAround to 100 - the table will show max 13 pages to both side, therefore 27 pages at top
+      //} else if (props[propName] >= 10) {
+      //  throw Error('numberOfPagesAround can\'t be greater than 10!');
+    } else if (!Number.isInteger(props[propName])) {
+      throw Error("numberOfPagesAround must be integer!");
+    }
+  },
 };
 
 MTablePaginationInner.defaultProps = {

--- a/src/default-props.js
+++ b/src/default-props.js
@@ -219,6 +219,7 @@ export const defaultProps = {
     paging: true,
     pageSize: 5,
     pageSizeOptions: [5, 10, 20],
+    numberOfPagesAround: 1,
     paginationType: "normal",
     paginationPosition: "bottom",
     showEmptyDataSourceMessage: true,

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -794,6 +794,7 @@ export default class MaterialTable extends React.Component {
                       showFirstLastPageButtons={
                         props.options.showFirstLastPageButtons
                       }
+                      numberOfPagesAround={props.options.numberOfPagesAround}
                     />
                   )
                 }

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -325,6 +325,7 @@ export const propTypes = {
     initialPage: PropTypes.number,
     maxBodyHeight: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     minBodyHeight: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+    numberOfPagesAround: PropTypes.number,
     loadingType: PropTypes.oneOf(["overlay", "linear"]),
     overflowY: PropTypes.oneOf([
       "visible",


### PR DESCRIPTION
## Related Issue

[Show more pages around current page in stepped pagination](https://github.com/material-table-core/core/discussions/477)

## Description

I added parameter numberOfPagesAround, that allow to show more pages arround current page in stepped pagination.

## Impacted Areas in Application

demo/demo.js
src/default-props.js
src/prop-types.js
src/material-table.js
src/components/m-table-stepped-pagination.js

## Additional Notes

(my first ever push to public repo. Have mercy, but feel free to criticize)
