### PR TITLE
chore: bump jspdf

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "debounce": "1.2.0",
     "fast-deep-equal": "2.0.1",
     "filefy": "0.1.10",
-    "jspdf": "2.1.0",
+    "jspdf": "^2.5.1",
     "jspdf-autotable": "3.5.9",
     "prop-types": "15.6.2",
     "react-beautiful-dnd": "13.1.0",


### PR DESCRIPTION
## Related Issue

None

## Description

This bumps the jsPDF version to resolve the ReDos vulnerability in addImage function. There are no breaking changes from jsPDF.

See also:
* https://github.com/parallax/jsPDF/releases/tag/v2.3.1
* https://github.com/parallax/jsPDF/pull/3091

## Related PRs

None

## Impacted Areas in Application

Dependencies

## Additional Notes

Right now, including `material-table` in a project shows these underlying security vulnerabilities. This PR updates `material-table` to resolve those vulnerabilities.