### PR TITLE
Upgrade jspdf to 2.3.1 and jspdf-autotable to 3.5.18

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,8 +84,8 @@
     "debounce": "1.2.0",
     "fast-deep-equal": "2.0.1",
     "filefy": "0.1.10",
-    "jspdf": "2.1.0",
-    "jspdf-autotable": "3.5.9",
+    "jspdf": "2.3.1",
+    "jspdf-autotable": "3.5.18",
     "prop-types": "15.6.2",
     "react-beautiful-dnd": "13.1.0",
     "react-double-scrollbar": "0.0.15"


### PR DESCRIPTION
## Related Issue
Fixes [#3221](https://github.com/mbrn/material-table/issues/3221), a ReDoS security vulnerability in the `jspdf` dependency.

## Description
Bumps `jspdf-autotable` to `3.5.18` which has a peer dependency of `jspdf` version `2.3.1` which is the [version](https://github.com/parallax/jsPDF/releases/tag/v2.3.1) that includes the fix for the ReDoS security vulnerability.

I inspected the [diff](https://github.com/parallax/jsPDF/compare/9b8f1e9..dd6bddd) between `jspdf` version `2.1.0` and `2.3.1` and they didn't change any of the interfaces that are used in this project.
