### PR TITLE
fix: setting custom container props type

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -218,23 +218,23 @@ export interface Column<RowData extends object> {
   width?: string | number;
 }
 
-export interface Components {
-  Action?: React.ComponentType<any>;
-  Actions?: React.ComponentType<any>;
-  Body?: React.ComponentType<any>;
-  Cell?: React.ComponentType<any>;
-  Container?: React.ComponentType<any>;
-  EditField?: React.ComponentType<any>;
-  EditRow?: React.ComponentType<any>;
-  FilterRow?: React.ComponentType<any>;
-  Groupbar?: React.ComponentType<any>;
-  GroupRow?: React.ComponentType<any>;
-  Header?: React.ComponentType<any>;
-  Pagination?: React.ComponentType<any>;
-  OverlayLoading?: React.ComponentType<any>;
-  OverlayError?: React.ComponentType<any>;
-  Row?: React.ComponentType<any>;
-  Toolbar?: React.ComponentType<any>;
+export interface Components<T> {
+  Action?: React.ComponentType<T>;
+  Actions?: React.ComponentType<T>;
+  Body?: React.ComponentType<T>;
+  Cell?: React.ComponentType<T>;
+  Container?: React.ComponentType<T>;
+  EditField?: React.ComponentType<T>;
+  EditRow?: React.ComponentType<T>;
+  FilterRow?: React.ComponentType<T>;
+  Groupbar?: React.ComponentType<T>;
+  GroupRow?: React.ComponentType<T>;
+  Header?: React.ComponentType<T>;
+  Pagination?: React.ComponentType<T>;
+  OverlayLoading?: React.ComponentType<T>;
+  OverlayError?: React.ComponentType<T>;
+  Row?: React.ComponentType<T>;
+  Toolbar?: React.ComponentType<T>;
 }
 
 export const MTableAction: (props: any) => React.ReactElement<any>;


### PR DESCRIPTION
## Description

I use material-table in react-typescript project
But i get error when trying to set custom container prop, because any types :)

<img width="689" alt="image" src="https://user-images.githubusercontent.com/79831859/159077381-cbc6b354-25db-421d-9a4d-b1a294651f14.png">

## Related PRs

List related PRs against other branches:

| branch              | PR       |
| ------------------- | -------- |
| other_pr_production | [link]() |
| other_pr_master     | [link]() |

## Impacted Areas in Application

List general components of the application that this PR will affect: `types.ts`