### PR TITLE
Add editComponent for cellEditable

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,8 +50,8 @@
     "@babel/plugin-transform-runtime": "7.1.0",
     "@babel/preset-env": "7.2.0",
     "@babel/preset-react": "7.0.0",
-    "@mui/material": "^5.5.0",
     "@mui/lab": "^5.0.0-alpha.72",
+    "@mui/material": "^5.5.0",
     "@mui/styles": "5.5.0",
     "babel-eslint": "10.0.1",
     "babel-loader": "8.0.4",
@@ -78,6 +78,7 @@
   },
   "dependencies": {
     "@date-io/date-fns": "2.13.1",
+    "@emotion/react": "^11.10.5",
     "@emotion/styled": "11.8.1",
     "classnames": "2.2.6",
     "date-fns": "2.28.0",
@@ -92,8 +93,8 @@
   },
   "peerDependencies": {
     "@date-io/core": "^2.13.1",
-    "@mui/material": "^5.5.0",
     "@mui/lab": "^5.0.0-alpha.72",
+    "@mui/material": "^5.5.0",
     "@mui/styles": "5.5.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"

--- a/src/components/m-table-edit-cell.js
+++ b/src/components/m-table-edit-cell.js
@@ -122,13 +122,16 @@ class MTableEditCell extends React.Component {
   }
 
   render() {
+    const { editComponent, ...cellProps } = this.props.columnDef;
+    const EditComponent = editComponent || this.props.components.EditField;
     return (
       <TableCell size={this.props.size} style={this.getStyle()} padding="none">
         <div style={{ display: "flex", alignItems: "center" }}>
           <div style={{ flex: 1, marginRight: 4 }}>
-            <this.props.components.EditField
-              columnDef={this.props.columnDef}
+            <EditComponent
+              columnDef={cellProps}
               value={this.state.value}
+              rowData={this.props.rowData}
               onChange={(value) => this.setState({ value })}
               onKeyDown={this.handleKeyDown}
               disabled={this.state.isLoading}


### PR DESCRIPTION
## Related Issue

#2700 

## Description

When using cellEditable we can't make custom `editComponent` for cell

## Additional Notes

How this works ?:
First you need to add `cellEditable` for the table 
```js
<MaterialTable
  cellEditable={{
    onCellEditApproved: (newValue, oldValue, rowData, columnDef) => {
      return new Promise((resolve, reject) => {
        console.log("new vault: ", newValue)
        setTimeout(resolve, 1000);
      });
   }
}}
>
```

then in the columns just pass the edit component

```js
editComponent: (props) => <Input fullWidth={true}
            type={'text'}
            placeholder={props.columnDef.title}
            value={props.value}
            onChange={e => props.onChange(e.target.value)}
            style={{}}
          />
```
