### PR TITLE
Upgrade jspdf to 2.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "debounce": "1.2.0",
     "fast-deep-equal": "2.0.1",
     "filefy": "0.1.10",
-    "jspdf": "2.1.0",
+    "jspdf": "2.5.1",
     "jspdf-autotable": "3.5.9",
     "prop-types": "15.6.2",
     "react-beautiful-dnd": "13.1.0",


### PR DESCRIPTION
## Related Issue

Resolves stale issue Vunerability in jspdf dependency #2890 

## Description

Upgraded to non-vulnerable jspdf version 2.5.1 



