### PR TITLE
Migrate to @mui/date-x-pickers

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@babel/preset-react": "7.0.0",
     "@mui/material": "^5.5.0",
     "@mui/lab": "^5.0.0-alpha.72",
+    "@mui/x-date-pickers": "^5.0.0-beta.6",
     "@mui/styles": "5.5.0",
     "babel-eslint": "10.0.1",
     "babel-loader": "8.0.4",

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "@mui/material": "^5.5.0",
     "@mui/lab": "^5.0.0-alpha.72",
     "@mui/styles": "5.5.0",
+    "@mui/x-date-pickers": "^5.0.0-beta.6",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   }

--- a/src/components/m-table-edit-field.js
+++ b/src/components/m-table-edit-field.js
@@ -7,13 +7,11 @@ import FormControl from "@mui/material/FormControl";
 import FormHelperText from "@mui/material/FormHelperText";
 import FormGroup from "@mui/material/FormGroup";
 import FormControlLabel from "@mui/material/FormControlLabel";
-import AdapterDateFns from "@mui/lab/AdapterDateFns";
-import {
-  LocalizationProvider,
-  DatePicker,
-  TimePicker,
-  DateTimePicker,
-} from "@mui/x-date-pickers";
+import { AdapterDateFns } from "@mui/x-date-pickers/AdapterDateFns";
+import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
+import { DatePicker } from "@mui/x-date-pickers/DatePicker";
+import { TimePicker } from "@mui/x-date-pickers/TimePicker";
+import { DateTimePicker } from "@mui/x-date-pickers/DateTimePicker";
 import PropTypes from "prop-types";
 
 class MTableEditField extends React.Component {

--- a/src/components/m-table-edit-field.js
+++ b/src/components/m-table-edit-field.js
@@ -13,7 +13,7 @@ import {
   DatePicker,
   TimePicker,
   DateTimePicker,
-} from "@mui/lab";
+} from "@mui/x-date-pickers";
 import PropTypes from "prop-types";
 
 class MTableEditField extends React.Component {

--- a/src/components/m-table-filter-row.js
+++ b/src/components/m-table-filter-row.js
@@ -13,13 +13,11 @@ import Checkbox from "@mui/material/Checkbox";
 import ListItemText from "@mui/material/ListItemText";
 import InputAdornment from "@mui/material/InputAdornment";
 import Tooltip from "@mui/material/Tooltip";
-import AdapterDateFns from "@mui/lab/AdapterDateFns";
-import {
-  LocalizationProvider,
-  DatePicker,
-  TimePicker,
-  DateTimePicker,
-} from "@mui/x-date-pickers";
+import { AdapterDateFns } from "@mui/x-date-pickers/AdapterDateFns";
+import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
+import { DatePicker } from "@mui/x-date-pickers/DatePicker";
+import { TimePicker } from "@mui/x-date-pickers/TimePicker";
+import { DateTimePicker } from "@mui/x-date-pickers/DateTimePicker";
 
 const ITEM_HEIGHT = 48;
 const ITEM_PADDING_TOP = 8;
@@ -161,6 +159,7 @@ class MTableFilterRow extends React.Component {
       onChange: onDateInputChange,
       placeholder: this.getLocalizedFilterPlaceHolder(columnDef),
       clearable: true,
+      renderInput: (params) => <TextField {...params} />,
     };
 
     let dateInputElement = null;

--- a/src/components/m-table-filter-row.js
+++ b/src/components/m-table-filter-row.js
@@ -19,7 +19,7 @@ import {
   DatePicker,
   TimePicker,
   DateTimePicker,
-} from "@mui/lab";
+} from "@mui/x-date-pickers";
 
 const ITEM_HEIGHT = 48;
 const ITEM_PADDING_TOP = 8;


### PR DESCRIPTION
## Related Issue

https://github.com/mbrn/material-table/issues/3177

## Description

Pickers migrated from @mui/lab to @mui/date-x-pickers
