### PR TITLE
feat: includes loadingType none in table options

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -322,7 +322,7 @@ export interface Options<RowData extends object> {
   headerStyle?: React.CSSProperties;
   hideFilterIcons?: boolean;
   initialPage?: number;
-  loadingType?: "overlay" | "linear";
+  loadingType?: "overlay" | "linear" | "none";
   maxBodyHeight?: number | string;
   minBodyHeight?: number | string;
   padding?: "default" | "dense";


### PR DESCRIPTION
in some cases (like auto updates with websockets) we don't want any progress indicator that my lead to "blinking" components if those updates happens to much. By sending any value diferent than "overlay" and "linear" to the loading type property, no loading overlays or progress indicators will be show when calling the tableRef.onQueryChange method

## Related Issue

Relate the Github issue with this PR using `#`

## Description

Better UX in apps that have data being updated automatically .

## Impacted Areas in Application

Typescript definition file. 

\*

## Additional Notes

Would be nice in future to have an option to show the spinner only in the first render (or when the table is empty)
